### PR TITLE
feat: decay during replay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,16 @@
 
 - Added `openclawbrain replay --fast-learning` for LLM transcript mining + injection from session logs.
 - Added `openclawbrain replay --full-learning` to run replay + fast-learning + slow maintenance.
+- `--full-learning` now enables decay during replay by default and runs harvest with decay task (`decay,scale,split,merge,prune,connect`).
+- Added `--decay-during-replay` flag to enable periodic decay during any replay run (not just full-learning).
+- Added `--decay-interval N` flag (default 10) to control how often decay fires during replay.
 - Added resumability options: `--resume`, `--checkpoint`, and `--ignore-checkpoint`.
 - Added learning-context knobs: `--workers`, `--window-radius`, `--max-windows`, `--hard-max-turns`.
 - Added explicit `--backup` control for replay-backed mutation persistence.
 - Added new `openclawbrain harvest` command to consume `learning_events.jsonl` and apply `split/merge/prune/connect/scale`.
 - Added dedupe/idempotent behavior for event log ingestion keyed by `(type, sha256(content), session_pointer)`.
 - Documented sidecar full-learning workflow and updated `docs/setup-guide.md`, `docs/openclaw-integration.md`, `docs/FULL_REBUILD.md`.
-- Added tests for window selection, dedupe/idempotency, and replay + fast-learning injection behavior.
+- Added tests for window selection, dedupe/idempotency, replay + fast-learning injection behavior, and decay-during-replay edge reduction.
 
 ## v12.2.1 (2026-02-27)
 

--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ See `examples/openai_embedder/` for a complete example.
 | `compact` | Compact old daily notes into graph nodes |
 | `sync` | Incremental re-embed after file changes |
 | `inject` | Add CORRECTION/TEACHING/DIRECTIVE nodes |
-| `replay` | Replay session queries, optionally with `--fast-learning` or `--full-learning` |
+| `replay` | Replay session queries, optionally with `--fast-learning`, `--full-learning`, `--decay-during-replay` |
 | `harvest` | Apply slow-learning pass from `learning_events.jsonl` to current graph |
 | `health` | Show graph health metrics |
 | `status` | `openclawbrain status --state brain/state.json [--json]` returns a one-command health overview: version, nodes, edges, tier distribution, daemon status, embedder, decay half-life |
@@ -571,6 +571,23 @@ openclawbrain replay \
   --sessions ./sessions/ \
   --full-learning
 ```
+
+`--full-learning` enables decay during replay by default and runs the harvest
+pass with decay included (`decay,scale,split,merge,prune,connect`), so
+unrelated edges weaken while active paths are reinforced.
+
+To enable decay during a plain replay (without full-learning):
+
+```bash
+openclawbrain replay \
+  --state /tmp/brain/state.json \
+  --sessions ./sessions/ \
+  --decay-during-replay \
+  --decay-interval 10
+```
+
+`--decay-interval N` controls how many learning steps occur between each decay
+pass (default 10).
 
 The fast-learning and harvest pipeline is sidecar-only to the core files:
 `learning_events.jsonl` is append-only, and `replay` updates `state.json` via the same graph mutation model as existing injection commands.

--- a/docs/openclaw-integration.md
+++ b/docs/openclaw-integration.md
@@ -359,9 +359,21 @@ openclawbrain replay \
 
 This does:
 
-- replay query edges from session history
+- replay query edges from session history (with decay enabled by default)
 - LLM transcript mining into `learning::` nodes (`--fast-learning` behavior)
-- slow-learning maintenance pass (`harvest`) with split/merge/prune/connect/scale
+- slow-learning maintenance pass (`harvest`) with decay/scale/split/merge/prune/connect
+
+To enable decay during a plain replay without full-learning, use `--decay-during-replay`:
+
+```bash
+openclawbrain replay \
+  --state ~/.openclawbrain/main/state.json \
+  --sessions /path/to/sessions \
+  --decay-during-replay \
+  --decay-interval 10
+```
+
+`--decay-interval N` (default 10) controls how many learning steps between each decay pass.
 
 `learning_events.jsonl` is an append-only sidecar under the brain directory used by harvest:
 

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -91,6 +91,18 @@ The harvest path is intentionally sidecar: it consumes OpenClaw replay artifacts
 
 For production automation, run `harvest` after `replay --fast-learning` with a bounded schedule (daily/hourly depending on session volume).
 
+## Decay during replay
+
+`--full-learning` automatically enables decay during the replay pass. Unrelated edges weaken while actively traversed paths are reinforced. The harvest step also includes the `decay` task (`decay,scale,split,merge,prune,connect`).
+
+To enable decay during a plain replay (without full-learning), pass `--decay-during-replay`:
+
+```bash
+openclawbrain replay --state ./brain/state.json --sessions ./sessions/ --decay-during-replay --decay-interval 10
+```
+
+`--decay-interval N` (default 10) controls how many learning steps occur between each decay pass.
+
 ## Performance knobs
 
 - `--workers`: parallelize LLM window extraction (higher = faster, bounded by rate limits)


### PR DESCRIPTION
Implements decay-during-replay (learn+decay concurrently) per Jon requirement.

- replay_queries: adds auto_decay + decay_interval; plumbed into apply_outcome(auto_decay)
- CLI: new flags --decay-during-replay, --decay-interval
- --full-learning: enables decay during replay by default and harvest includes decay task
- docs: README + setup-guide + integration + changelog updates
- tests: replay decay regression test

pytest: 290 passed