### PR TITLE
docs: add canonical principal operator guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 
 OpenClawBrain is designed to be the memory layer for **OpenClaw agents**.
 
+- Canonical operator runbook: **[docs/operator-guide.md](docs/operator-guide.md)**
 - Guide: **[docs/openclaw-integration.md](docs/openclaw-integration.md)**
 
 Quickstart (OpenClaw users):

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -1,0 +1,105 @@
+# OpenClawBrain Principal Operator Guide
+
+## 1) What OpenClawBrain is
+OpenClawBrain is the long-term memory layer for OpenClaw agents: it builds a learned graph from your workspace (`~/.openclaw/workspace`) plus session feedback (`~/.openclaw/agents/<agent>/sessions`), then serves fast query/learn operations from a persistent daemon state file (`~/.openclawbrain/<agent>/state.json`).
+
+## 2) Turn brain ON
+Canonical run command (this repo has no `openclawbrain serve` subcommand):
+
+```bash
+python3 -m openclawbrain.socket_server --state ~/.openclawbrain/main/state.json
+```
+
+What `socket_server` does:
+- Starts the long-lived `openclawbrain daemon` worker.
+- Exposes a Unix socket at `~/.openclawbrain/main/daemon.sock` (for agent `main`).
+- Keeps the daemon hot in memory and restarts it if needed.
+
+## 3) Confirm it's ON
+
+```bash
+openclawbrain status --state ~/.openclawbrain/main/state.json
+ls -l ~/.openclawbrain/main/daemon.sock
+```
+
+Healthy signal:
+- `status` shows `Daemon: running ~/.openclawbrain/main/daemon.sock`
+- `daemon.sock` exists as a Unix socket (`-S` / `srw...`).
+
+## 4) Safe rebuild paths
+
+### quick cutover
+Use when you need improvements now and can defer full replay/harvest.
+
+```bash
+openclawbrain replay \
+  --state ~/.openclawbrain/main/state.json \
+  --sessions ~/.openclaw/agents/main/sessions \
+  --fast-learning \
+  --stop-after-fast-learning \
+  --resume \
+  --checkpoint ~/.openclawbrain/main/replay_checkpoint.json
+```
+
+Then keep serving from the daemon state.
+
+### no-drama rebuild_then_cutover
+Use when you need single-writer safety during rebuild and minimal cutover downtime.
+
+```bash
+examples/ops/rebuild_then_cutover.sh main ~/.openclaw/workspace \
+  ~/.openclaw/agents/main/sessions
+```
+
+This rebuilds into a fresh directory, verifies it, stops daemon briefly at cutover, swaps dirs atomically, then restarts.
+
+### full-learning guidance + when to schedule it
+Use full-learning (`--full-learning`) off-peak (nightly/low traffic, and after large session growth or major workspace changes).  
+Single-writer rule still applies: either run full-learning on a NEW state before cutover, or stop daemon writes before replaying LIVE.
+
+## 5) Checkpoints & resume
+Default checkpoint path is next to state: `~/.openclawbrain/main/replay_checkpoint.json`.
+
+Inspect:
+
+```bash
+cat ~/.openclawbrain/main/replay_checkpoint.json
+# or:
+jq . ~/.openclawbrain/main/replay_checkpoint.json
+```
+
+Flag meanings:
+- `--checkpoint <path>`: checkpoint file location.
+- `--resume`: continue from saved per-session line offsets.
+- `--ignore-checkpoint`: start from scratch even if checkpoint exists.
+- `--checkpoint-every-seconds N`: periodic time-based checkpointing.
+- `--checkpoint-every N`: checkpoint every N replay windows/merge batches.
+- `--stop-after-fast-learning`: end after fast-learning phase (for quick cutover).
+
+## 6) Progress: expected output by phase
+- Fast-learning only: ends with `Completed fast-learning; stopped before replay/harvest.`
+- Replay phase: stderr shows `Loaded <N> interactions from session files`; with `--progress-every`, shows `[replay] <done>/<total> (<pct>%)`.
+- Replay completion: `Replayed <n>/<total> queries, <m> cross-file edges created`
+- Full-learning completion (`--full-learning`): final line includes harvest summary, e.g. `harvest: tasks=<k>, damped_edges=<x>`.
+
+## 7) Concurrency rules (single writer)
+Only one process should write a given `state.json` at a time.
+
+Writers include:
+- daemon learning/injection flows
+- `openclawbrain replay`
+- maintenance/harvest operations that persist state
+
+If violated, writes can clobber each other (lost updates, split/corrupted operational state, stale checkpoints).  
+Use rebuild-then-cutover for safe parallel operations.
+
+## 8) Troubleshooting
+
+| Symptom | Likely cause | Commands |
+|---|---|---|
+| `status` says `Daemon: not running` | socket server not started, crashed, or wrong state path | `python3 -m openclawbrain.socket_server --state ~/.openclawbrain/main/state.json` then `openclawbrain status --state ~/.openclawbrain/main/state.json` |
+| `daemon.sock` missing | server never started or wrong agent/state directory | `ls -la ~/.openclawbrain/main` and restart socket server with the same `--state` |
+| Replay refuses/unsafe on LIVE | active daemon socket detected; single-writer guard | stop daemon first, or run `examples/ops/rebuild_then_cutover.sh main ~/.openclaw/workspace ~/.openclaw/agents/main/sessions` |
+| Replay restarts from old work | checkpoint not used, wrong path, or intentionally ignored | run with `--resume --checkpoint ~/.openclawbrain/main/replay_checkpoint.json`; inspect file with `jq . ~/.openclawbrain/main/replay_checkpoint.json` |
+| `LLM required for fast-learning` | no OpenAI client/key configured for fast-learning mining | set `OPENAI_API_KEY` or run `--edges-only` replay path |
+| CLI says invalid sessions path | wrong sessions directory/file path | `ls -la ~/.openclaw/agents/main/sessions` and pass existing dir/files to `--sessions` |

--- a/docs/ops-recipes.md
+++ b/docs/ops-recipes.md
@@ -2,6 +2,8 @@
 
 Practical operator runbooks for cutovers and large replays.
 
+Canonical day-0/day-2 runbook: **[docs/operator-guide.md](operator-guide.md)**
+
 **OpenClaw path note:** OpenClaw agent session logs typically live at `~/.openclaw/agents/<agent>/sessions` (e.g., `~/.openclaw/agents/main/sessions`). You can pass that directory directly via `--sessions <dir>`.
 
 ## Cutover fast
@@ -13,7 +15,7 @@ Use this when you need improved retrieval quickly and can defer full replay/harv
 ```bash
 openclawbrain replay \
   --state ~/.openclawbrain/main/state.json \
-  --sessions /path/to/sessions \
+  --sessions ~/.openclaw/agents/main/sessions \
   --fast-learning \
   --stop-after-fast-learning \
   --resume \
@@ -33,7 +35,7 @@ python3 -m openclawbrain.socket_server --state ~/.openclawbrain/main/state.json
 ```bash
 openclawbrain replay \
   --state ~/.openclawbrain/main/state.json \
-  --sessions /path/to/sessions \
+  --sessions ~/.openclaw/agents/main/sessions \
   --full-learning \
   --resume \
   --checkpoint ~/.openclawbrain/main/replay_checkpoint.json
@@ -83,7 +85,7 @@ For large histories, run replay in parallel workers and checkpoint frequently:
 ```bash
 openclawbrain replay \
   --state ~/.openclawbrain/main/state.json \
-  --sessions /path/to/sessions \
+  --sessions ~/.openclaw/agents/main/sessions \
   --full-learning \
   --replay-workers 4 \
   --workers 4 \
@@ -124,7 +126,7 @@ OpenClaw session logs often store uploads as `[media attached: ...]` stubs. Thos
 ```bash
 openclawbrain replay \
   --state ~/.openclawbrain/main/state.json \
-  --sessions /path/to/sessions \
+  --sessions ~/.openclaw/agents/main/sessions \
   --include-tool-results \
   --tool-result-allowlist image,openai-whisper,openai-whisper-api,openai-whisper-local,summarize \
   --tool-result-max-chars 20000


### PR DESCRIPTION
## Summary
- add canonical principal operator runbook at `docs/operator-guide.md`
- add prominent links to the new guide in `README.md` and `docs/ops-recipes.md`
- align ops recipe examples to OpenClaw paths (`~/.openclaw/workspace`, `~/.openclaw/agents/<agent>/sessions`)

Closes #25
