### PR TITLE
Issue #19: replay progress/checkpoints, fast-learning cutover, and parallel replay v0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 ## Unreleased
 
+### Replay ops hardening + simple parallel replay v0 (issue #19)
+- `openclawbrain replay` adds:
+  - `--progress-every N` (periodic progress, JSONL events when `--json` is enabled)
+  - `--checkpoint-every-seconds S` and `--checkpoint-every K` (frequent checkpoints during fast-learning and replay)
+  - `--persist-state-every-seconds S` (periodic state persistence during replay)
+  - `--stop-after-fast-learning` (cutover mode: inject/embed/persist, then exit before replay/harvest)
+  - `--replay-workers N` (simple true-parallel replay mode; default `1`)
+- Replay now supports line-offset checkpoint resume through replay sessions, and writes replay checkpoints incrementally during processing.
+- Added simple deterministic parallel replay reducer: workers compute shard deltas from traversal results, reducer merges batches in deterministic order, and checkpoints are written after merges.
+- Added tests for replay progress events, replay checkpoint+resume behavior, stop-after-fast-learning early exit, and parallel replay mode output.
+
 ### OpenAI LLM client stability (issue #17)
 - `openai_llm.py`: made OpenAI clients thread-local for batch-thread safety, added client-level defaults `timeout=60` and `max_retries=2` when supported, and narrowed the `TypeError` fallback in `openai_llm_fn` to timeout-only compatibility only.
 

--- a/README.md
+++ b/README.md
@@ -578,6 +578,50 @@ openclawbrain replay \
   --checkpoint /tmp/brain/replay_checkpoint.json
 ```
 
+For cutover-friendly startup (inject quickly, then start daemon immediately):
+
+```bash
+openclawbrain replay \
+  --state /tmp/brain/state.json \
+  --sessions ./sessions/ \
+  --fast-learning \
+  --stop-after-fast-learning \
+  --checkpoint /tmp/brain/replay_checkpoint.json
+```
+
+For durable long replays with periodic progress/checkpoint/state persistence:
+
+```bash
+openclawbrain replay \
+  --state /tmp/brain/state.json \
+  --sessions ./sessions/ \
+  --edges-only \
+  --resume \
+  --checkpoint /tmp/brain/replay_checkpoint.json \
+  --checkpoint-every-seconds 60 \
+  --checkpoint-every 1 \
+  --persist-state-every-seconds 30 \
+  --progress-every 250
+```
+
+When `--json` is set, progress is emitted as JSONL events:
+`{"type":"progress","phase":"replay",...}`.
+
+For simple true-parallel replay v0:
+
+```bash
+openclawbrain replay \
+  --state /tmp/brain/state.json \
+  --sessions ./sessions/ \
+  --edges-only \
+  --replay-workers 4 \
+  --checkpoint-every 1
+```
+
+Parallel replay v0 is an approximation: workers process deterministic shards and
+compute replay deltas without mutating shared state; the reducer applies those
+deltas in deterministic merge order, with checkpoints after each merge batch.
+
 To enable decay during an edges-only replay:
 
 ```bash

--- a/openclawbrain/full_learning.py
+++ b/openclawbrain/full_learning.py
@@ -7,6 +7,7 @@ import hashlib
 import json
 import os
 import sys
+import time
 from collections import defaultdict
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -417,30 +418,59 @@ def append_learning_events(path: Path | str, events: list[dict]) -> None:
             pass
 
 
-def _load_checkpoint(path: Path | str) -> dict[str, int]:
+def _load_checkpoint(path: Path | str) -> dict[str, Any]:
     """Load checkpoint JSON."""
-    payload = {"sessions": {}}
+    payload: dict[str, Any] = {"version": 1, "sessions": {}}
     p = Path(path)
     if not p.exists():
-        return {"sessions": {}}
+        return payload
     try:
         raw = json.loads(p.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, OSError):
         return payload
     if not isinstance(raw, dict):
         return payload
-    sessions = raw.get("sessions")
-    if not isinstance(sessions, dict):
-        return payload
-    return {"sessions": {k: int(v) for k, v in sessions.items() if isinstance(v, (int, float))}}
+    raw_sessions = raw.get("sessions")
+    if isinstance(raw_sessions, dict):
+        payload["sessions"] = {k: int(v) for k, v in raw_sessions.items() if isinstance(v, (int, float))}
+
+    for phase in ("fast_learning", "replay"):
+        phase_payload = raw.get(phase)
+        if not isinstance(phase_payload, dict):
+            continue
+        normalized_phase: dict[str, Any] = dict(phase_payload)
+        sessions = phase_payload.get("sessions")
+        if isinstance(sessions, dict):
+            normalized_phase["sessions"] = {k: int(v) for k, v in sessions.items() if isinstance(v, (int, float))}
+        payload[phase] = normalized_phase
+    return payload
 
 
-def _save_checkpoint(path: Path | str, session_offsets: dict[str, int]) -> None:
-    """Save replay checkpoint."""
+def _save_checkpoint(
+    path: Path | str,
+    *,
+    phase: str,
+    session_offsets: dict[str, int] | None = None,
+    extra: dict[str, object] | None = None,
+) -> None:
+    """Save replay checkpoint with phase-scoped fields."""
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
+    payload = _load_checkpoint(path)
+    payload["version"] = 1
+    phase_payload = payload.get(phase)
+    if not isinstance(phase_payload, dict):
+        phase_payload = {}
+    phase_payload = dict(phase_payload)
+    if session_offsets is not None:
+        phase_payload["sessions"] = {key: int(value) for key, value in session_offsets.items()}
+    if extra:
+        phase_payload.update(extra)
+    payload[phase] = phase_payload
+    if phase == "fast_learning" and session_offsets is not None:
+        payload["sessions"] = dict(phase_payload.get("sessions", {}))
     with path.open("w", encoding="utf-8") as handle:
-        json.dump({"version": 1, "sessions": session_offsets}, handle, indent=2)
+        json.dump(payload, handle, indent=2)
 
 
 def _persist_state(
@@ -494,7 +524,16 @@ def load_interactions_for_replay(
                 if not query:
                     last_user_idx = None
                     continue
-                interactions.append({"query": query, "response": None, "tool_calls": [], "ts": record_ts})
+                interactions.append(
+                    {
+                        "query": query,
+                        "response": None,
+                        "tool_calls": [],
+                        "ts": record_ts,
+                        "source": path_name,
+                        "line_no": line_no,
+                    }
+                )
                 last_user_idx = len(interactions) - 1
                 continue
 
@@ -542,6 +581,8 @@ def run_fast_learning(
     resume: bool = False,
     ignore_checkpoint: bool = False,
     backup: bool = True,
+    checkpoint_every: int = 0,
+    checkpoint_every_seconds: int = 60,
 ) -> dict[str, Any]:
     """Run LLM-backed transcript mining and inject new learning nodes."""
     if workers < 1:
@@ -551,10 +592,16 @@ def run_fast_learning(
             raise SystemExit("LLM required for fast-learning; install openai and set OPENAI_API_KEY")
         llm_fn = openai_llm_fn
 
-    checkpoint = _load_checkpoint(checkpoint_path) if (checkpoint_path and resume) else {"sessions": {}}
+    checkpoint = _load_checkpoint(checkpoint_path) if (checkpoint_path and resume) else {"version": 1, "sessions": {}}
     if ignore_checkpoint:
-        checkpoint = {"sessions": {}}
-    start_lines = checkpoint.get("sessions", {})
+        checkpoint = {"version": 1, "sessions": {}}
+    fast_checkpoint = checkpoint.get("fast_learning")
+    if not isinstance(fast_checkpoint, dict):
+        fast_checkpoint = {}
+    start_lines_raw = fast_checkpoint.get("sessions")
+    if not isinstance(start_lines_raw, dict):
+        start_lines_raw = checkpoint.get("sessions", {})
+    start_lines = {k: int(v) for k, v in start_lines_raw.items() if isinstance(v, (int, float))}
 
     grouped_turns, turn_offsets = _collect_turns(session_paths, since_lines=start_lines)
     windows: list[tuple[str, list[SessionTurn], int]] = []
@@ -572,11 +619,43 @@ def run_fast_learning(
                 windows.append((source, turns[start:end], idx))
 
     all_events: list[dict] = []
+    completed_windows = 0
+    checkpoint_every_windows = max(0, checkpoint_every)
+    checkpoint_interval_seconds = max(0, checkpoint_every_seconds)
+    last_checkpoint_at = time.monotonic()
+
+    def _maybe_checkpoint_fast() -> None:
+        nonlocal last_checkpoint_at
+        if not checkpoint_path:
+            return
+        should_checkpoint_by_count = (
+            checkpoint_every_windows > 0 and completed_windows > 0 and completed_windows % checkpoint_every_windows == 0
+        )
+        should_checkpoint_by_time = (
+            checkpoint_interval_seconds > 0 and (time.monotonic() - last_checkpoint_at) >= checkpoint_interval_seconds
+        )
+        if not (should_checkpoint_by_count or should_checkpoint_by_time):
+            return
+        _save_checkpoint(
+            checkpoint_path,
+            phase="fast_learning",
+            session_offsets=None,
+            extra={
+                "status": "running",
+                "windows_processed": completed_windows,
+                "windows_total": len(windows),
+                "updated_at": time.time(),
+            },
+        )
+        last_checkpoint_at = time.monotonic()
+
     if windows:
         request_ctx = [(source, idx + 1, len(windows), segment) for idx, (source, segment, _) in enumerate(windows)]
         if workers == 1:
             for source, idx, total, segment in request_ctx:
                 all_events.extend(_window_to_payload(session=source, window=segment, window_idx=idx, total_windows=total, llm_fn=llm_fn))
+                completed_windows += 1
+                _maybe_checkpoint_fast()
         else:
             with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
                 futures = {
@@ -592,6 +671,8 @@ def run_fast_learning(
                 }
                 for future in concurrent.futures.as_completed(futures):
                     all_events.extend(future.result())
+                    completed_windows += 1
+                    _maybe_checkpoint_fast()
 
     if not include_reinforcements:
         all_events = [event for event in all_events if event.get("type") != "REINFORCEMENT"]
@@ -645,8 +726,18 @@ def run_fast_learning(
         )
         _persist_state(graph=graph, index=index, meta=meta, state_path=state_path, backup=backup)
 
-    if checkpoint_path and resume:
-        _save_checkpoint(checkpoint_path, turn_offsets)
+    if checkpoint_path:
+        _save_checkpoint(
+            checkpoint_path,
+            phase="fast_learning",
+            session_offsets=turn_offsets,
+            extra={
+                "status": "complete",
+                "windows_processed": completed_windows,
+                "windows_total": len(windows),
+                "updated_at": time.time(),
+            },
+        )
 
     return {
         "windows": len(windows),


### PR DESCRIPTION
Implements #19.

## What changed
- Added replay ops flags:
  - `--progress-every N`
  - `--checkpoint-every-seconds S`
  - `--checkpoint-every K`
  - `--stop-after-fast-learning`
  - `--replay-workers N`
  - `--persist-state-every-seconds S`
- Added cutover mode so operators can stop after fast-learning injection and start daemon immediately.
- Added replay checkpointing/persistence cadence hooks and line-offset replay resume checkpoints.
- Added simple deterministic true-parallel replay v0:
  - stable sharding across workers
  - worker-side delta extraction without shared-state mutation
  - deterministic reducer merge batches
  - checkpoint cadence after merges
- Added tests for:
  - replay progress events
  - replay checkpoint write/resume behavior
  - stop-after-fast-learning early exit
  - parallel replay mode output
- Updated README + CHANGELOG with new flags and parallel replay semantics/tradeoffs.

## Validation
- `PYTHONPATH=$PWD pytest -q tests/test_cli.py tests/test_replay.py tests/test_full_learning.py`
- `PYTHONPATH=$PWD pytest -q`
