### PR TITLE
Add fast-learning progress reporting in replay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@
 - Added checkpoint fixture-based tests for legacy/new schemas, replay/fast-learning legacy fallback warnings, and startup/checkpoint status output.
 - Updated operator docs (`docs/ops-recipes.md`, `docs/setup-guide.md`) with `--show-checkpoint` and explicit resume semantics.
 
+### Fast-learning progress visibility (issues #24, #25)
+- `run_fast_learning()` now supports an optional `on_progress` callback with payloads shaped like:
+  - `{"type":"progress","phase":"fast_learning","completed","total","elapsed_seconds","rate","eta_seconds","updated_at"}`
+- `openclawbrain replay` now forwards fast-learning progress through the existing CLI progress emitter, including JSON progress lines (`type=progress`) and text-mode elapsed/rate/ETA details.
+- Added tests for CLI JSON progress emission during fast-learning.
+- Updated `docs/ops-recipes.md` with a fast-learning progress output example.
+
 ### Replay ops hardening + simple parallel replay v0 (issue #19)
 - `openclawbrain replay` adds:
   - `--progress-every N` (periodic progress, JSONL events when `--json` is enabled)

--- a/docs/ops-recipes.md
+++ b/docs/ops-recipes.md
@@ -18,8 +18,15 @@ openclawbrain replay \
   --sessions ~/.openclaw/agents/main/sessions \
   --fast-learning \
   --stop-after-fast-learning \
+  --progress-every 25 \
   --resume \
   --checkpoint ~/.openclawbrain/main/replay_checkpoint.json
+```
+
+Example progress output during fast-learning:
+
+```text
+[fast_learning] 250/1800 (13.9%) elapsed=41.7s rate=6.00/s eta=258.3s
 ```
 
 2. Start the daemon so serving traffic uses the latest state:


### PR DESCRIPTION
## Summary
- add optional `on_progress` callback support to `run_fast_learning` with low-overhead periodic emits
- wire replay CLI to forward fast-learning progress via existing `_emit_progress`
- include elapsed/rate/eta fields in fast-learning progress payloads and text output
- document fast-learning progress output in ops recipes
- add unit + CLI tests for fast-learning progress events
- update changelog

## Issues
Closes #24
Closes #25

## Validation
- `python3 -m pytest -q tests/test_full_learning.py::test_run_fast_learning_invokes_progress_callback tests/test_cli.py::test_cli_replay_progress_events_jsonl tests/test_cli.py::test_cli_replay_fast_learning_progress_events_jsonl`
- `python3 -m pytest -q tests/test_cli.py::test_cli_replay_with_fast_learning_writes_learning_events_and_injects_nodes tests/test_cli.py::test_cli_replay_stop_after_fast_learning`
