### PR TITLE
Replay checkpoint UX overhaul with show-checkpoint and startup banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@
 - Startup now prints an operator banner with socket path, state path, status-check command, and `Ctrl-C` shutdown guidance.
 - Updated operator docs to recommend `openclawbrain serve` as the canonical production startup path.
 
+### Replay checkpoint UX overhaul (issues #24, #25)
+- Added `openclawbrain replay --show-checkpoint` to print checkpoint status without opening JSON files.
+  - Human output includes checkpoint path, schema version, fast-learning progress/status, replay progress/merge batches, and whether resume would take effect.
+  - `--json` emits stable schema payloads with `type: checkpoint_status`.
+- `openclawbrain replay` now prints a startup banner in text mode with checkpoint path, `resume`, `ignore_checkpoint`, and planned phases.
+- Backward compatibility: if `fast_learning.sessions` or `replay.sessions` is missing, replay falls back to legacy top-level `sessions` offsets and emits warnings.
+- Added checkpoint fixture-based tests for legacy/new schemas, replay/fast-learning legacy fallback warnings, and startup/checkpoint status output.
+- Updated operator docs (`docs/ops-recipes.md`, `docs/setup-guide.md`) with `--show-checkpoint` and explicit resume semantics.
+
 ### Replay ops hardening + simple parallel replay v0 (issue #19)
 - `openclawbrain replay` adds:
   - `--progress-every N` (periodic progress, JSONL events when `--json` is enabled)

--- a/docs/ops-recipes.md
+++ b/docs/ops-recipes.md
@@ -100,6 +100,30 @@ Notes:
 - `--replay-workers` controls edge-replay parallelism.
 - `merge_batches` in replay output indicates how many merge windows were applied.
 - Use both `--checkpoint-every-seconds` and `--checkpoint-every` for long runs so restarts resume from recent progress.
+- Replay startup now prints a banner (unless `--json`) with checkpoint path, `resume`, `ignore_checkpoint`, and planned phases.
+
+Inspect checkpoint progress without opening JSON:
+
+```bash
+openclawbrain replay \
+  --state ~/.openclawbrain/main/state.json \
+  --show-checkpoint \
+  --resume
+```
+
+Machine-readable checkpoint status:
+
+```bash
+openclawbrain replay \
+  --state ~/.openclawbrain/main/state.json \
+  --show-checkpoint \
+  --resume \
+  --json
+```
+
+Resume semantics:
+- Resume takes effect only when `--resume` is set and `--ignore-checkpoint` is not set.
+- If phase-scoped offsets are missing, replay falls back to legacy top-level `sessions` offsets and emits a warning.
 
 Use `examples/ops/replay_last_days.sh` when you want a bounded replay window.
 

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -54,6 +54,18 @@ You can run this repeatedly; dedupe is by `(type, sha256(content), session_point
 
 For ongoing operation after startup, use `--ignore-checkpoint` only when you intentionally want to replay older chunks that were already ingested.
 
+Checkpoint visibility:
+
+```bash
+openclawbrain replay --state ./brain/state.json --show-checkpoint --resume
+openclawbrain replay --state ./brain/state.json --show-checkpoint --resume --json
+```
+
+Resume semantics:
+- `--resume` enables checkpoint offsets.
+- `--ignore-checkpoint` disables resume even when a checkpoint exists.
+- If a checkpoint only has legacy top-level `sessions` offsets, replay still resumes from them and prints a warning.
+
 ## Step 2: Wire up the fast loop (per-query)
 
 Minimum per-query pattern: **query → log → learn**.  

--- a/tests/fixtures/checkpoints/legacy_schema.json
+++ b/tests/fixtures/checkpoints/legacy_schema.json
@@ -1,0 +1,6 @@
+{
+  "version": 1,
+  "sessions": {
+    "/tmp/sessions-a.jsonl": 2
+  }
+}

--- a/tests/fixtures/checkpoints/new_schema.json
+++ b/tests/fixtures/checkpoints/new_schema.json
@@ -1,0 +1,21 @@
+{
+  "version": 1,
+  "fast_learning": {
+    "sessions": {
+      "/tmp/sessions-a.jsonl": 12
+    },
+    "status": "running",
+    "windows_processed": 4,
+    "windows_total": 10,
+    "updated_at": 1700000100.0
+  },
+  "replay": {
+    "sessions": {
+      "/tmp/sessions-a.jsonl": 14
+    },
+    "queries_processed": 8,
+    "queries_total": 16,
+    "merge_batches": 2,
+    "updated_at": 1700000200.0
+  }
+}


### PR DESCRIPTION
## Summary
- add `openclawbrain replay --show-checkpoint` with human + JSON status output (`type=checkpoint_status`)
- add replay startup banner in text mode showing checkpoint path, resume, ignore_checkpoint, and planned phases
- add legacy checkpoint fallback warnings when phase-scoped offsets are missing (`fast_learning.sessions` / `replay.sessions`)
- keep backward compatibility by falling back to top-level legacy `sessions` offsets for fast-learning and replay resume
- add replay checkpoint fixtures (new schema + legacy schema) and tests for new status output + fallback behavior
- update docs and changelog for new replay checkpoint UX and resume semantics

## Testing
- `PYTHONPATH=. pytest -q`

Closes #24
Closes #25
