### PR TITLE
Improve replay CLI ergonomics with aliases, quiet mode, and clearer worker semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,20 @@
 - Added tests for CLI JSON progress emission during fast-learning.
 - Updated `docs/ops-recipes.md` with a fast-learning progress output example.
 
+### Replay CLI ergonomics and clearer naming (issue #25)
+- Added replay flag aliases:
+  - `--extract-learning-events` as an alias for `--fast-learning`
+  - `--full-pipeline` as an alias for `--full-learning`
+- Clarified replay help text:
+  - fast-learning is LLM-bound and can be the slowest stage
+  - `--workers` controls fast-learning LLM workers
+  - `--replay-workers` controls edge replay workers
+  - `--replay-workers > 1` uses a deterministic shard/merge approximation instead of strict sequential replay behavior
+- Added `--quiet` to suppress replay banners/progress output.
+- Replay now emits heartbeat progress every 30 seconds by default (unless `--quiet`); `--progress-every` still controls count-based progress events.
+- Updated docs and operator examples to mention the new aliases while keeping existing flags.
+- Added CLI tests for replay alias parsing and alias execution paths.
+
 ### Replay ops hardening + simple parallel replay v0 (issue #19)
 - `openclawbrain replay` adds:
   - `--progress-every N` (periodic progress, JSONL events when `--json` is enabled)

--- a/docs/FULL_REBUILD.md
+++ b/docs/FULL_REBUILD.md
@@ -107,6 +107,7 @@ openclawbrain replay \
   --full-learning \
   --json
 ```
+`--full-pipeline` is an alias for `--full-learning` (and `--extract-learning-events` aliases `--fast-learning` when you only want extraction/injection).
 
 **What it does:**
 

--- a/docs/openclaw-integration.md
+++ b/docs/openclaw-integration.md
@@ -347,7 +347,7 @@ OpenClawBrain ships an OpenClaw adapter that logs fired IDs per chat.
 
 That’s the ergonomic way to do “same-turn correction” inside OpenClaw.
 
-For full-history rebuilds, replay your sessions (full-learning is the default):
+For full-history rebuilds, replay your sessions (full-learning is the default; explicit alias pair: `--full-learning` / `--full-pipeline`):
 
 ```bash
 openclawbrain replay \
@@ -374,7 +374,7 @@ openclawbrain replay \
 This does:
 
 - replay query edges from session history (with decay enabled by default)
-- LLM transcript mining into `learning::` nodes (`--fast-learning` behavior)
+- LLM transcript mining into `learning::` nodes (`--fast-learning` / `--extract-learning-events` behavior)
 - slow-learning maintenance pass (`harvest`) with decay/scale/split/merge/prune/connect
 
 For cheap edge-only replay (no LLM, no harvest), use `--edges-only`:

--- a/docs/ops-recipes.md
+++ b/docs/ops-recipes.md
@@ -22,6 +22,7 @@ openclawbrain replay \
   --resume \
   --checkpoint ~/.openclawbrain/main/replay_checkpoint.json
 ```
+`--extract-learning-events` is an alias for `--fast-learning`.
 
 Example progress output during fast-learning:
 
@@ -47,6 +48,7 @@ openclawbrain replay \
   --resume \
   --checkpoint ~/.openclawbrain/main/replay_checkpoint.json
 ```
+`--full-pipeline` is an alias for `--full-learning`.
 
 `examples/ops/cutover_then_background_full_learning.sh` automates this sequence.
 
@@ -80,7 +82,7 @@ examples/ops/rebuild_then_cutover.sh main ~/.openclaw/workspace \
 
 Notes:
 - `replay --sessions` accepts one or more paths, and each path may be a sessions directory or an individual `.jsonl` file.
-- The helper script uses fast-learning (`--fast-learning --stop-after-fast-learning`) for fast, safe cutover.
+- The helper script uses fast-learning (`--fast-learning --stop-after-fast-learning`; alias: `--extract-learning-events`) for fast, safe cutover.
 - For full-learning, either run it into NEW before cutover, or rebuild again into a new directory and cut over again. Avoid replaying directly against LIVE while the daemon is running.
 - Tradeoff: events learned while rebuild is running are not in the NEW snapshot unless you pause learning traffic or run a small delta replay before/after cutover.
 - On systems without `launchctl`, the script skips stop/start and tells you what to do manually.
@@ -105,6 +107,8 @@ openclawbrain replay \
 
 Notes:
 - `--replay-workers` controls edge-replay parallelism.
+- `--workers` controls fast-learning LLM extraction workers.
+- `--replay-workers > 1` uses a deterministic shard/merge approximation rather than strict sequential replay semantics.
 - `merge_batches` in replay output indicates how many merge windows were applied.
 - Use both `--checkpoint-every-seconds` and `--checkpoint-every` for long runs so restarts resume from recent progress.
 - Replay startup now prints a banner (unless `--json`) with checkpoint path, `resume`, `ignore_checkpoint`, and planned phases.

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -24,7 +24,7 @@ After init, replay your existing sessions to seed graph edges and extract learni
 openclawbrain replay --state ./brain/state.json --sessions ./sessions/
 ```
 
-This extracts durable correction/teaching nodes and runs maintenance in one command.
+This extracts durable correction/teaching nodes and runs maintenance in one command (`--full-learning`, alias: `--full-pipeline`).
 
 For cheap edge-only replay (no LLM, no harvest):
 
@@ -46,6 +46,7 @@ openclawbrain replay \
   --checkpoint ./brain/replay_checkpoint.json \
   --json
 ```
+`--extract-learning-events` is an alias for `--fast-learning`.
 
 `fast-learning` stores extracted events in an append-only log:
 - `./brain/learning_events.jsonl`
@@ -125,7 +126,7 @@ openclawbrain replay --state ./brain/state.json --sessions ./sessions/ --edges-o
 
 ## Performance knobs
 
-- `--workers`: parallelize LLM window extraction (higher = faster, bounded by rate limits)
+- `--workers`: LLM workers for fast-learning window extraction (higher = faster, bounded by rate limits)
 - `--window-radius`: context breadth around likely feedback turns
 - `--max-windows`: max feedback windows sampled per file/session
 - `--hard-max-turns`: hard cap total turns considered to keep extraction bounded

--- a/examples/ops/README.md
+++ b/examples/ops/README.md
@@ -8,6 +8,7 @@
 - `replay_last_days.sh`: full-learning replay over session files modified in the last N days, with safe checkpoint defaults for long runs
 - `cutover_then_background_full_learning.sh`: fast-learning cutover first, then background full-learning replay via `nohup`
 - `rebuild_then_cutover.sh`: rebuild into a new brain directory, verify, then atomic cutover with launchd-aware stop/start
+- Replay aliases: `--extract-learning-events` = `--fast-learning`, `--full-pipeline` = `--full-learning`
 
 By default, examples use OpenAI callbacks as the production path:
 

--- a/examples/ops/cutover_then_background_full_learning.sh
+++ b/examples/ops/cutover_then_background_full_learning.sh
@@ -18,8 +18,8 @@ Usage: cutover_then_background_full_learning.sh [options]
 Options:
   --state PATH
   --sessions-dir PATH
-  --replay-workers N
-  --workers N
+  --replay-workers N    # edge replay workers
+  --workers N           # fast-learning LLM workers
   --progress-every N
   --checkpoint-every-seconds N
   --checkpoint-every N
@@ -70,6 +70,7 @@ OUT_LOG="${OUT_LOG:-$STATE_DIR/replay-full-${timestamp}.out.log}"
 ERR_LOG="${ERR_LOG:-$STATE_DIR/replay-full-${timestamp}.err.log}"
 
 echo "1) Fast cutover pass (stop after fast-learning)"
+echo "   (alias available: --extract-learning-events)"
 openclawbrain replay \
   --state "$STATE" \
   --sessions "$SESSIONS_DIR" \
@@ -82,6 +83,7 @@ openclawbrain replay \
   --checkpoint-every "$CHECKPOINT_EVERY"
 
 echo "2) Starting background full-learning replay with nohup"
+echo "   (alias available: --full-pipeline)"
 nohup openclawbrain replay \
   --state "$STATE" \
   --sessions "$SESSIONS_DIR" \

--- a/examples/ops/rebuild_then_cutover.sh
+++ b/examples/ops/rebuild_then_cutover.sh
@@ -65,6 +65,7 @@ openclawbrain init --workspace "$WORKSPACE_DIR" --output "$NEW"
 
 echo
 echo "== 2) Fast-learning replay into NEW state =="
+echo "(alias available: --extract-learning-events)"
 openclawbrain replay \
   --state "$NEW_STATE" \
   --sessions "${SESSIONS[@]}" \
@@ -80,7 +81,7 @@ cat <<EOF
 # openclawbrain replay \\
 #   --state "$NEW_STATE" \\
 #   --sessions ${SESSIONS[*]} \\
-#   --full-learning \\
+#   --full-learning \\  # alias: --full-pipeline
 #   --resume \\
 #   --checkpoint "$CHECKPOINT"
 #

--- a/examples/ops/replay_last_days.sh
+++ b/examples/ops/replay_last_days.sh
@@ -20,8 +20,8 @@ Options:
   --state PATH
   --sessions-dir PATH
   --days N
-  --replay-workers N
-  --workers N
+  --replay-workers N    # edge replay workers
+  --workers N           # fast-learning LLM workers
   --progress-every N
   --checkpoint-every-seconds N
   --checkpoint-every N
@@ -95,7 +95,7 @@ else
   cmd+=("${session_files[@]}")
 fi
 cmd+=(
-  --full-learning
+  --full-learning  # alias: --full-pipeline
   --resume
   --checkpoint "$CHECKPOINT"
   --replay-workers "$REPLAY_WORKERS"


### PR DESCRIPTION
## Summary
- add replay flag aliases without breaking existing flags:
  - `--extract-learning-events` as alias for `--fast-learning`
  - `--full-pipeline` as alias for `--full-learning`
- improve replay help text to clarify:
  - fast-learning is LLM-bound and can be the slowest step
  - `--workers` controls fast-learning LLM workers
  - `--replay-workers` controls edge replay workers and `>1` uses deterministic shard/merge approximation
- add `--quiet` to suppress replay banners/progress output
- add default non-JSON replay heartbeat progress every 30s (unless `--quiet`)
- update docs/examples to mention new aliases while retaining old flags
- update `CHANGELOG.md`
- add CLI parsing/behavior tests for aliases and quiet mode

## Testing
- `python3 -m pytest -q tests/test_cli.py`

Closes #25