### PR TITLE
cli: add openclawbrain serve command for OpenClaw operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+### Operator CLI: canonical brain-on command (issues #24, #25)
+- Added `openclawbrain serve --state <path> [--socket-path <path>] [--foreground]` as the first-class foreground socket service command for OpenClaw operators.
+- Startup now prints an operator banner with socket path, state path, status-check command, and `Ctrl-C` shutdown guidance.
+- Updated operator docs to recommend `openclawbrain serve` as the canonical production startup path.
+
 ### Replay ops hardening + simple parallel replay v0 (issue #19)
 - `openclawbrain replay` adds:
   - `--progress-every N` (periodic progress, JSONL events when `--json` is enabled)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Quickstart (OpenClaw users):
 ```bash
 pip install openclawbrain
 openclawbrain init --workspace ~/.openclaw/workspace --output ~/.openclawbrain/main
-python3 -m openclawbrain.socket_server --state ~/.openclawbrain/main/state.json
+openclawbrain serve --state ~/.openclawbrain/main/state.json
 ```
 
 Production Deployment (socket):
@@ -27,7 +27,7 @@ Production Deployment (socket):
 Use LaunchAgent/systemd to keep the socket server running:
 
 ```bash
-python3 -m openclawbrain.socket_server --state ~/.openclawbrain/main/state.json
+openclawbrain serve --state ~/.openclawbrain/main/state.json
 ```
 
 macOS (`~/Library/LaunchAgents/com.openclawbrain.daemon.plist`):
@@ -35,9 +35,9 @@ macOS (`~/Library/LaunchAgents/com.openclawbrain.daemon.plist`):
 ```xml
 <key>ProgramArguments</key>
 <array>
-  <string>/usr/bin/python3</string>
-  <string>-m</string>
-  <string>openclawbrain.socket_server</string>
+  <string>/usr/bin/env</string>
+  <string>openclawbrain</string>
+  <string>serve</string>
   <string>--state</string>
   <string>/Users/YOU/.openclawbrain/main/state.json</string>
 </array>
@@ -47,7 +47,7 @@ Linux (`/etc/systemd/system/openclawbrain-daemon.service`):
 
 ```ini
 [Service]
-ExecStart=/usr/bin/python3 -m openclawbrain.socket_server --state /home/YOUR_USER/.openclawbrain/main/state.json
+ExecStart=/usr/bin/env openclawbrain serve --state /home/YOUR_USER/.openclawbrain/main/state.json
 ```
 
 ```bash
@@ -348,6 +348,7 @@ See `examples/openai_embedder/` for a complete example.
 | `harvest` | Apply slow-learning pass from `learning_events.jsonl` to current graph |
 | `health` | Show graph health metrics |
 | `status` | `openclawbrain status --state brain/state.json [--json]` returns a one-command health overview: version, nodes, edges, tier distribution, daemon status, embedder, decay half-life |
+| `serve` | `openclawbrain serve --state brain/state.json [--socket-path path] [--foreground]` starts the Unix socket service in the foreground |
 | `journal` | Show event journal |
 | `doctor` | Run diagnostic checks |
 | `info` | Show brain info (nodes, edges, embedder) |

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -237,13 +237,13 @@ Reference: `examples/ops/callbacks.py`
 Run the production service as a Unix socket wrapper around the NDJSON daemon:
 
 ```bash
-python3 -m openclawbrain.socket_server --state ~/.openclawbrain/main/state.json
+openclawbrain serve --state ~/.openclawbrain/main/state.json
 ```
 
 The socket server creates and manages:
 
 - `~/.openclawbrain/<agent>/daemon.sock` (for example: `~/.openclawbrain/main/daemon.sock`)  
-  (created automatically by `socket_server`)
+  (created automatically by `openclawbrain serve`)
 
 Test it with:
 
@@ -265,9 +265,8 @@ Create `~/Library/LaunchAgents/com.openclawbrain.daemon.plist`:
   <key>ProgramArguments</key>
   <array>
     <string>/usr/bin/env</string>
-    <string>python3</string>
-    <string>-m</string>
-    <string>openclawbrain.socket_server</string>
+    <string>openclawbrain</string>
+    <string>serve</string>
     <string>--state</string>
     <string>/Users/YOU/.openclawbrain/main/state.json</string>
   </array>
@@ -303,7 +302,7 @@ After=network-online.target
 Type=simple
 User=YOUR_USER
 WorkingDirectory=/home/YOUR_USER
-ExecStart=/usr/bin/python3 -m openclawbrain.socket_server --state /home/YOUR_USER/.openclawbrain/main/state.json
+ExecStart=/usr/bin/env openclawbrain serve --state /home/YOUR_USER/.openclawbrain/main/state.json
 Restart=always
 RestartSec=1
 


### PR DESCRIPTION
## Summary
- add first-class `openclawbrain serve` subcommand in `openclawbrain/cli.py`
- run socket server in foreground by default via in-process call to `openclawbrain.socket_server.main`
- print startup operator banner to stderr with socket path, state path, status command, and Ctrl-C stop hint
- update OpenClaw integration docs (`README.md`, `docs/openclaw-integration.md`, `docs/setup-guide.md`) to recommend `openclawbrain serve` as canonical brain-on command
- add lightweight CLI tests for `serve` parse/delegation and include `serve --help` coverage
- add operator-facing changelog entry

## Validation
- `python3 -m openclawbrain serve --help`
- `python3 -m pytest tests/test_cli.py`

Closes #24
Closes #25
