### PR TITLE
Add practical operator replay/cutover helpers and recipes

### DIFF
--- a/docs/openclaw-integration.md
+++ b/docs/openclaw-integration.md
@@ -2,6 +2,7 @@
 
 OpenClawBrain is built to be the long-term memory layer for **OpenClaw agents**.
 Canonical docs and examples: https://openclawbrain.ai
+Operator recipes (cutover, parallel replay, prompt caching, media memory): [docs/ops-recipes.md](ops-recipes.md)
 
 If you’re already running OpenClaw, this guide shows the fastest path to:
 

--- a/docs/ops-recipes.md
+++ b/docs/ops-recipes.md
@@ -1,0 +1,97 @@
+# OpenClawBrain Ops Recipes
+
+Practical operator runbooks for cutovers and large replays.
+
+## Cutover fast
+
+Use this when you need improved retrieval quickly and can defer full replay/harvest.
+
+1. Run fast-learning only:
+
+```bash
+openclawbrain replay \
+  --state ~/.openclawbrain/main/state.json \
+  --sessions /path/to/sessions \
+  --fast-learning \
+  --stop-after-fast-learning \
+  --resume \
+  --checkpoint ~/.openclawbrain/main/replay_checkpoint.json
+```
+
+2. Start the daemon so serving traffic uses the latest state:
+
+```bash
+python3 -m openclawbrain.socket_server --state ~/.openclawbrain/main/state.json
+```
+
+3. Run full replay/harvest later (off-peak):
+
+```bash
+openclawbrain replay \
+  --state ~/.openclawbrain/main/state.json \
+  --sessions /path/to/sessions \
+  --full-learning \
+  --resume \
+  --checkpoint ~/.openclawbrain/main/replay_checkpoint.json
+```
+
+`examples/ops/cutover_then_background_full_learning.sh` automates this sequence.
+
+## Parallel replay
+
+For large histories, run replay in parallel workers and checkpoint frequently:
+
+```bash
+openclawbrain replay \
+  --state ~/.openclawbrain/main/state.json \
+  --sessions /path/to/sessions \
+  --full-learning \
+  --replay-workers 4 \
+  --workers 4 \
+  --checkpoint ~/.openclawbrain/main/replay_checkpoint.json \
+  --checkpoint-every-seconds 60 \
+  --checkpoint-every 50 \
+  --persist-state-every-seconds 300 \
+  --resume
+```
+
+Notes:
+- `--replay-workers` controls edge-replay parallelism.
+- `merge_batches` in replay output indicates how many merge windows were applied.
+- Use both `--checkpoint-every-seconds` and `--checkpoint-every` for long runs so restarts resume from recent progress.
+
+Use `examples/ops/replay_last_days.sh` when you want a bounded replay window.
+
+## Prompt caching
+
+For stable prompt caching, build the appendix from fired nodes and append it late:
+
+```bash
+python3 examples/openclaw_adapter/query_brain.py \
+  ~/.openclawbrain/main/state.json \
+  "user query summary" \
+  --format prompt
+```
+
+Guidelines:
+- Append the `[BRAIN_CONTEXT v1]...[/BRAIN_CONTEXT]` block near the end of the final prompt.
+- Keep stable node ordering (do not reshuffle lines between retries).
+- Avoid echoing/paraphrasing this block earlier in the prompt; duplicated context reduces cache stability.
+
+## Media memory
+
+OpenClaw session logs often store uploads as `[media attached: ...]` stubs. Those stubs are low-signal by themselves, so replay should ingest allowlisted `toolResult` text (OCR/transcripts/captions) when present.
+
+```bash
+openclawbrain replay \
+  --state ~/.openclawbrain/main/state.json \
+  --sessions /path/to/sessions \
+  --include-tool-results \
+  --tool-result-allowlist image,openai-whisper,openai-whisper-api,openai-whisper-local,summarize \
+  --tool-result-max-chars 20000
+```
+
+Flags:
+- `--include-tool-results` enables attachment of tool outputs to media-stub user turns.
+- `--tool-result-allowlist` limits ingestion to trusted tool names.
+- `--tool-result-max-chars` bounds appended text size per interaction.

--- a/docs/ops-recipes.md
+++ b/docs/ops-recipes.md
@@ -2,6 +2,8 @@
 
 Practical operator runbooks for cutovers and large replays.
 
+**OpenClaw path note:** OpenClaw agent session logs typically live at `~/.openclaw/agents/<agent>/sessions` (e.g., `~/.openclaw/agents/main/sessions`). You can pass that directory directly via `--sessions <dir>`.
+
 ## Cutover fast
 
 Use this when you need improved retrieval quickly and can defer full replay/harvest.

--- a/examples/ops/README.md
+++ b/examples/ops/README.md
@@ -5,6 +5,8 @@
 - `query_and_learn.py`: fast-loop interaction (`query -> traverse -> outcome`)
 - `run_maintenance.py`: slow-loop maintenance run (`health,decay,merge,prune`)
 - `compact_notes.py`: compact old daily notes into teaching summaries before graph updates
+- `replay_last_days.sh`: full-learning replay over session files modified in the last N days, with safe checkpoint defaults for long runs
+- `cutover_then_background_full_learning.sh`: fast-learning cutover first, then background full-learning replay via `nohup`
 
 By default, examples use OpenAI callbacks as the production path:
 
@@ -28,3 +30,36 @@ run_maintenance(..., embed_fn=embedder, llm_fn=llm)
 ```
 
 Use `--embedder hash` explicitly when you want deterministic, zero-API testing.
+
+## Shell helper usage
+
+Replay the last 14 days (defaults shown):
+
+```bash
+examples/ops/replay_last_days.sh \
+  --state ~/.openclawbrain/main/state.json \
+  --sessions-dir ~/.openclaw/sessions \
+  --days 14 \
+  --replay-workers 4 \
+  --workers 4 \
+  --progress-every 2000 \
+  --checkpoint-every-seconds 60 \
+  --checkpoint-every 50 \
+  --persist-state-every-seconds 300
+```
+
+Fast cutover, then background full-learning replay:
+
+```bash
+examples/ops/cutover_then_background_full_learning.sh \
+  --state ~/.openclawbrain/main/state.json \
+  --sessions-dir ~/.openclaw/sessions \
+  --replay-workers 4 \
+  --workers 4 \
+  --progress-every 2000 \
+  --checkpoint-every-seconds 60 \
+  --checkpoint-every 50 \
+  --persist-state-every-seconds 300
+```
+
+Both scripts run with `set -euo pipefail` and do not print secrets.

--- a/examples/ops/README.md
+++ b/examples/ops/README.md
@@ -38,7 +38,7 @@ Replay the last 14 days (defaults shown):
 ```bash
 examples/ops/replay_last_days.sh \
   --state ~/.openclawbrain/main/state.json \
-  --sessions-dir ~/.openclaw/sessions \
+  --sessions-dir ~/.openclaw/agents/main/sessions \
   --days 14 \
   --replay-workers 4 \
   --workers 4 \
@@ -53,7 +53,7 @@ Fast cutover, then background full-learning replay:
 ```bash
 examples/ops/cutover_then_background_full_learning.sh \
   --state ~/.openclawbrain/main/state.json \
-  --sessions-dir ~/.openclaw/sessions \
+  --sessions-dir ~/.openclaw/agents/main/sessions \
   --replay-workers 4 \
   --workers 4 \
   --progress-every 2000 \

--- a/examples/ops/cutover_then_background_full_learning.sh
+++ b/examples/ops/cutover_then_background_full_learning.sh
@@ -2,7 +2,8 @@
 set -euo pipefail
 
 STATE="${STATE:-$HOME/.openclawbrain/main/state.json}"
-SESSIONS_DIR="${SESSIONS_DIR:-$HOME/.openclaw/sessions}"
+# For OpenClaw, sessions live under: ~/.openclaw/agents/<agent>/sessions
+SESSIONS_DIR="${SESSIONS_DIR:-$HOME/.openclaw/agents/main/sessions}"
 REPLAY_WORKERS="${REPLAY_WORKERS:-4}"
 WORKERS="${WORKERS:-4}"
 PROGRESS_EVERY="${PROGRESS_EVERY:-2000}"

--- a/examples/ops/cutover_then_background_full_learning.sh
+++ b/examples/ops/cutover_then_background_full_learning.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+STATE="${STATE:-$HOME/.openclawbrain/main/state.json}"
+SESSIONS_DIR="${SESSIONS_DIR:-$HOME/.openclaw/sessions}"
+REPLAY_WORKERS="${REPLAY_WORKERS:-4}"
+WORKERS="${WORKERS:-4}"
+PROGRESS_EVERY="${PROGRESS_EVERY:-2000}"
+CHECKPOINT_EVERY_SECONDS="${CHECKPOINT_EVERY_SECONDS:-60}"
+CHECKPOINT_EVERY="${CHECKPOINT_EVERY:-50}"
+PERSIST_STATE_EVERY_SECONDS="${PERSIST_STATE_EVERY_SECONDS:-300}"
+
+usage() {
+  cat <<'EOF'
+Usage: cutover_then_background_full_learning.sh [options]
+
+Options:
+  --state PATH
+  --sessions-dir PATH
+  --replay-workers N
+  --workers N
+  --progress-every N
+  --checkpoint-every-seconds N
+  --checkpoint-every N
+  --persist-state-every-seconds N
+  -h, --help
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --state) STATE="$2"; shift 2 ;;
+    --sessions-dir) SESSIONS_DIR="$2"; shift 2 ;;
+    --replay-workers) REPLAY_WORKERS="$2"; shift 2 ;;
+    --workers) WORKERS="$2"; shift 2 ;;
+    --progress-every) PROGRESS_EVERY="$2"; shift 2 ;;
+    --checkpoint-every-seconds) CHECKPOINT_EVERY_SECONDS="$2"; shift 2 ;;
+    --checkpoint-every) CHECKPOINT_EVERY="$2"; shift 2 ;;
+    --persist-state-every-seconds) PERSIST_STATE_EVERY_SECONDS="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; usage; exit 2 ;;
+  esac
+done
+
+if [[ ! -f "$STATE" ]]; then
+  echo "state file not found: $STATE" >&2
+  exit 1
+fi
+if [[ ! -d "$SESSIONS_DIR" ]]; then
+  echo "sessions directory not found: $SESSIONS_DIR" >&2
+  exit 1
+fi
+
+STATE_DIR="$(dirname "$STATE")"
+CHECKPOINT="${CHECKPOINT:-$STATE_DIR/replay_checkpoint.json}"
+timestamp="$(date '+%Y%m%d-%H%M%S')"
+OUT_LOG="${OUT_LOG:-$STATE_DIR/replay-full-${timestamp}.out.log}"
+ERR_LOG="${ERR_LOG:-$STATE_DIR/replay-full-${timestamp}.err.log}"
+
+echo "1) Fast cutover pass (stop after fast-learning)"
+openclawbrain replay \
+  --state "$STATE" \
+  --sessions "$SESSIONS_DIR" \
+  --fast-learning \
+  --stop-after-fast-learning \
+  --resume \
+  --checkpoint "$CHECKPOINT" \
+  --workers "$WORKERS" \
+  --checkpoint-every-seconds "$CHECKPOINT_EVERY_SECONDS" \
+  --checkpoint-every "$CHECKPOINT_EVERY"
+
+echo "2) Starting background full-learning replay with nohup"
+nohup openclawbrain replay \
+  --state "$STATE" \
+  --sessions "$SESSIONS_DIR" \
+  --full-learning \
+  --resume \
+  --checkpoint "$CHECKPOINT" \
+  --replay-workers "$REPLAY_WORKERS" \
+  --workers "$WORKERS" \
+  --progress-every "$PROGRESS_EVERY" \
+  --checkpoint-every-seconds "$CHECKPOINT_EVERY_SECONDS" \
+  --checkpoint-every "$CHECKPOINT_EVERY" \
+  --persist-state-every-seconds "$PERSIST_STATE_EVERY_SECONDS" \
+  >"$OUT_LOG" 2>"$ERR_LOG" < /dev/null &
+
+pid=$!
+
+echo "Background replay started."
+echo "  pid: $pid"
+echo "  state: $STATE"
+echo "  sessions_dir: $SESSIONS_DIR"
+echo "  checkpoint: $CHECKPOINT"
+echo "  stdout_log: $OUT_LOG"
+echo "  stderr_log: $ERR_LOG"

--- a/examples/ops/replay_last_days.sh
+++ b/examples/ops/replay_last_days.sh
@@ -2,7 +2,8 @@
 set -euo pipefail
 
 STATE="${STATE:-$HOME/.openclawbrain/main/state.json}"
-SESSIONS_DIR="${SESSIONS_DIR:-$HOME/.openclaw/sessions}"
+# For OpenClaw, sessions live under: ~/.openclaw/agents/<agent>/sessions
+SESSIONS_DIR="${SESSIONS_DIR:-$HOME/.openclaw/agents/main/sessions}"
 DAYS="${DAYS:-14}"
 REPLAY_WORKERS="${REPLAY_WORKERS:-4}"
 WORKERS="${WORKERS:-4}"

--- a/examples/ops/replay_last_days.sh
+++ b/examples/ops/replay_last_days.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+STATE="${STATE:-$HOME/.openclawbrain/main/state.json}"
+SESSIONS_DIR="${SESSIONS_DIR:-$HOME/.openclaw/sessions}"
+DAYS="${DAYS:-14}"
+REPLAY_WORKERS="${REPLAY_WORKERS:-4}"
+WORKERS="${WORKERS:-4}"
+PROGRESS_EVERY="${PROGRESS_EVERY:-2000}"
+CHECKPOINT_EVERY_SECONDS="${CHECKPOINT_EVERY_SECONDS:-60}"
+CHECKPOINT_EVERY="${CHECKPOINT_EVERY:-50}"
+PERSIST_STATE_EVERY_SECONDS="${PERSIST_STATE_EVERY_SECONDS:-300}"
+
+usage() {
+  cat <<'EOF'
+Usage: replay_last_days.sh [options]
+
+Options:
+  --state PATH
+  --sessions-dir PATH
+  --days N
+  --replay-workers N
+  --workers N
+  --progress-every N
+  --checkpoint-every-seconds N
+  --checkpoint-every N
+  --persist-state-every-seconds N
+  -h, --help
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --state) STATE="$2"; shift 2 ;;
+    --sessions-dir) SESSIONS_DIR="$2"; shift 2 ;;
+    --days) DAYS="$2"; shift 2 ;;
+    --replay-workers) REPLAY_WORKERS="$2"; shift 2 ;;
+    --workers) WORKERS="$2"; shift 2 ;;
+    --progress-every) PROGRESS_EVERY="$2"; shift 2 ;;
+    --checkpoint-every-seconds) CHECKPOINT_EVERY_SECONDS="$2"; shift 2 ;;
+    --checkpoint-every) CHECKPOINT_EVERY="$2"; shift 2 ;;
+    --persist-state-every-seconds) PERSIST_STATE_EVERY_SECONDS="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; usage; exit 2 ;;
+  esac
+done
+
+if [[ ! -f "$STATE" ]]; then
+  echo "state file not found: $STATE" >&2
+  exit 1
+fi
+if [[ ! -d "$SESSIONS_DIR" ]]; then
+  echo "sessions directory not found: $SESSIONS_DIR" >&2
+  exit 1
+fi
+
+CHECKPOINT="${CHECKPOINT:-$(dirname "$STATE")/replay_checkpoint.json}"
+
+session_files=()
+while IFS= read -r -d '' file; do
+  session_files+=("$file")
+done < <(
+  find "$SESSIONS_DIR" -type f \
+    \( -name '*.jsonl' -o -name '*.jsonl.reset.*' -o -name '*.jsonl.deleted.*' \) \
+    -mtime "-$DAYS" -print0 | sort -z
+)
+
+if [[ "${#session_files[@]}" -eq 0 ]]; then
+  echo "no session files found in the last $DAYS day(s) under: $SESSIONS_DIR" >&2
+  exit 1
+fi
+
+arg_max="$(getconf ARG_MAX 2>/dev/null || echo 262144)"
+arg_bytes=0
+for file in "${session_files[@]}"; do
+  arg_bytes=$((arg_bytes + ${#file} + 1))
+done
+
+use_sessions_dir=0
+if [[ "${#session_files[@]}" -gt 5000 || "$arg_bytes" -gt $((arg_max / 2)) ]]; then
+  use_sessions_dir=1
+  echo "warning: too many session paths for a safe argv payload (${#session_files[@]} files, ~${arg_bytes} bytes)." >&2
+  echo "warning: falling back to --sessions $SESSIONS_DIR (replay may include files older than --days)." >&2
+fi
+
+cmd=(
+  openclawbrain replay
+  --state "$STATE"
+  --sessions
+)
+if [[ "$use_sessions_dir" -eq 1 ]]; then
+  cmd+=("$SESSIONS_DIR")
+else
+  cmd+=("${session_files[@]}")
+fi
+cmd+=(
+  --full-learning
+  --resume
+  --checkpoint "$CHECKPOINT"
+  --replay-workers "$REPLAY_WORKERS"
+  --workers "$WORKERS"
+  --progress-every "$PROGRESS_EVERY"
+  --checkpoint-every-seconds "$CHECKPOINT_EVERY_SECONDS"
+  --checkpoint-every "$CHECKPOINT_EVERY"
+  --persist-state-every-seconds "$PERSIST_STATE_EVERY_SECONDS"
+)
+
+echo "Running replay:"
+echo "  state: $STATE"
+echo "  sessions_dir: $SESSIONS_DIR"
+echo "  days: $DAYS"
+echo "  selected_files: ${#session_files[@]}"
+echo "  checkpoint: $CHECKPOINT"
+
+exec "${cmd[@]}"


### PR DESCRIPTION
## Summary
- Add `docs/ops-recipes.md` with practical runbooks for:
  - fast cutover (`--stop-after-fast-learning`)
  - parallel replay v0 (`--replay-workers`, merge batches)
  - prompt caching (`query_brain.py --format prompt` as a late appendix)
  - media memory (ingest allowlisted `toolResult` transcripts/OCR)
- Add shell helpers:
  - `examples/ops/replay_last_days.sh` (bounded replay window over recently modified session files)
  - `examples/ops/cutover_then_background_full_learning.sh` (cut over quickly, then run full replay via `nohup`)
- Update `examples/ops/README.md` and `docs/openclaw-integration.md` to link to the above.

## Validation
- `python3 -m pytest -q` (317 passed)
