### PR TITLE
Perf: concurrent LLM splitting + only LLM-split large/complex files by default

### DIFF
--- a/openclawbrain/_batch.py
+++ b/openclawbrain/_batch.py
@@ -13,7 +13,12 @@ def batch_or_single(
 ) -> list[dict]:
     """Execute LLM requests using a batch callback when available, otherwise parallel single calls."""
     if llm_batch_fn is not None:
-        return llm_batch_fn(requests)
+        # Prefer an explicit batch implementation when provided.
+        # If it supports concurrency, pass max_workers.
+        try:
+            return llm_batch_fn(requests, max_workers=max_workers)  # type: ignore[misc]
+        except TypeError:
+            return llm_batch_fn(requests)
     if llm_fn is None:
         raise ValueError("either llm_fn or llm_batch_fn must be provided")
     if not requests:

--- a/openclawbrain/openai_llm.py
+++ b/openclawbrain/openai_llm.py
@@ -57,29 +57,42 @@ def chat_completion(system: str, user: str) -> str:
     return openai_llm_fn(system, user)
 
 
-def openai_llm_batch_fn(requests: list[dict]) -> list[dict]:
-    """Run OpenAI chat requests sequentially."""
+def openai_llm_batch_fn(requests: list[dict], *, max_workers: int = 8) -> list[dict]:
+    """Run OpenAI chat requests concurrently.
+
+    This is used by `batch_or_single()` when an explicit batch fn is provided.
+    Historically this implementation was sequential, which made `init --llm openai`
+    take hours for medium workspaces.
+
+    Args:
+        requests: list of {id, system, user}
+        max_workers: thread pool size
+    """
     if not requests:
         return []
 
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+
     total = len(requests)
     results: list[dict] = []
-    for index, req in enumerate(requests, start=1):
-        print(f"LLM batch progress: processing {index}/{total}", file=sys.stderr)
+
+    def _call(idx: int, req: dict) -> dict:
         system = str(req.get("system", ""))
         user = str(req.get("user", ""))
         request_id = req.get("id")
         try:
             response = openai_llm_fn(system, user)
         except Exception as exc:  # noqa: BLE001
-            print(
-                f"LLM batch request {index}/{total} failed: {exc}",
-                file=sys.stderr,
-            )
-            result = {"response": "", "error": str(exc)}
-        else:
-            result = {"response": response}
-        if request_id is not None:
-            result["id"] = request_id
-        results.append(result)
+            return {"id": request_id, "response": "", "error": str(exc)}
+        return {"id": request_id, "response": response}
+
+    with ThreadPoolExecutor(max_workers=max_workers) as pool:
+        futures = {pool.submit(_call, i, req): i for i, req in enumerate(requests, start=1)}
+        completed = 0
+        for fut in as_completed(futures):
+            completed += 1
+            if completed % 5 == 0 or completed == total:
+                print(f"LLM batch progress: processing {completed}/{total}", file=sys.stderr)
+            results.append(fut.result())
+
     return results


### PR DESCRIPTION
Fixes the init bottleneck when running `openclawbrain init --llm openai`:

- Make OpenAI LLM batch path concurrent (thread pool)
- Thread pool size is wired through `_batch.batch_or_single` into `openai_llm_batch_fn`
- Add init flags to reduce LLM usage by default:
  - `--llm-split-mode auto|all|off` (default auto)
  - `--llm-split-min-chars` (default 20000)
- In `auto` mode, only use LLM splitting for large files and key docs; smaller files use heuristic chunking.

Tests: `pytest` passes (291).

Related: #13