### PR TITLE
Include deterministic prompt_context in daemon query responses

### DIFF
--- a/openclawbrain/daemon.py
+++ b/openclawbrain/daemon.py
@@ -249,7 +249,6 @@ def _handle_query(
 
     Includes a deterministic `prompt_context` block suitable for prompt caching.
     """
-    """Handle query requests with embed + traversal timings."""
     query_text = params.get("query")
     if not isinstance(query_text, str) or not query_text.strip():
         raise ValueError("query must be a non-empty string")

--- a/openclawbrain/daemon.py
+++ b/openclawbrain/daemon.py
@@ -25,6 +25,7 @@ from .maintain import run_maintenance
 from .inject import _apply_inhibitory_edges, inject_node
 from .store import load_state, save_state
 from .traverse import TraversalConfig, traverse
+from .prompt_context import build_prompt_context
 
 
 FIRED_LOG_LIMIT_PER_CHAT = 100
@@ -244,12 +245,19 @@ def _handle_query(
     params: dict[str, object],
     state_path: str,
 ) -> dict[str, object]:
+    """Handle query requests with embed + traversal timings.
+
+    Includes a deterministic `prompt_context` block suitable for prompt caching.
+    """
     """Handle query requests with embed + traversal timings."""
     query_text = params.get("query")
     if not isinstance(query_text, str) or not query_text.strip():
         raise ValueError("query must be a non-empty string")
 
     top_k = _parse_int(params.get("top_k"), "top_k", default=4)
+    max_prompt_chars = params.get("max_prompt_context_chars")
+    if not isinstance(max_prompt_chars, int):
+        max_prompt_chars = 20000
 
     total_start = time.perf_counter()
     resolved_embed = embed_fn or HashEmbedder().embed
@@ -283,9 +291,17 @@ def _handle_query(
         metadata={"chat_id": params.get("chat_id")},
     )
 
+    prompt_context = build_prompt_context(
+        graph=graph,
+        node_ids=[str(node_id) for node_id in result.fired],
+        max_chars=max_prompt_chars,
+        include_node_ids=True,
+    )
+
     return {
         "fired_nodes": result.fired,
         "context": result.context,
+        "prompt_context": prompt_context,
         "seeds": [[node_id, score] for node_id, score in seeds],
         "embed_query_ms": _ms(embed_start, embed_stop),
         "traverse_ms": _ms(traverse_start, traverse_stop),

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -130,6 +130,13 @@ def test_daemon_query_returns_fired_nodes(tmp_path: Path) -> None:
         assert result["fired_nodes"]
         assert "a" in result["fired_nodes"]
         assert result["seeds"]
+
+        # Deterministic appendix block for prompt caching.
+        assert "prompt_context" in result
+        assert result["prompt_context"].startswith("[BRAIN_CONTEXT v1]")
+        assert "- node:" in result["prompt_context"]
+        assert "alpha" in result["prompt_context"]
+
         assert isinstance(result["embed_query_ms"], float)
         assert isinstance(result["traverse_ms"], float)
         assert isinstance(result["total_ms"], float)


### PR DESCRIPTION
Why:
- We want prompt-caching savings by using stable [BRAIN_CONTEXT v1] blocks by default in runtime queries.
- Today the socket daemon returns only `context` and `fired_nodes`; operators have to rerun local state formatting to get deterministic prompt_context.

What:
- Add `prompt_context` to daemon `query` method response using `build_prompt_context(...)`.
- Supports optional `max_prompt_context_chars` param (default 20000).

Notes:
- This is additive/backward-compatible for clients reading `context`.
- Helps OpenClaw integration: append `prompt_context` late in prompts to maximize prefix caching.