### PR TITLE
Add media toolResult text ingestion for replay and full-learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,6 +552,32 @@ full learning pipeline (LLM transcript mining + edge replay + harvest):
 openclawbrain replay --state /tmp/brain/state.json --sessions ./sessions/
 ```
 
+OpenClaw media uploads are usually logged as user text stubs like
+`[media attached: ...]`. Those stubs alone have little semantic value, so they
+often do not improve memory quality by themselves. The useful text typically
+arrives in later `toolResult` messages (OCR, image captions, audio transcript).
+
+Recommended approach:
+
+- Use dedicated media tools to emit transcript/OCR/caption text as `toolResult`.
+- Let OpenClawBrain attach allowlisted `toolResult` text to media-stub user
+  queries during replay and expose the same text to fast-learning windows.
+
+Replay controls for this behavior:
+
+```bash
+openclawbrain replay \
+  --state /tmp/brain/state.json \
+  --sessions ./sessions/ \
+  --include-tool-results \
+  --tool-result-allowlist image,openai-whisper,openai-whisper-api,openai-whisper-local,summarize \
+  --tool-result-max-chars 20000
+```
+
+- `--include-tool-results` / `--no-include-tool-results` (default enabled)
+- `--tool-result-allowlist` (comma-separated tool names)
+- `--tool-result-max-chars` (max allowlisted tool text appended per user query)
+
 This is equivalent to passing `--full-learning` explicitly. Decay is enabled
 during replay by default and the harvest pass runs
 (`decay,scale,split,merge,prune,connect`), so unrelated edges weaken while

--- a/docs/openclaw-integration.md
+++ b/docs/openclaw-integration.md
@@ -357,6 +357,22 @@ openclawbrain replay \
   --sessions /path/to/sessions
 ```
 
+Media note for OpenClaw logs:
+
+- User-uploaded image/audio is often stored as a stub like `[media attached: ...]`.
+- The meaningful OCR/transcript text usually appears later as `toolResult`.
+- OpenClawBrain replay can attach allowlisted `toolResult` text back onto the
+  media-stub user query and also expose it to fast-learning extraction windows.
+
+```bash
+openclawbrain replay \
+  --state ~/.openclawbrain/main/state.json \
+  --sessions /path/to/sessions \
+  --include-tool-results \
+  --tool-result-allowlist image,openai-whisper,openai-whisper-api,openai-whisper-local,summarize \
+  --tool-result-max-chars 20000
+```
+
 This does:
 
 - replay query edges from session history (with decay enabled by default)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "openclawbrain"
 version = "12.2.1"
 description = "Memory graph for AI agents that learns what to retrieve — and what to suppress."
 requires-python = ">=3.10"
-dependencies = []
+dependencies = ["openai>=1.0"]
 license = {text = "Apache-2.0"}
 authors = [{name = "Jonathan Gu", email = "jonathangu@gmail.com"}]
 readme = "README.md"


### PR DESCRIPTION
## Summary
- attach allowlisted `toolResult` text to preceding media-stub user queries during replay extraction
- include allowlisted media `toolResult` text as `tool` turns in fast-learning `_collect_turns` windows
- add replay CLI controls: `--include-tool-results`, `--tool-result-allowlist`, and `--tool-result-max-chars`
- add default dependency `openai>=1.0` for out-of-the-box OpenClaw usage
- add regression tests for replay/full-learning media toolResult behavior and CLI flag forwarding
- document media stub behavior and replay flag usage in README and OpenClaw integration docs

## Tests
- `python3 -m pytest -q tests/test_replay.py tests/test_full_learning.py tests/test_cli.py`
