### PR TITLE
feat: best brain by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+### Best brain by default
+- `replay` now defaults to full-learning (fast-learning + harvest). Use `--edges-only` for cheap edge-only replay.
+- `init` now defaults to `--embedder auto --llm auto`, which tries OpenAI and falls back to hash/none gracefully.
+- Added `--edges-only` flag for replay to explicitly request old edge-only behavior.
+- Guarded `full_learning.py` OpenAI imports with try/except so the module loads without openai installed.
+
 ### Full-learning replay and harvest
 
 - Added `openclawbrain replay --fast-learning` for LLM transcript mining + injection from session logs.

--- a/docs/openclaw-integration.md
+++ b/docs/openclaw-integration.md
@@ -123,7 +123,8 @@ BRAIN_DIR=~/.openclawbrain/main
 mkdir -p "$BRAIN_DIR"
 
 # Create/overwrite state.json inside the output directory
-openclawbrain init --workspace "$WORKSPACE" --output "$BRAIN_DIR" --embedder openai --llm openai
+# By default, init auto-detects OpenAI (uses it if OPENAI_API_KEY is set, falls back to hash otherwise)
+openclawbrain init --workspace "$WORKSPACE" --output "$BRAIN_DIR"
 
 # Quick health signal
 openclawbrain doctor --state "$BRAIN_DIR/state.json"
@@ -348,13 +349,12 @@ OpenClawBrain ships an OpenClaw adapter that logs fired IDs per chat.
 
 That’s the ergonomic way to do “same-turn correction” inside OpenClaw.
 
-For full-history rebuilds, use fast/full replay:
+For full-history rebuilds, replay your sessions (full-learning is the default):
 
 ```bash
 openclawbrain replay \
   --state ~/.openclawbrain/main/state.json \
-  --sessions /path/to/sessions \
-  --full-learning
+  --sessions /path/to/sessions
 ```
 
 This does:
@@ -363,12 +363,22 @@ This does:
 - LLM transcript mining into `learning::` nodes (`--fast-learning` behavior)
 - slow-learning maintenance pass (`harvest`) with decay/scale/split/merge/prune/connect
 
-To enable decay during a plain replay without full-learning, use `--decay-during-replay`:
+For cheap edge-only replay (no LLM, no harvest), use `--edges-only`:
 
 ```bash
 openclawbrain replay \
   --state ~/.openclawbrain/main/state.json \
   --sessions /path/to/sessions \
+  --edges-only
+```
+
+To enable decay during an edges-only replay, add `--decay-during-replay`:
+
+```bash
+openclawbrain replay \
+  --state ~/.openclawbrain/main/state.json \
+  --sessions /path/to/sessions \
+  --edges-only \
   --decay-during-replay \
   --decay-interval 10
 ```


### PR DESCRIPTION
Per Jon requirement: the default experience should build the best brain.

Changes:
- `openclawbrain replay` now defaults to FULL learning (replay + fast-learning + harvest) when no mode flags are provided.
- Added `--edges-only` to run the old cheap edge-only replay (no LLM/no injections/no harvest).
- `openclawbrain init` defaults to `--embedder auto` and `--llm auto`: uses OpenAI embeddings + GPT-5-mini when OPENAI_API_KEY is present; falls back to hash + no-LLM with a warning.
- Updated README + setup guide + integration docs + changelog.
- Updated/added tests for the new defaults; tests are explicit about `--edges-only` and init fallback.

Tests:
- `pytest`: 294 passed