### PR TITLE
Add deterministic prompt context formatter for cache-stable retrieval blocks

### DIFF
--- a/examples/openclaw_adapter/README.md
+++ b/examples/openclaw_adapter/README.md
@@ -29,6 +29,10 @@ Script specifics:
 - `learn_correction.py`: apply corrections to the last `lookback` queries using `--chat-id`-scoped fired nodes.
 - `agents_hook.md`: AGENTS.md integration block.
 
+## Prompt caching tip
+
+Use `query_brain.py --format prompt` to print a deterministic `[BRAIN_CONTEXT v1]...[/BRAIN_CONTEXT]` appendix block built from fired node content. Append that block late in your final OpenAI prompt to improve prompt caching stability.
+
 ## Real-time corrections
 
 The live correction flow adds two pieces:

--- a/openclawbrain/__init__.py
+++ b/openclawbrain/__init__.py
@@ -18,6 +18,7 @@ from .split import generate_summaries, split_workspace
 from .sync import DEFAULT_AUTHORITY_MAP, SyncReport, sync_workspace
 from .store import ManagedState, load_state, save_state
 from .traverse import TraversalResult, TraversalConfig, traverse
+from .prompt_context import build_prompt_context
 
 __all__ = [
     "Node",
@@ -38,6 +39,7 @@ __all__ = [
     "prune_edges",
     "prune_orphan_nodes",
     "traverse",
+    "build_prompt_context",
     "ManagedState",
     "split_workspace",
     "generate_summaries",

--- a/openclawbrain/prompt_context.py
+++ b/openclawbrain/prompt_context.py
@@ -1,0 +1,181 @@
+"""Deterministic prompt-context block formatting for retrieval output."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from .graph import Graph
+
+
+def _as_int(value: Any) -> int | None:
+    """Best-effort conversion to integer line numbers."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return None
+        try:
+            return int(stripped)
+        except ValueError:
+            return None
+    return None
+
+
+def _line_bounds(metadata: dict[str, Any]) -> tuple[int | None, int | None]:
+    """Extract start/end line values from common metadata fields."""
+    start = _as_int(metadata.get("start_line"))
+    end = _as_int(metadata.get("end_line"))
+
+    if start is not None or end is not None:
+        return start, end
+
+    line_range = metadata.get("line_range")
+    if isinstance(line_range, (list, tuple)):
+        if len(line_range) >= 2:
+            return _as_int(line_range[0]), _as_int(line_range[1])
+        if len(line_range) == 1:
+            value = _as_int(line_range[0])
+            return value, value
+
+    if isinstance(line_range, dict):
+        start_value = _as_int(line_range.get("start"))
+        end_value = _as_int(line_range.get("end"))
+        if start_value is not None or end_value is not None:
+            return start_value, end_value
+
+    if isinstance(line_range, str):
+        matches = [int(value) for value in re.findall(r"\d+", line_range)]
+        if len(matches) >= 2:
+            return matches[0], matches[1]
+        if len(matches) == 1:
+            return matches[0], matches[0]
+
+    return None, None
+
+
+def _source_path(metadata: dict[str, Any]) -> str | None:
+    """Extract source-path metadata from common keys."""
+    for key in ("path", "file", "source"):
+        value = metadata.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _citation(path: str | None, start_line: int | None, end_line: int | None) -> str | None:
+    """Build source citation text when path metadata is available."""
+    if not path:
+        return None
+    if start_line is not None and end_line is not None:
+        return f"{path}#L{start_line}-L{end_line}"
+    if start_line is not None:
+        return f"{path}#L{start_line}"
+    if end_line is not None:
+        return f"{path}#L{end_line}"
+    return path
+
+
+def _sort_key(graph: Graph, node_id: str) -> tuple[int, str, int, str]:
+    """Sort by source metadata when available, otherwise by node id."""
+    node = graph.get_node(node_id)
+    if node is None or not isinstance(node.metadata, dict):
+        return (1, "", 0, node_id)
+
+    path = _source_path(node.metadata)
+    if path is None:
+        return (1, "", 0, node_id)
+
+    start_line, _end_line = _line_bounds(node.metadata)
+    return (0, path, start_line if start_line is not None else 0, node_id)
+
+
+def _format_entry(
+    graph: Graph,
+    node_id: str,
+    *,
+    include_node_ids: bool,
+) -> str | None:
+    """Render one deterministic context entry."""
+    node = graph.get_node(node_id)
+    if node is None:
+        return None
+
+    metadata = node.metadata if isinstance(node.metadata, dict) else {}
+    path = _source_path(metadata)
+    start_line, end_line = _line_bounds(metadata)
+    citation = _citation(path, start_line, end_line)
+
+    lines: list[str] = []
+    if include_node_ids:
+        lines.append(f"- node: {node_id}")
+    else:
+        lines.append("- snippet")
+    if citation is not None:
+        lines.append(f"  source: {citation}")
+
+    content = node.content or ""
+    if content:
+        lines.extend(f"  {line}" for line in content.splitlines())
+    else:
+        lines.append("  ")
+    return "\n".join(lines)
+
+
+def build_prompt_context(
+    graph: Graph,
+    node_ids: list[str],
+    *,
+    max_chars: int | None = 20000,
+    include_node_ids: bool = True,
+) -> str:
+    """Build a deterministic, cache-friendly context appendix block."""
+    header = "[BRAIN_CONTEXT v1]"
+    footer = "[/BRAIN_CONTEXT]"
+
+    unique_ids = sorted(set(node_ids), key=lambda item: _sort_key(graph, item))
+    entries = [
+        entry
+        for entry in (
+            _format_entry(graph, node_id, include_node_ids=include_node_ids)
+            for node_id in unique_ids
+        )
+        if entry is not None
+    ]
+
+    if entries:
+        body = "\n\n".join(entries)
+        rendered = f"{header}\n{body}\n{footer}"
+    else:
+        rendered = f"{header}\n{footer}"
+
+    if max_chars is None:
+        return rendered
+    if max_chars <= 0:
+        return ""
+    if len(rendered) <= max_chars:
+        return rendered
+
+    minimum = len(header) + 1 + len(footer)
+    if max_chars <= minimum:
+        return rendered[:max_chars]
+
+    body_budget = max_chars - minimum
+    trimmed_body = ""
+    for entry in entries:
+        candidate = entry if not trimmed_body else f"{trimmed_body}\n\n{entry}"
+        if len(candidate) <= body_budget:
+            trimmed_body = candidate
+            continue
+        if not trimmed_body and body_budget > 0:
+            trimmed_body = entry[:body_budget]
+        break
+
+    if trimmed_body:
+        return f"{header}\n{trimmed_body}\n{footer}"
+    return f"{header}\n{footer}"[:max_chars]

--- a/tests/test_prompt_context.py
+++ b/tests/test_prompt_context.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from openclawbrain.graph import Graph, Node
+from openclawbrain.prompt_context import build_prompt_context
+
+
+def test_build_prompt_context_is_deterministic_across_input_order() -> None:
+    """Prompt block is stable regardless of incoming node_ids order."""
+    graph = Graph()
+    graph.add_node(
+        Node(
+            "z",
+            "zeta",
+            metadata={"file": "docs/a.md", "start_line": 10, "end_line": 20},
+        )
+    )
+    graph.add_node(
+        Node(
+            "a",
+            "alpha",
+            metadata={"file": "docs/a.md", "start_line": 2, "end_line": 5},
+        )
+    )
+    graph.add_node(Node("m", "mu"))
+
+    rendered_one = build_prompt_context(graph=graph, node_ids=["z", "m", "a"])
+    rendered_two = build_prompt_context(graph=graph, node_ids=["a", "z", "m"])
+
+    assert rendered_one == rendered_two
+
+    first_entry_idx = rendered_one.find("- node: a")
+    second_entry_idx = rendered_one.find("- node: z")
+    third_entry_idx = rendered_one.find("- node: m")
+    assert first_entry_idx < second_entry_idx < third_entry_idx
+
+
+def test_build_prompt_context_includes_citation_with_source_lines() -> None:
+    """Citation line uses source path and line span when metadata is present."""
+    graph = Graph()
+    graph.add_node(
+        Node(
+            "deploy.md::0",
+            "Deploy with CI checks enabled.",
+            metadata={"path": "workspace/deploy.md", "start_line": 41, "end_line": 63},
+        )
+    )
+
+    rendered = build_prompt_context(graph=graph, node_ids=["deploy.md::0"])
+
+    assert "[BRAIN_CONTEXT v1]" in rendered
+    assert "- node: deploy.md::0" in rendered
+    assert "  source: workspace/deploy.md#L41-L63" in rendered
+    assert "  Deploy with CI checks enabled." in rendered
+    assert rendered.endswith("[/BRAIN_CONTEXT]")


### PR DESCRIPTION
## Summary
- add `openclawbrain.prompt_context.build_prompt_context()` for deterministic `[BRAIN_CONTEXT v1]` formatting
- sort fired snippets by source metadata (`path/file/source`, line info) with stable fallback to node id
- include source citations in prompt blocks when metadata has source path + line bounds
- add `--format {text,json,prompt}` to `examples/openclaw_adapter/query_brain.py`
- in `prompt` mode, emit formatter output from fired nodes (not raw traversal context)
- in `json` mode, add `prompt_context` alongside `context`
- add tests for deterministic output and citation formatting
- document prompt caching tip in `examples/openclaw_adapter/README.md`

## Testing
- `python3 -m pytest -q tests/test_prompt_context.py tests/test_traverse.py`
- `python3 -m pytest -q tests/test_cli.py`
