### PR TITLE
docs: clarity sweep for OpenClaw operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@
 
 **Setup:** [Setup Guide](docs/setup-guide.md)
 
+## Docs
+
+- Operator guide: [docs/operator-guide.md](docs/operator-guide.md)
+- OpenClaw integration: [docs/openclaw-integration.md](docs/openclaw-integration.md)
+- Setup guide: [docs/setup-guide.md](docs/setup-guide.md)
+- GitHub repo: https://github.com/jonathangu/openclawbrain
+- ClawHub skill: https://clawhub.ai/skills/openclawbrain
+
 ## OpenClaw Integration (start here if you run OpenClaw)
 
 OpenClawBrain is designed to be the memory layer for **OpenClaw agents**.
@@ -698,5 +706,6 @@ Three brains run in production on a Mac Mini M4 Pro:
 
 - PyPI: `pip install openclawbrain`
 - GitHub: [jonathangu/openclawbrain](https://github.com/jonathangu/openclawbrain)
-- ClawHub: `clawhub install openclawbrain`
+- ClawHub skill: https://clawhub.ai/skills/openclawbrain
+- ClawHub CLI: `clawhub install openclawbrain`
 - Benchmarks: `python3 benchmarks/run_benchmark.py` (deterministic per commit; timings vary by machine)

--- a/docs/openclaw-integration.md
+++ b/docs/openclaw-integration.md
@@ -2,6 +2,7 @@
 
 OpenClawBrain is built to be the long-term memory layer for **OpenClaw agents**.
 Canonical docs and examples: https://openclawbrain.ai
+Primary operator runbook: [docs/operator-guide.md](operator-guide.md)
 Operator recipes (cutover, parallel replay, prompt caching, media memory): [docs/ops-recipes.md](ops-recipes.md)
 
 If you’re already running OpenClaw, this guide shows the fastest path to:
@@ -354,6 +355,11 @@ openclawbrain replay \
   --state ~/.openclawbrain/main/state.json \
   --sessions /path/to/sessions
 ```
+
+Single-writer reminder:
+- Rebuild/replay and daemon learning are both writers.
+- If lock checks fail on LIVE state, prefer rebuild-then-cutover from [docs/operator-guide.md](operator-guide.md).
+- Expert override: `--force` or `OPENCLAWBRAIN_STATE_LOCK_FORCE=1` (only when no conflicting writer is active).
 
 Media note for OpenClaw logs:
 

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -4,13 +4,13 @@
 OpenClawBrain is the long-term memory layer for OpenClaw agents: it builds a learned graph from your workspace (`~/.openclaw/workspace`) plus session feedback (`~/.openclaw/agents/<agent>/sessions`), then serves fast query/learn operations from a persistent daemon state file (`~/.openclawbrain/<agent>/state.json`).
 
 ## 2) Turn brain ON
-Canonical run command (this repo has no `openclawbrain serve` subcommand):
+Canonical run command:
 
 ```bash
-python3 -m openclawbrain.socket_server --state ~/.openclawbrain/main/state.json
+openclawbrain serve --state ~/.openclawbrain/main/state.json
 ```
 
-What `socket_server` does:
+What `serve` does:
 - Starts the long-lived `openclawbrain daemon` worker.
 - Exposes a Unix socket at `~/.openclawbrain/main/daemon.sock` (for agent `main`).
 - Keeps the daemon hot in memory and restarts it if needed.
@@ -60,11 +60,28 @@ Single-writer rule still applies: either run full-learning on a NEW state before
 ## 5) Checkpoints & resume
 Default checkpoint path is next to state: `~/.openclawbrain/main/replay_checkpoint.json`.
 
-Inspect:
+Inspect checkpoint state (recommended):
 
 ```bash
-cat ~/.openclawbrain/main/replay_checkpoint.json
-# or:
+openclawbrain replay \
+  --state ~/.openclawbrain/main/state.json \
+  --show-checkpoint \
+  --resume
+```
+
+Machine-readable checkpoint status:
+
+```bash
+openclawbrain replay \
+  --state ~/.openclawbrain/main/state.json \
+  --show-checkpoint \
+  --resume \
+  --json
+```
+
+Direct file inspection is still useful for debugging:
+
+```bash
 jq . ~/.openclawbrain/main/replay_checkpoint.json
 ```
 
@@ -77,7 +94,9 @@ Flag meanings:
 - `--stop-after-fast-learning`: end after fast-learning phase (for quick cutover).
 
 ## 6) Progress: expected output by phase
-- Fast-learning only: ends with `Completed fast-learning; stopped before replay/harvest.`
+- Fast-learning prints progress and completes with `Completed fast-learning; stopped before replay/harvest.` when `--stop-after-fast-learning` is set.
+- Replay emits a progress heartbeat every 30 seconds by default; add `--progress-every N` for per-item cadence.
+- Use `--quiet` to suppress replay banners/progress when scripting.
 - Replay phase: stderr shows `Loaded <N> interactions from session files`; with `--progress-every`, shows `[replay] <done>/<total> (<pct>%)`.
 - Replay completion: `Replayed <n>/<total> queries, <m> cross-file edges created`
 - Full-learning completion (`--full-learning`): final line includes harvest summary, e.g. `harvest: tasks=<k>, damped_edges=<x>`.
@@ -91,15 +110,21 @@ Writers include:
 - maintenance/harvest operations that persist state
 
 If violated, writes can clobber each other (lost updates, split/corrupted operational state, stale checkpoints).  
-Use rebuild-then-cutover for safe parallel operations.
+OpenClawBrain enforces this with `state.json.lock` next to your state file.
+
+If a lock is active and you still need to proceed, override only when you are certain there is no conflicting writer:
+- `--force`
+- `OPENCLAWBRAIN_STATE_LOCK_FORCE=1`
+
+Recommended production path: use `examples/ops/rebuild_then_cutover.sh` so rebuild/replay happens on a fresh state and cutover is atomic.
 
 ## 8) Troubleshooting
 
 | Symptom | Likely cause | Commands |
 |---|---|---|
-| `status` says `Daemon: not running` | socket server not started, crashed, or wrong state path | `python3 -m openclawbrain.socket_server --state ~/.openclawbrain/main/state.json` then `openclawbrain status --state ~/.openclawbrain/main/state.json` |
-| `daemon.sock` missing | server never started or wrong agent/state directory | `ls -la ~/.openclawbrain/main` and restart socket server with the same `--state` |
-| Replay refuses/unsafe on LIVE | active daemon socket detected; single-writer guard | stop daemon first, or run `examples/ops/rebuild_then_cutover.sh main ~/.openclaw/workspace ~/.openclaw/agents/main/sessions` |
-| Replay restarts from old work | checkpoint not used, wrong path, or intentionally ignored | run with `--resume --checkpoint ~/.openclawbrain/main/replay_checkpoint.json`; inspect file with `jq . ~/.openclawbrain/main/replay_checkpoint.json` |
+| `status` says `Daemon: not running` | service not started, crashed, or wrong state path | `openclawbrain serve --state ~/.openclawbrain/main/state.json` then `openclawbrain status --state ~/.openclawbrain/main/state.json` |
+| `daemon.sock` missing | service never started or wrong agent/state directory | `ls -la ~/.openclawbrain/main` and restart `openclawbrain serve` with the same `--state` |
+| Replay fails with lock/single-writer message | another process holds `state.json.lock` | stop the other writer, use `examples/ops/rebuild_then_cutover.sh ...`, or expert override with `--force` / `OPENCLAWBRAIN_STATE_LOCK_FORCE=1` |
+| Replay restarts from old work | checkpoint not used, wrong path, or intentionally ignored | run with `--resume --checkpoint ~/.openclawbrain/main/replay_checkpoint.json`; inspect with `openclawbrain replay --state ~/.openclawbrain/main/state.json --show-checkpoint --resume` |
 | `LLM required for fast-learning` | no OpenAI client/key configured for fast-learning mining | set `OPENAI_API_KEY` or run `--edges-only` replay path |
 | CLI says invalid sessions path | wrong sessions directory/file path | `ls -la ~/.openclaw/agents/main/sessions` and pass existing dir/files to `--sessions` |

--- a/docs/ops-recipes.md
+++ b/docs/ops-recipes.md
@@ -18,7 +18,6 @@ openclawbrain replay \
   --sessions ~/.openclaw/agents/main/sessions \
   --fast-learning \
   --stop-after-fast-learning \
-  --progress-every 25 \
   --resume \
   --checkpoint ~/.openclawbrain/main/replay_checkpoint.json
 ```
@@ -30,10 +29,21 @@ Example progress output during fast-learning:
 [fast_learning] 250/1800 (13.9%) elapsed=41.7s rate=6.00/s eta=258.3s
 ```
 
+Default replay heartbeat is every 30 seconds; use `--quiet` to suppress banners/progress in scripted runs.
+
+Checkpoint status after fast-learning:
+
+```bash
+openclawbrain replay \
+  --state ~/.openclawbrain/main/state.json \
+  --show-checkpoint \
+  --resume
+```
+
 2. Start the daemon so serving traffic uses the latest state:
 
 ```bash
-python3 -m openclawbrain.socket_server --state ~/.openclawbrain/main/state.json
+openclawbrain serve --state ~/.openclawbrain/main/state.json
 ```
 
 3. Run full replay/harvest later (off-peak):

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -55,6 +55,16 @@ You can run this repeatedly; dedupe is by `(type, sha256(content), session_point
 
 For ongoing operation after startup, use `--ignore-checkpoint` only when you intentionally want to replay older chunks that were already ingested.
 
+Replay progress defaults:
+- Fast-learning prints progress as it processes extraction windows.
+- Replay emits a heartbeat every 30 seconds by default.
+- Use `--quiet` to suppress banners/progress for automation.
+
+Single-writer lock:
+- Writer commands lock `state.json` via `state.json.lock` to prevent clobbered writes.
+- If a lock is active, prefer rebuilding into a new state and cut over (`examples/ops/rebuild_then_cutover.sh`).
+- Expert override exists (`--force` or `OPENCLAWBRAIN_STATE_LOCK_FORCE=1`) and should only be used when no conflicting writer is active.
+
 Checkpoint visibility:
 
 ```bash
@@ -251,6 +261,12 @@ Run the production service as a Unix socket wrapper around the NDJSON daemon:
 
 ```bash
 openclawbrain serve --state ~/.openclawbrain/main/state.json
+```
+
+Advanced/alternate module form (same service behavior):
+
+```bash
+python3 -m openclawbrain.socket_server --state ~/.openclawbrain/main/state.json
 ```
 
 The socket server creates and manages:


### PR DESCRIPTION
## Summary
- align operator docs with canonical `openclawbrain serve --state ...` brain-on command
- add checkpoint inspection guidance using `openclawbrain replay --show-checkpoint --resume`
- document replay progress expectations (fast-learning + 30s heartbeat + `--quiet`)
- document single-writer lock behavior, expert bypass (`--force` / `OPENCLAWBRAIN_STATE_LOCK_FORCE=1`), and recommend rebuild_then_cutover
- add README docs entry links and ClawHub deep link

## Validation
- python3 -m pytest -q
- grep check: no docs still contain "no serve subcommand"