### PR TITLE
feat: full-learning replay (issue #7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## Unreleased
+
+### Full-learning replay and harvest
+
+- Added `openclawbrain replay --fast-learning` for LLM transcript mining + injection from session logs.
+- Added `openclawbrain replay --full-learning` to run replay + fast-learning + slow maintenance.
+- Added resumability options: `--resume`, `--checkpoint`, and `--ignore-checkpoint`.
+- Added learning-context knobs: `--workers`, `--window-radius`, `--max-windows`, `--hard-max-turns`.
+- Added explicit `--backup` control for replay-backed mutation persistence.
+- Added new `openclawbrain harvest` command to consume `learning_events.jsonl` and apply `split/merge/prune/connect/scale`.
+- Added dedupe/idempotent behavior for event log ingestion keyed by `(type, sha256(content), session_pointer)`.
+- Documented sidecar full-learning workflow and updated `docs/setup-guide.md`, `docs/openclaw-integration.md`, `docs/FULL_REBUILD.md`.
+- Added tests for window selection, dedupe/idempotency, and replay + fast-learning injection behavior.
+
 ## v12.2.1 (2026-02-27)
 
 ### Bug fixes (from deployment feedback — GH #4, #5, #6)

--- a/README.md
+++ b/README.md
@@ -344,7 +344,8 @@ See `examples/openai_embedder/` for a complete example.
 | `compact` | Compact old daily notes into graph nodes |
 | `sync` | Incremental re-embed after file changes |
 | `inject` | Add CORRECTION/TEACHING/DIRECTIVE nodes |
-| `replay` | Replay session queries into brain |
+| `replay` | Replay session queries, optionally with `--fast-learning` or `--full-learning` |
+| `harvest` | Apply slow-learning pass from `learning_events.jsonl` to current graph |
 | `health` | Show graph health metrics |
 | `status` | `openclawbrain status --state brain/state.json [--json]` returns a one-command health overview: version, nodes, edges, tier distribution, daemon status, embedder, decay half-life |
 | `journal` | Show event journal |
@@ -549,6 +550,30 @@ If you have prior conversation logs, replay them:
 ```bash
 openclawbrain replay --state /tmp/brain/state.json --sessions ./sessions/
 ```
+
+For transcript-backed fast-learning:
+
+```bash
+openclawbrain replay \
+  --state /tmp/brain/state.json \
+  --sessions ./sessions/ \
+  --fast-learning \
+  --resume \
+  --workers 4 \
+  --checkpoint /tmp/brain/replay_checkpoint.json
+```
+
+For the full learning pipeline (replay + fast-learning + harvest):
+
+```bash
+openclawbrain replay \
+  --state /tmp/brain/state.json \
+  --sessions ./sessions/ \
+  --full-learning
+```
+
+The fast-learning and harvest pipeline is sidecar-only to the core files:
+`learning_events.jsonl` is append-only, and `replay` updates `state.json` via the same graph mutation model as existing injection commands.
 
 Skip this if you are just getting started.
 

--- a/docs/FULL_REBUILD.md
+++ b/docs/FULL_REBUILD.md
@@ -1,0 +1,368 @@
+# Full OpenClawBrain Rebuild — Complete Learning Pipeline
+
+A comprehensive brain rebuild that applies **all** learning mechanisms to historical conversation data.
+
+## What This Does
+
+Most brain operations are incremental — they learn from new queries as they come in. A **full rebuild** replays your entire conversation history through the graph with every learning mechanism active:
+
+1. **Init** — GPT-5-mini smart splits + OpenAI embeddings
+2. **Replay** — fire all historical queries through the graph to warm edges
+3. **Auto-scoring** — `apply_outcome` on every query/response pair with heuristic outcome detection
+4. **Corrections** — inject CORRECTION nodes from detected corrections in transcripts
+5. **Teachings** — inject TEACHING nodes from lessons learned
+6. **Maintenance** — full pipeline: health→decay→scale→split→merge→prune→connect (multiple passes)
+
+## When to Use This
+
+- **After major changes** to workspace structure or memory organization
+- **Periodic refresh** (monthly?) to consolidate learning across all history
+- **Migration** when switching embedders or adding new context files
+- **Debugging** when the brain feels "stale" or missing obvious connections
+
+## The Pipeline
+
+### Phase 1: Init with LLM Splitting
+
+```bash
+openclawbrain init \
+  --workspace ~/.openclaw/workspace \
+  --output ~/.openclawbrain/main/state.json \
+  --embedder openai \
+  --llm openai \
+  --json
+```
+
+**What it does:**
+- Uses GPT-5-mini to intelligently split workspace files into semantic chunks
+- Embeds all chunks with OpenAI `text-embedding-3-small` (dim=1536)
+- Creates initial graph structure from workspace files
+
+**Time:** ~30 min for 200 workspace files (326 LLM calls @ ~5 sec each)
+
+### Phase 2: Replay All Sessions
+
+Collect all session files:
+
+```bash
+# For main agent
+SESSIONS=$(find ~/.openclaw/agents/main/sessions \
+  -maxdepth 1 \( -name "*.jsonl" -o -name "*.jsonl.reset.*" -o -name "*.jsonl.deleted.*" \) \
+  | grep -v ".lock$" | grep -v "sessions.json" | sort)
+
+# For cross-agent context (e.g., bountiful in main sessions)
+BOUNTIFUL_MAIN=$(grep -rl "5151316478" ~/.openclaw/agents/main/sessions/ | grep -v ".lock$")
+BOUNTIFUL_OWN=$(find ~/.openclaw/agents/bountiful/sessions -maxdepth 1 -name "*.jsonl*" | grep -v ".lock$")
+SESSIONS="$BOUNTIFUL_MAIN $BOUNTIFUL_OWN"
+```
+
+Clear the replay checkpoint:
+
+```bash
+python3 -c "
+import json
+with open('~/.openclawbrain/main/state.json') as f: d = json.load(f)
+d['meta'].pop('last_replayed_ts', None)
+with open('~/.openclawbrain/main/state.json', 'w') as f: json.dump(d, f)
+"
+```
+
+Replay:
+
+```bash
+openclawbrain replay \
+  --state ~/.openclawbrain/main/state.json \
+  --sessions $SESSIONS \
+  --json
+```
+
+**What it does:**
+- Extracts user queries and assistant responses from each session
+- Fires each query through the graph (keyword seeding → traversal)
+- Applies outcome weighting based on response quality heuristics
+- Reinforces edges for co-activated nodes (Hebbian learning)
+- Creates cross-file connections
+
+**Output:**
+```json
+{
+  "queries_replayed": 1899,
+  "edges_reinforced": 57163,
+  "cross_file_edges_created": 2617,
+  "last_replayed_ts": 1772261254.121
+}
+```
+
+### Phase 3: Extract & Inject Corrections/Teachings (LLM-Powered)
+
+**This is the key difference from basic replay.**
+
+Use GPT-5-mini to analyze each conversation and extract learning signals through
+the built-in full-learning replay path:
+
+```bash
+openclawbrain replay \
+  --state ~/.openclawbrain/main/state.json \
+  --sessions ~/.openclaw/agents/main/sessions \
+  --full-learning \
+  --json
+```
+
+**What it does:**
+
+For each session transcript:
+1. **LLM analyzes the conversation** (not regex patterns!)
+2. **Detects corrections** — user says "no that's wrong", "actually X", "don't do Y"
+   - Extracts the specific error and the correct answer
+   - Severity-weighted: high/medium/low → -1.0/-0.5/-0.2 outcome
+3. **Detects teachings** — user provides new facts, preferences, rules
+   - Extracts the knowledge being taught
+   - Severity-weighted: high/medium/low → +1.0/+0.5/+0.2 outcome
+4. **Detects reinforcements** — user confirms good output
+   - Identifies what was done right
+5. **Injects CORRECTION/TEACHING nodes** with reinforcement signals
+
+**Example LLM output:**
+```json
+{
+  "corrections": [
+    {
+      "content": "ANAB is not Adage — they are different entities",
+      "context": "User corrected entity confusion in financial data",
+      "severity": "high"
+    }
+  ],
+  "teachings": [
+    {
+      "content": "Don't include market cap for private companies in financial reports",
+      "context": "User established a rule for report generation",
+      "severity": "high"
+    }
+  ]
+}
+```
+
+**Typical output:**
+```
+Analyzing 115 session files with LLM...
+[1/115] session_abc.jsonl...
+  Found: 3 corrections, 2 teachings, 1 reinforcements
+[2/115] session_def.jsonl...
+  Found: 1 corrections, 0 teachings, 2 reinforcements
+...
+{
+  "sessions_analyzed": 115,
+  "corrections_found": 342,
+  "teachings_found": 187,
+  "reinforcements_found": 94,
+  "total_injected": 623
+}
+```
+
+**Why this matters:**
+
+The gap in basic replay is that it only sees **query patterns** (what files were accessed together). It never reads the **actual content** of the conversations. So when you said "no, ANAB is not Adage" or "don't include market cap for private companies," those corrections just flowed through as edge formations — the graph learned you talked about ANAB and Adage in the same session, but it didn't learn that they're different entities.
+
+LLM-powered extraction captures the **semantic knowledge** from corrections and teachings, not just co-occurrence patterns.
+
+### Phase 4: Maintenance (Multiple Passes)
+
+Run 3 full maintenance cycles to let the graph stabilize:
+
+```bash
+for pass in 1 2 3; do
+  openclawbrain maintain \
+    --state ~/.openclawbrain/main/state.json \
+    --tasks health,decay,scale,split,merge,prune,connect
+done
+```
+
+**Task breakdown:**
+
+| Task | What It Does | When to Run |
+|------|-------------|-------------|
+| `health` | Check orphans, distribution stats | Always (diagnostic) |
+| `decay` | Apply temporal decay to edge weights | After each replay |
+| `scale` | Synaptic scaling (normalize activations) | After large replays |
+| `split` | Runtime node splitting (high-activation nodes) | After major growth |
+| `merge` | Consolidate duplicate/similar nodes | Periodic cleanup |
+| `prune` | Remove weak edges, dormant nodes | After decay cycles |
+| `connect` | Create edges from TEACHING/CORRECTION nodes | After injections |
+
+**Typical output (pass 1):**
+```
+Maintenance report:
+  tasks: health, decay, scale, split, prune, merge, connect
+  nodes: 4834 -> 5124
+  edges: 9106 -> 11438
+  merges: 23/50 candidates
+  pruned: edges=2891 nodes=12
+  decay_applied: True
+  notes: split created 290 new nodes
+```
+
+### Phase 5: Slow Harvesting (Cross-Conversation Patterns)
+
+Now implemented with `openclawbrain harvest`:
+
+- Edge-density damping for correction-heavy nodes
+- Connect/merge/split/prune/scale maintenance runs against the current graph
+
+```bash
+openclawbrain harvest \
+  --state STATE \
+  --events STATE_DIR/learning_events.jsonl \
+  --tasks split,merge,prune,connect,scale \
+  --json
+```
+This consumes `learning_events.jsonl` as a durable sidecar artifact and can run after `replay --fast-learning`.
+
+### Phase 6: Final Health Check
+
+```bash
+openclawbrain health --state ~/.openclawbrain/main/state.json
+```
+
+**Healthy brain indicators:**
+
+```
+Brain health:
+  Nodes: 5124
+  Edges: 11438
+  Reflex: 8.2%  Habitual: 61.3%  Dormant: 30.5%
+  Orphans: 0
+  Cross-file edges: 34.7%
+```
+
+- **No orphans** — every node is connected
+- **30-40% cross-file edges** — good inter-context connections
+- **Reflex 5-10%** — frequently activated core knowledge
+- **Habitual 50-70%** — well-practiced patterns
+- **Dormant < 40%** — not too much dead weight
+
+## Full Script
+
+```bash
+#!/bin/bash
+# Full learning suite: init + replay + LLM injections + 3x maintenance
+set -e
+
+STATE="~/.openclawbrain/main/state.json"
+WORKSPACE="~/.openclaw/workspace"
+
+echo "=== PHASE 1: INIT ==="
+openclawbrain init \
+  --workspace "$WORKSPACE" \
+  --output "$STATE" \
+  --embedder openai \
+  --llm openai \
+  --json
+
+echo "=== PHASE 2: REPLAY (Edge Formation) ==="
+python3 -c "
+import json
+with open('$STATE') as f: d = json.load(f)
+d['meta'].pop('last_replayed_ts', None)
+with open('$STATE', 'w') as f: json.dump(d, f)
+"
+
+SESSIONS=$(find ~/.openclaw/agents/main/sessions -maxdepth 1 \
+  \( -name "*.jsonl" -o -name "*.jsonl.reset.*" \) | grep -v ".lock$" | sort)
+
+echo "=== PHASE 3: LLM-POWERED FULL LEARNING ==="
+openclawbrain replay --state "$STATE" --sessions $SESSIONS --full-learning --json
+
+echo "=== PHASE 4: MAINTENANCE (3 passes) ==="
+for pass in 1 2 3; do
+  echo "Pass $pass/3..."
+  openclawbrain harvest --state "$STATE" \
+    --events "$(dirname "$STATE")/learning_events.jsonl" \
+    --tasks split,merge,prune,connect,scale
+done
+
+echo "=== PHASE 5: FINAL HEALTH ==="
+openclawbrain health --state "$STATE"
+ls -lh "$STATE"
+```
+
+## Performance Notes
+
+**Typical times** (Mac Mini M4 Pro, 64GB RAM):
+
+| Brain | Workspace Files | Sessions | Queries | Total Time |
+|-------|----------------|----------|---------|------------|
+| Main (GUCLAW) | 186 | 115 | 1,899 | ~90 min |
+| Pelican | 70 | 192 | 1,427 | ~45 min |
+| Bountiful | 73 | 31 | 1,313 | ~35 min |
+
+**Bottlenecks:**
+- Init LLM splitting: ~5 sec per workspace file (sequential GPT-5-mini calls)
+- Replay: ~0.5 sec per query (graph traversal + outcome application)
+- Injections: ~0.2 sec per batched `inject_batch` insertion step
+- Maintenance: ~10-30 sec per pass (depends on graph size)
+
+**Parallelization:**
+- Run multiple agents in parallel (main + pelican + bountiful) via `nohup`
+- Each agent is independent — no shared state
+
+## Troubleshooting
+
+### "state file not found" after init
+
+Init didn't finish. Check:
+```bash
+tail -50 /tmp/brain_init.log
+ps aux | grep "openclawbrain init"
+```
+
+LLM splitting can be slow (~30 min for 200 files). Run with `nohup` to survive disconnects.
+
+### Replay loads 0 interactions
+
+Session files might be in a different format. Check:
+```bash
+head -1 ~/.openclaw/agents/main/sessions/SESSION_ID.jsonl
+```
+
+Expected: `{"type": "message", "message": {"role": "user", "content": "..."}}`
+
+### Injections fail silently
+
+If only transcript mining is needed first, run:
+
+```bash
+openclawbrain replay \
+  --state STATE \
+  --sessions SESSIONS \
+  --fast-learning \
+  --json
+```
+
+### Graph size explodes after multiple passes
+
+Too many split nodes. Try:
+```bash
+openclawbrain maintain --state STATE --tasks merge,prune
+```
+
+Then verify:
+```bash
+openclawbrain health --state STATE
+```
+
+If dormant > 50%, prune more aggressively.
+
+## Next Steps
+
+After a full rebuild:
+
+1. **Verify query quality** — test a few queries and check fired nodes
+2. **Monitor performance** — watch `health` output over next few days
+3. **Schedule periodic rebuilds** — monthly or after major workspace changes
+4. **Backup** — `cp state.json state.json.backup` before experiments
+
+## Related
+
+- [Learning Pipeline](./LEARNING.md) — incremental learning from live queries
+- [Maintenance Tasks](./MAINTENANCE.md) — task-by-task breakdown
+- [Query Adapter](../examples/openclaw_adapter/) — how OpenClaw agents query the brain

--- a/docs/openclaw-integration.md
+++ b/docs/openclaw-integration.md
@@ -348,6 +348,25 @@ OpenClawBrain ships an OpenClaw adapter that logs fired IDs per chat.
 
 That’s the ergonomic way to do “same-turn correction” inside OpenClaw.
 
+For full-history rebuilds, use fast/full replay:
+
+```bash
+openclawbrain replay \
+  --state ~/.openclawbrain/main/state.json \
+  --sessions /path/to/sessions \
+  --full-learning
+```
+
+This does:
+
+- replay query edges from session history
+- LLM transcript mining into `learning::` nodes (`--fast-learning` behavior)
+- slow-learning maintenance pass (`harvest`) with split/merge/prune/connect/scale
+
+`learning_events.jsonl` is an append-only sidecar under the brain directory used by harvest:
+
+`~/.openclawbrain/main/learning_events.jsonl`
+
 ---
 
 ## Step 5 — Maintenance cron (keep the graph healthy)
@@ -361,6 +380,15 @@ Recommended maintenance command:
 
 ```bash
 openclawbrain maintain --state ~/.openclawbrain/main/state.json --tasks health,decay,prune,merge
+```
+
+The explicit slow-learning path is:
+
+```bash
+openclawbrain harvest \
+  --state ~/.openclawbrain/main/state.json \
+  --events ~/.openclawbrain/main/learning_events.jsonl \
+  --tasks split,merge,prune,connect,scale
 ```
 
 Start conservative:

--- a/examples/openclaw_adapter/learn_correction.py
+++ b/examples/openclaw_adapter/learn_correction.py
@@ -11,7 +11,7 @@ from collections.abc import Callable
 from typing import Any
 import time
 
-from openclawbrain import HashEmbedder, apply_outcome_pg, inject_correction, load_state, save_state
+from openclawbrain import HashEmbedder, apply_outcome, inject_correction, load_state, save_state
 from openclawbrain.socket_client import OCBClient
 
 
@@ -192,12 +192,10 @@ def main(argv: list[str] | None = None) -> None:
 
     if fired_ids:
         graph, index, meta = load_state(str(state_path))
-        updates = apply_outcome_pg(
+        updates = apply_outcome(
             graph=graph,
             fired_nodes=fired_ids,
             outcome=args.outcome,
-            baseline=0.0,
-            temperature=1.0,
         )
         edges_updated = len(updates)
         save_state(graph=graph, index=index, path=str(state_path), meta=meta)

--- a/openclawbrain/daemon.py
+++ b/openclawbrain/daemon.py
@@ -82,6 +82,11 @@ def _node_ids_with_authority(graph: Graph, authority: str) -> set[str]:
     return {node.id for node in graph.nodes() if _node_authority(node) == authority}
 
 
+def _real_graph_updates(updates: dict[str, float]) -> int:
+    """Count updates that target concrete edges and ignore pseudo STOP transitions."""
+    return sum(1 for key in updates if not key.endswith("->__STOP__"))
+
+
 def _health_payload(graph: Graph) -> dict[str, object]:
     """Build health payload with node/edge counts included."""
     health = measure_health(graph)
@@ -359,7 +364,7 @@ def _do_learn(
             graph=graph, fired_nodes=fired_ids, outcome=outcome,
             baseline=0.0, temperature=1.0,
         )
-        edges_updated = len(updates)
+        edges_updated = _real_graph_updates(updates)
         if edges_updated:
             should_write = True
         log_learn(

--- a/openclawbrain/full_learning.py
+++ b/openclawbrain/full_learning.py
@@ -1,0 +1,703 @@
+"""Full-learning replay and harvest helpers."""
+
+from __future__ import annotations
+
+import concurrent.futures
+import hashlib
+import json
+import os
+import sys
+from collections import defaultdict
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from ._util import _extract_json
+from .inject import inject_batch
+from .maintain import run_maintenance
+from .openai_embeddings import OpenAIEmbedder
+from .hasher import HashEmbedder
+from .openai_llm import openai_llm_fn
+from .replay import replay_queries
+from .store import load_state, save_state
+
+
+LEARNING_EVENTS_FILENAME = "learning_events.jsonl"
+REPLAY_CHECKPOINT_FILENAME = "replay_checkpoint.json"
+
+FEEDBACK_CORRECTION = [
+    "wrong",
+    "incorrect",
+    "no",
+    "not what",
+    "fix",
+    "don't",
+    "never",
+]
+FEEDBACK_TEACHING = [
+    "should",
+    "must",
+    "prefer",
+    "remember",
+    "policy",
+    "always",
+]
+FEEDBACK_REINFORCE = [
+    "thanks",
+    "great",
+    "perfect",
+    "correct",
+    "good",
+]
+
+LEARNING_EXTRACTOR_PROMPT = """Extract feedback signals from a compact conversation window.
+
+Return ONLY JSON:
+{
+  "corrections": [{"content": str, "context": str, "severity": "high|medium|low"}],
+  "teachings": [{"content": str, "context": str, "severity": "high|medium|low"}],
+  "reinforcements": [{"content": str, "context": str, "severity": "high|medium|low"}]
+}
+"""
+
+
+@dataclass(frozen=True)
+class SessionTurn:
+    """Single user/assistant turn from a session log."""
+
+    role: str
+    content: str
+    line_no: int
+    source: str
+    ts: float | None = None
+
+
+def learning_event_path(state_path: str) -> Path:
+    """Default path for append-only full-learning events."""
+    return Path(state_path).expanduser().parent / LEARNING_EVENTS_FILENAME
+
+
+def default_checkpoint_path(state_path: str) -> Path:
+    """Default path for resume checkpoint."""
+    return Path(state_path).expanduser().parent / REPLAY_CHECKPOINT_FILENAME
+
+
+def _resolve_text(payload: object) -> str | None:
+    """Extract normalized text from text, list, or OpenAI message payload."""
+    if isinstance(payload, str):
+        text = payload.strip()
+        return text or None
+    if isinstance(payload, list):
+        out: list[str] = []
+        for item in payload:
+            piece = _resolve_text(item)
+            if piece:
+                out.append(piece)
+        return " ".join(out) if out else None
+    if isinstance(payload, dict):
+        text = payload.get("text")
+        if isinstance(text, str):
+            resolved = text.strip()
+            if resolved:
+                return resolved
+        content = payload.get("content")
+        return _resolve_text(content)
+    return None
+
+
+def _read_records(path: Path, start_line: int = 0) -> list[tuple[int, dict]]:
+    """Read JSONL records from a session file."""
+    if not path.exists():
+        raise SystemExit(f"invalid sessions path: {path}")
+
+    records: list[tuple[int, dict]] = []
+    for idx, raw in enumerate(path.expanduser().open("r", encoding="utf-8"), start=1):
+        if idx <= start_line:
+            continue
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict):
+            records.append((idx, payload))
+    return records
+
+
+def _extract_ts(payload: dict) -> float | None:
+    """Extract timestamp from session record."""
+    for key in ("ts", "timestamp", "created_at", "time"):
+        value = payload.get(key)
+        if isinstance(value, (int, float)):
+            return float(value)
+        if isinstance(value, str):
+            try:
+                return float(value)
+            except ValueError:
+                continue
+    return None
+
+
+def collect_session_files(session_paths: str | Path | list[str] | list[Path]) -> list[Path]:
+    """Resolve session paths and return JSONL files."""
+    paths: list[Path] = []
+    if isinstance(session_paths, (str, Path)):
+        session_paths = [session_paths]
+    for item in session_paths:
+        src = Path(item).expanduser()
+        if src.is_dir():
+            paths.extend(sorted(src.glob("*.jsonl")))
+            continue
+        if src.is_file():
+            paths.append(src)
+            continue
+        raise SystemExit(f"invalid sessions path: {src}")
+    return paths
+
+
+def _collect_turns(
+    session_paths: str | Path | list[str] | list[Path],
+    since_lines: dict[str, int] | None = None,
+) -> tuple[list[tuple[str, list[SessionTurn]]], dict[str, int]]:
+    """Collect role turns from session files.
+
+    Returns:
+        grouped turns per source and latest processed line per source.
+    """
+    files = collect_session_files(session_paths)
+    grouped: list[tuple[str, list[SessionTurn]]] = []
+    next_offsets: dict[str, int] = {}
+
+    for path in files:
+        path_name = str(path)
+        start_line = int((since_lines or {}).get(path_name, 0))
+        turns: list[SessionTurn] = []
+        last_line = start_line
+
+        for line_no, payload in _read_records(path, start_line=start_line):
+            last_line = line_no
+            record_message = payload.get("message") if isinstance(payload.get("message"), dict) else payload
+            if not isinstance(record_message, dict):
+                continue
+            role = str(record_message.get("role", "")).strip().lower()
+            if role not in {"user", "assistant"}:
+                continue
+            content = _resolve_text(record_message.get("content"))
+            if not content:
+                continue
+            turns.append(
+                SessionTurn(
+                    role=role,
+                    content=content,
+                    line_no=line_no,
+                    source=path_name,
+                    ts=_extract_ts(payload),
+                )
+            )
+        grouped.append((path_name, turns))
+        next_offsets[path_name] = last_line
+    return grouped, next_offsets
+
+
+def _turn_score(turn: SessionTurn) -> int:
+    """Score turns for feedback extraction priority."""
+    if turn.role != "user":
+        return 0
+    text = turn.content.lower()
+    score = 0
+    if len(text) >= 200:
+        score += 1
+    for token in FEEDBACK_CORRECTION:
+        if token in text:
+            score += 5
+            break
+    for token in FEEDBACK_TEACHING:
+        if token in text:
+            score += 3
+            break
+    for token in FEEDBACK_REINFORCE:
+        if token in text:
+            score += 1
+            break
+    return score
+
+
+def select_feedback_windows(
+    turns: list[SessionTurn],
+    *,
+    window_radius: int,
+    max_windows: int,
+    hard_max_turns: int,
+) -> list[tuple[int, int]]:
+    """Select feedback windows around likely feedback turns."""
+    if not turns:
+        return []
+    if len(turns) <= hard_max_turns:
+        return [(0, len(turns))]
+
+    scored: list[tuple[int, int]] = []
+    for index, turn in enumerate(turns):
+        score = _turn_score(turn)
+        if score > 0:
+            scored.append((index, score))
+
+    if not scored:
+        head_end = max(1, len(turns) // 2)
+        ranges = [(0, head_end), (max(0, len(turns) - head_end), len(turns))]
+        if ranges[0][1] >= ranges[1][0]:
+            return [(ranges[0][0], ranges[1][1])]
+        return ranges
+
+    scored.sort(key=lambda item: item[1], reverse=True)
+    picks = [idx for idx, _ in scored[:max_windows]]
+    ranges: list[tuple[int, int]] = []
+    for idx in sorted(picks):
+        start = max(0, idx - window_radius)
+        end = min(len(turns), idx + window_radius + 1)
+        if not ranges or start > ranges[-1][1]:
+            ranges.append((start, end))
+        else:
+            prev_start, prev_end = ranges[-1]
+            ranges[-1] = (prev_start, max(prev_end, end))
+    return ranges
+
+
+def _window_to_payload(
+    *,
+    session: str,
+    window: list[SessionTurn],
+    window_idx: int,
+    total_windows: int,
+    llm_fn: Callable[[str, str], str],
+) -> list[dict]:
+    """Extract learning signals from one window."""
+    text = "\n\n".join(f"{turn.role.upper()}: {turn.content[:1200]}" for turn in window).strip()
+    if not text:
+        return []
+
+    window_suffix = f" (window {window_idx}/{total_windows})" if total_windows > 1 else ""
+    user_prompt = f"Session: {session}{window_suffix}\n\n{text}\n\nExtract learning signals."
+    response = llm_fn(LEARNING_EXTRACTOR_PROMPT, user_prompt)
+    payload = _extract_json(response)
+    if not isinstance(payload, dict):
+        return []
+
+    pointer = f"{session}:{window[0].line_no}-{window[-1].line_no}"
+    events: list[dict] = []
+
+    for event_type, key in (("CORRECTION", "corrections"), ("TEACHING", "teachings"), ("REINFORCEMENT", "reinforcements")):
+        raw = payload.get(key)
+        if not isinstance(raw, list):
+            continue
+        for item in raw:
+            if not isinstance(item, dict):
+                continue
+            content = item.get("content")
+            if not isinstance(content, str):
+                continue
+            normalized = content.strip()
+            if not normalized:
+                continue
+            severity = str(item.get("severity", "medium")).strip().lower()
+            if severity not in {"low", "medium", "high"}:
+                severity = "medium"
+            context = item.get("context")
+            if not isinstance(context, str):
+                context = ""
+            digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+            events.append(
+                {
+                    "type": event_type,
+                    "content": normalized,
+                    "content_hash": digest,
+                    "severity": severity,
+                    "context": context[:600],
+                    "session": session,
+                    "session_pointer": pointer,
+                }
+            )
+    return events
+
+
+def _event_key(event: dict) -> str:
+    """Stable dedup key: (type, sha256(content), session pointer)."""
+    return "|".join(
+        (
+            str(event.get("type")),
+            str(event.get("content_hash")),
+            str(event.get("session_pointer")),
+        )
+    )
+
+
+def event_log_entries(path: Path | str) -> list[dict]:
+    """Load learning events from append-only log."""
+    path = Path(path)
+    if not path.exists():
+        return []
+    entries: list[dict] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict):
+            entries.append(payload)
+    return entries
+
+
+def dedupe_learning_events(existing: set[str], events: list[dict]) -> tuple[list[dict], int]:
+    """Deduplicate by (type, sha(content), session pointer)."""
+    appended: list[dict] = []
+    skipped = 0
+    for event in events:
+        key = _event_key(event)
+        if key in existing:
+            skipped += 1
+            continue
+        existing.add(key)
+        event["event_hash"] = key
+        appended.append(event)
+    return appended, skipped
+
+
+def append_learning_events(path: Path | str, events: list[dict]) -> None:
+    """Append new events durably."""
+    if not events:
+        return
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        for event in events:
+            handle.write(json.dumps(event, indent=None) + "\n")
+        handle.flush()
+        try:
+            os.fsync(handle.fileno())
+        except OSError:
+            pass
+
+
+def _load_checkpoint(path: Path | str) -> dict[str, int]:
+    """Load checkpoint JSON."""
+    payload = {"sessions": {}}
+    p = Path(path)
+    if not p.exists():
+        return {"sessions": {}}
+    try:
+        raw = json.loads(p.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return payload
+    if not isinstance(raw, dict):
+        return payload
+    sessions = raw.get("sessions")
+    if not isinstance(sessions, dict):
+        return payload
+    return {"sessions": {k: int(v) for k, v in sessions.items() if isinstance(v, (int, float))}}
+
+
+def _save_checkpoint(path: Path | str, session_offsets: dict[str, int]) -> None:
+    """Save replay checkpoint."""
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump({"version": 1, "sessions": session_offsets}, handle, indent=2)
+
+
+def _persist_state(
+    graph: object,
+    index: object,
+    meta: dict[str, object],
+    state_path: str,
+    backup: bool,
+) -> None:
+    """Persist state while honoring backup semantics."""
+    target = Path(state_path).expanduser()
+    backup_path = target.with_suffix(".bak")
+    had_backup = backup_path.exists()
+    save_state(graph=graph, index=index, path=state_path, meta=meta)
+    if not backup and not had_backup and backup_path.exists():
+        try:
+            backup_path.unlink()
+        except OSError:
+            print(f"warning: could not remove backup file {backup_path}", file=sys.stderr)
+
+
+def load_interactions_for_replay(
+    session_paths: str | Path | list[str] | list[Path],
+    since_lines: dict[str, int] | None = None,
+) -> tuple[list[dict], dict[str, int]]:
+    """Load interactions from sessions with line-aware resume support."""
+    files = collect_session_files(session_paths)
+    interactions: list[dict] = []
+    offsets: dict[str, int] = {}
+
+    for path in files:
+        path_name = str(path)
+        start_line = int((since_lines or {}).get(path_name, 0))
+        last_line = start_line
+        last_user_idx: int | None = None
+
+        for line_no, payload in _read_records(path, start_line=start_line):
+            last_line = line_no
+            message = payload.get("message") if isinstance(payload.get("message"), dict) else payload
+            if not isinstance(message, dict):
+                continue
+
+            role = str(message.get("role", "")).strip().lower()
+            if role not in {"user", "assistant"}:
+                last_user_idx = None
+                continue
+
+            record_ts = _extract_ts(payload)
+            if role == "user":
+                query = _resolve_text(message.get("content"))
+                if not query:
+                    last_user_idx = None
+                    continue
+                interactions.append({"query": query, "response": None, "tool_calls": [], "ts": record_ts})
+                last_user_idx = len(interactions) - 1
+                continue
+
+            if last_user_idx is None:
+                continue
+
+            response = _resolve_text(message.get("content"))
+            interactions[last_user_idx]["response"] = response
+            tool_calls = []
+            raw_calls = message.get("tool_calls")
+            if isinstance(raw_calls, list):
+                tool_calls = [call for call in raw_calls if isinstance(call, dict)]
+            interactions[last_user_idx]["tool_calls"] = tool_calls
+            interactions[last_user_idx]["ts"] = record_ts
+            last_user_idx = None
+
+        offsets[path_name] = last_line
+    return interactions, offsets
+
+
+def _state_embedder_info(
+    meta: dict[str, object],
+) -> tuple[Callable[[list[tuple[str, str]]], dict[str, list[float]]], float]:
+    """Resolve embed batch fn and default connect similarity."""
+    embedder_name = str(meta.get("embedder_name", ""))
+    if embedder_name == OpenAIEmbedder().name:
+        embedder = OpenAIEmbedder()
+        return embedder.embed_batch, 0.30
+    embedder = HashEmbedder()
+    return embedder.embed_batch, 0.0
+
+
+def run_fast_learning(
+    state_path: str,
+    session_paths: str | list[str] | list[Path] | Path,
+    *,
+    workers: int = 4,
+    window_radius: int = 8,
+    max_windows: int = 6,
+    hard_max_turns: int = 120,
+    include_reinforcements: bool = True,
+    llm_fn: Callable[[str, str], str] | None = None,
+    embed_batch_fn: Callable[[list[tuple[str, str]],], dict[str, list[float]]] | None = None,
+    checkpoint_path: str | None = None,
+    resume: bool = False,
+    ignore_checkpoint: bool = False,
+    backup: bool = True,
+) -> dict[str, Any]:
+    """Run LLM-backed transcript mining and inject new learning nodes."""
+    if workers < 1:
+        workers = 1
+    if llm_fn is None:
+        llm_fn = openai_llm_fn
+
+    checkpoint = _load_checkpoint(checkpoint_path) if (checkpoint_path and resume) else {"sessions": {}}
+    if ignore_checkpoint:
+        checkpoint = {"sessions": {}}
+    start_lines = checkpoint.get("sessions", {})
+
+    grouped_turns, turn_offsets = _collect_turns(session_paths, since_lines=start_lines)
+    windows: list[tuple[str, list[SessionTurn], int]] = []
+    for source, turns in grouped_turns:
+        for idx, (start, end) in enumerate(
+            select_feedback_windows(
+                turns,
+                window_radius=window_radius,
+                max_windows=max_windows,
+                hard_max_turns=hard_max_turns,
+            ),
+            start=1,
+        ):
+            if start < end:
+                windows.append((source, turns[start:end], idx))
+
+    all_events: list[dict] = []
+    if windows:
+        request_ctx = [(source, idx + 1, len(windows), segment) for idx, (source, segment, _) in enumerate(windows)]
+        if workers == 1:
+            for source, idx, total, segment in request_ctx:
+                all_events.extend(_window_to_payload(session=source, window=segment, window_idx=idx, total_windows=total, llm_fn=llm_fn))
+        else:
+            with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
+                futures = {
+                    executor.submit(
+                        _window_to_payload,
+                        session=source,
+                        window=segment,
+                        window_idx=idx,
+                        total_windows=total,
+                        llm_fn=llm_fn,
+                    ): source
+                    for source, idx, total, segment in request_ctx
+                }
+                for future in concurrent.futures.as_completed(futures):
+                    all_events.extend(future.result())
+
+    if not include_reinforcements:
+        all_events = [event for event in all_events if event.get("type") != "REINFORCEMENT"]
+
+    log_path = learning_event_path(state_path)
+    existing = {_event_key(item) for item in event_log_entries(log_path)}
+    deduped, skipped = dedupe_learning_events(existing, all_events)
+    append_learning_events(log_path, deduped)
+
+    graph, index, meta = load_state(state_path)
+    if embed_batch_fn is None:
+        embed_batch_fn, connect_min_sim = _state_embedder_info(meta)
+    else:
+        connect_min_sim = 0.30
+
+    nodes: list[dict[str, object]] = []
+    for event in deduped:
+        node_type = event.get("type")
+        if node_type == "REINFORCEMENT":
+            node_type = "TEACHING"
+        content_hash = str(event.get("content_hash"))
+        pointer = str(event.get("session_pointer"))
+        pointer_hash = hashlib.sha256(pointer.encode("utf-8")).hexdigest()[:10]
+        event["node_id"] = f"learning::{node_type.lower()}::{content_hash[:12]}::{pointer_hash}"
+        nodes.append(
+            {
+                "id": event["node_id"],
+                "type": node_type,
+                "content": event.get("content", ""),
+                "summary": str(event.get("content", "")).split("\n")[0][:120],
+                "metadata": {
+                    "source": "full_learning",
+                    "type": str(node_type),
+                    "session": event.get("session"),
+                    "session_pointer": event.get("session_pointer"),
+                    "severity": event.get("severity"),
+                    "content_hash": event.get("content_hash"),
+                },
+            }
+        )
+
+    injected = {"injected": 0, "edges_added": 0, "inhibitory": 0, "skipped": 0}
+    if nodes:
+        injected = inject_batch(
+            graph=graph,
+            index=index,
+            nodes=nodes,
+            embed_batch_fn=embed_batch_fn,
+            connect_top_k=3,
+            connect_min_sim=connect_min_sim,
+        )
+        _persist_state(graph=graph, index=index, meta=meta, state_path=state_path, backup=backup)
+
+    if checkpoint_path and resume:
+        _save_checkpoint(checkpoint_path, turn_offsets)
+
+    return {
+        "windows": len(windows),
+        "events_extracted": len(all_events),
+        "events_appended": len(deduped),
+        "events_skipped": skipped,
+        "events_injected": int(injected.get("injected", 0)),
+        "edges_added": int(injected.get("edges_added", 0)),
+        "learning_events_path": str(log_path),
+        "session_offsets": turn_offsets,
+    }
+
+
+def run_harvest(
+    state_path: str,
+    *,
+    events_path: Path | str | None = None,
+    tasks: list[str] | None = None,
+    dry_run: bool = False,
+    max_merges: int = 5,
+    prune_below: float = 0.01,
+    backup: bool = True,
+) -> dict[str, Any]:
+    """Run slow loop maintenance from learning events."""
+    if tasks is None:
+        tasks = ["split", "merge", "prune", "connect", "scale"]
+
+    event_path = Path(events_path) if events_path is not None else learning_event_path(state_path)
+    events = event_log_entries(event_path)
+    graph, index, meta = load_state(state_path)
+
+    correction_nodes = defaultdict(int)
+    for event in events:
+        if str(event.get("type", "")).upper() != "CORRECTION":
+            continue
+        node_id = event.get("node_id")
+        if isinstance(node_id, str) and graph.get_node(node_id) is not None:
+            correction_nodes[node_id] += 1
+
+    damped_edges = 0
+    for node_id, count in correction_nodes.items():
+        if count <= 0:
+            continue
+        factor = 1.0 / (1.0 + (0.25 * count))
+        for _target, edge in graph.outgoing(node_id):
+            before = edge.weight
+            edge.weight = before * factor
+            if edge.weight != before:
+                damped_edges += 1
+        for _source, edge in graph.incoming(node_id):
+            before = edge.weight
+            edge.weight = before * factor
+            if edge.weight != before:
+                damped_edges += 1
+
+    if not dry_run:
+        _persist_state(graph=graph, index=index, meta=meta, state_path=state_path, backup=backup)
+
+    embedder_name = meta.get("embedder_name")
+    if embedder_name == OpenAIEmbedder().name:
+        from .openai_embeddings import OpenAIEmbedder as _OAI
+
+        embed_fn = _OAI().embed
+    else:
+        embed_fn = HashEmbedder().embed
+
+    maintenance_report = run_maintenance(
+        state_path=state_path,
+        tasks=tasks,
+        embed_fn=embed_fn,
+        dry_run=dry_run,
+        max_merges=max_merges,
+        prune_below=prune_below,
+    )
+
+    return {
+        "events_seen": len(events),
+        "correction_nodes": len(correction_nodes),
+        "damped_edges": damped_edges,
+        "maintenance": {
+            "tasks_run": maintenance_report.tasks_run,
+            "edges_before": maintenance_report.edges_before,
+            "edges_after": maintenance_report.edges_after,
+            "pruned_edges": maintenance_report.pruned_edges,
+            "pruned_nodes": maintenance_report.pruned_nodes,
+            "merges_applied": maintenance_report.merges_applied,
+            "merges_proposed": maintenance_report.merges_proposed,
+        },
+        "learning_events_path": str(event_path),
+    }

--- a/tests/test_full_learning.py
+++ b/tests/test_full_learning.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from openclawbrain.full_learning import SessionTurn, dedupe_learning_events, select_feedback_windows
+
+
+def test_select_feedback_windows_picks_likely_feedback_regions() -> None:
+    """test select_feedback_windows picks windows around likely feedback turns."""
+    turns = [
+        SessionTurn(role="user", content="how do I deploy?", line_no=1, source="session.jsonl"),
+        SessionTurn(role="assistant", content="yes deploy from branch.", line_no=2, source="session.jsonl"),
+        SessionTurn(role="user", content="that is wrong", line_no=3, source="session.jsonl"),
+        SessionTurn(role="assistant", content="rollback", line_no=4, source="session.jsonl"),
+        SessionTurn(role="user", content="thanks", line_no=5, source="session.jsonl"),
+        SessionTurn(role="assistant", content="all good", line_no=6, source="session.jsonl"),
+        SessionTurn(role="user", content="please explain", line_no=7, source="session.jsonl"),
+    ]
+
+    windows = select_feedback_windows(
+        turns,
+        window_radius=1,
+        max_windows=6,
+        hard_max_turns=3,
+    )
+    assert windows == [(1, 6)]
+
+
+def test_select_feedback_windows_merges_overlapping_regions() -> None:
+    """test select_feedback_windows merges overlapping windows."""
+    turns = [
+        SessionTurn(role="user", content="hello", line_no=1, source="session.jsonl"),
+        SessionTurn(role="user", content="that was wrong", line_no=2, source="session.jsonl"),
+        SessionTurn(role="assistant", content="ok", line_no=3, source="session.jsonl"),
+        SessionTurn(role="user", content="and again incorrect", line_no=4, source="session.jsonl"),
+        SessionTurn(role="assistant", content="yes", line_no=5, source="session.jsonl"),
+        SessionTurn(role="user", content="final", line_no=6, source="session.jsonl"),
+    ]
+
+    windows = select_feedback_windows(
+        turns,
+        window_radius=2,
+        max_windows=6,
+        hard_max_turns=3,
+    )
+    assert windows == [(0, 6)]
+
+
+def test_dedupe_learning_events_is_idempotent() -> None:
+    """test dedupe_learning_events skips events seen before by deterministic key."""
+    events = [
+        {
+            "type": "CORRECTION",
+            "content": "alpha",
+            "content_hash": "cafebabe",
+            "session_pointer": "s:1-10",
+        },
+        {
+            "type": "CORRECTION",
+            "content": "alpha",
+            "content_hash": "cafebabe",
+            "session_pointer": "s:1-10",
+        },
+        {
+            "type": "TEACHING",
+            "content": "alpha",
+            "content_hash": "cafebabe",
+            "session_pointer": "s:1-10",
+        },
+    ]
+    existing = {"CORRECTION|cafebabe|s:1-10"}
+    appended, skipped = dedupe_learning_events(existing=existing, events=events)
+
+    assert skipped == 2
+    assert len(appended) == 1
+    assert appended[0]["type"] == "TEACHING"


### PR DESCRIPTION
Implements full-learning replay per #7 + latest acceptance criteria.\n\nKey:\n- replay: --fast-learning / --full-learning, checkpoint/resume, backup\n- fast loop: LLM transcript mining (gpt-5-mini) + durable learning_events.jsonl + batch inject (inject_batch + embed_batch)\n- slow loop: new harvest command + correction-density damping + report\n- docs: setup + integration + full rebuild\n- tests: idempotency + window selection + CLI coverage\n\nLocal: python3 -m pytest (289 passed)