### PR TITLE
fix: self-healing replay + connect maintenance crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Unreleased
 
+### Self-healing replay for rotated/missing session files
+- `replay.py`: `extract_queries`, `extract_query_records`, and `extract_interactions` now return empty lists (with a stderr warning) when a session file is missing or a broken symlink, instead of raising `SystemExit`. This lets long full-learning rebuilds survive rotated or deleted session files.
+- `full_learning.py`: `_read_records` and `collect_session_files` apply the same self-healing behavior — missing or broken-symlink paths are skipped with a warning. If *all* paths are invalid, `collect_session_files` still exits with a helpful message.
+- Added tests for missing-file and broken-symlink cases in both modules.
+
+### Bug fix: maintain.py `apply_connections` import
+- **CRITICAL**: `maintain.py` was missing `from .connect import apply_connections`, causing a `NameError` crash whenever `connect_learning_nodes` ran during full-learning harvest. Added the import and a regression test.
+
 ### Best brain by default
 - `replay` now defaults to full-learning (fast-learning + harvest). Use `--edges-only` for cheap edge-only replay.
 - `init` now defaults to `--embedder auto --llm auto`, which tries OpenAI and falls back to hash/none gracefully.

--- a/README.md
+++ b/README.md
@@ -592,6 +592,9 @@ openclawbrain replay \
 `--decay-interval N` controls how many learning steps occur between each decay
 pass (default 10).
 
+Missing or rotated session files are skipped with a warning instead of aborting
+the run, so long rebuilds survive file rotation.
+
 The fast-learning and harvest pipeline is sidecar-only to the core files:
 `learning_events.jsonl` is append-only, and `replay` updates `state.json` via the same graph mutation model as existing injection commands.
 

--- a/docs/FULL_REBUILD.md
+++ b/docs/FULL_REBUILD.md
@@ -317,6 +317,16 @@ ps aux | grep "openclawbrain init"
 
 LLM splitting can be slow (~30 min for 200 files). Run with `nohup` to survive disconnects.
 
+### Session files rotated or deleted mid-rebuild
+
+Replay and full-learning now **skip** missing or broken-symlink session files with a stderr warning instead of aborting. You will see messages like:
+
+```
+warning: skipping missing session file: /path/to/rotated.jsonl
+```
+
+This is safe — the pipeline continues with the remaining files. If *all* paths are invalid, it exits with a clear error.
+
 ### Replay loads 0 interactions
 
 Session files might be in a different format. Check:

--- a/openclawbrain/maintain.py
+++ b/openclawbrain/maintain.py
@@ -7,6 +7,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 
+from .connect import apply_connections
 from .decay import DecayConfig, apply_decay
 from .graph import Graph, Node
 from .index import VectorIndex

--- a/openclawbrain/replay.py
+++ b/openclawbrain/replay.py
@@ -200,12 +200,19 @@ def extract_interactions(
     """
     path = Path(session_path).expanduser()
     if not path.exists():
-        raise SystemExit(f"missing sessions file: {path}")
+        print(f"warning: skipping missing session file: {path}", file=sys.stderr)
+        return []
 
     interactions: list[dict[str, object]] = []
     last_user_index: int | None = None
 
-    for raw in path.open("r", encoding="utf-8"):
+    try:
+        fh = path.open("r", encoding="utf-8")
+    except (FileNotFoundError, OSError) as exc:
+        print(f"warning: skipping unreadable session file: {path} ({exc})", file=sys.stderr)
+        return []
+
+    for raw in fh:
         raw = raw.strip()
         if not raw:
             continue
@@ -289,10 +296,16 @@ def extract_queries(session_path: str | Path, since_ts: float | None = None) -> 
     """
     path = Path(session_path).expanduser()
     if not path.exists():
-        raise SystemExit(f"missing sessions file: {path}")
+        print(f"warning: skipping missing session file: {path}", file=sys.stderr)
+        return []
 
     queries: list[str] = []
-    with path.open("r", encoding="utf-8") as handle:
+    try:
+        handle = path.open("r", encoding="utf-8")
+    except (FileNotFoundError, OSError) as exc:
+        print(f"warning: skipping unreadable session file: {path} ({exc})", file=sys.stderr)
+        return []
+    with handle:
         for raw in handle:
             query, query_ts = _extract_query_record(raw.strip())
             if query is None:
@@ -311,10 +324,16 @@ def extract_query_records(
     """Extract (query, timestamp) pairs from session log."""
     path = Path(session_path).expanduser()
     if not path.exists():
-        raise SystemExit(f"missing sessions file: {path}")
+        print(f"warning: skipping missing session file: {path}", file=sys.stderr)
+        return []
 
     records: list[tuple[str, float | None]] = []
-    with path.open("r", encoding="utf-8") as handle:
+    try:
+        handle = path.open("r", encoding="utf-8")
+    except (FileNotFoundError, OSError) as exc:
+        print(f"warning: skipping unreadable session file: {path} ({exc})", file=sys.stderr)
+        return []
+    with handle:
         for raw in handle:
             raw = raw.strip()
             if not raw:

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -250,6 +250,34 @@ def test_replay_queries_auto_scores_if_assistant_response_matches() -> None:
     assert boosted._edges["a"]["b"].weight > base._edges["a"]["b"].weight
 
 
+def test_extract_queries_missing_file_returns_empty(tmp_path: Path) -> None:
+    """Missing session file returns empty list instead of crashing."""
+    missing = tmp_path / "does_not_exist.jsonl"
+    assert extract_queries(missing) == []
+
+
+def test_extract_interactions_missing_file_returns_empty(tmp_path: Path) -> None:
+    """Missing session file returns empty list instead of crashing."""
+    missing = tmp_path / "gone.jsonl"
+    assert extract_interactions(missing) == []
+
+
+def test_extract_queries_broken_symlink_returns_empty(tmp_path: Path) -> None:
+    """Broken symlink is skipped gracefully."""
+    target = tmp_path / "real.jsonl"
+    link = tmp_path / "broken.jsonl"
+    link.symlink_to(target)  # target does not exist → broken symlink
+    assert extract_queries(link) == []
+
+
+def test_extract_interactions_broken_symlink_returns_empty(tmp_path: Path) -> None:
+    """Broken symlink is skipped gracefully."""
+    target = tmp_path / "real.jsonl"
+    link = tmp_path / "broken.jsonl"
+    link.symlink_to(target)
+    assert extract_interactions(link) == []
+
+
 def test_decay_during_replay_reduces_unrelated_edge() -> None:
     """Decay during replay weakens edges not reinforced by replayed queries."""
     # Reset the global call counter so decay_interval triggers deterministically.


### PR DESCRIPTION
## Why
- Full-learning rebuilds can fail when session files rotate / symlinks break mid-run.
- Harvest/maintenance `connect` task was crashing with `NameError: apply_connections not defined` (missing import).

## What
- `openclawbrain/replay.py`: missing/broken session files now warn+skip (return empty) instead of `SystemExit`.
- `openclawbrain/full_learning.py`: `_read_records` + `collect_session_files` skip missing/broken paths with warnings; still exits if *all* paths invalid.
- `openclawbrain/maintain.py`: import `apply_connections` to fix connect-task crash.
- Added tests:
  - missing file + broken symlink cases for replay/full-learning
  - regression test ensuring `run_maintenance(tasks=["connect"])` does not raise
- Docs: README + `docs/FULL_REBUILD.md` + CHANGELOG updated.

## Testing
- `python3 -m pytest tests/ -q` (301 passed)
