### PR TITLE
daemon: default max_prompt_context_chars 30k

### DIFF
--- a/openclawbrain/daemon.py
+++ b/openclawbrain/daemon.py
@@ -261,7 +261,7 @@ def _handle_query(
     # Prompt caching appendix (deterministic) size.
     max_prompt_chars = params.get("max_prompt_context_chars")
     if not isinstance(max_prompt_chars, int):
-        max_prompt_chars = 20000
+        max_prompt_chars = 30000
 
     # Returned `context` size (human-readable, non-deterministic ordering). If not set, default
     # to the prompt appendix size so operators can bound output in one knob.

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -138,7 +138,7 @@ def test_daemon_query_returns_fired_nodes(tmp_path: Path) -> None:
         assert "- node:" in result["prompt_context"]
         assert "alpha" in result["prompt_context"]
         assert result["prompt_context_len"] == len(result["prompt_context"])
-        assert result["prompt_context_max_chars"] == 20000
+        assert result["prompt_context_max_chars"] == 30000
         assert isinstance(result["prompt_context_trimmed"], bool)
         assert isinstance(result["prompt_context_included_node_ids"], list)
         assert isinstance(result["prompt_context_dropped_node_ids"], list)
@@ -155,7 +155,7 @@ def test_daemon_query_returns_fired_nodes(tmp_path: Path) -> None:
     assert query_entries
     metadata = query_entries[-1]["metadata"]
     assert metadata["prompt_context_len"] == len(result["prompt_context"])
-    assert metadata["prompt_context_max_chars"] == 20000
+    assert metadata["prompt_context_max_chars"] == 30000
     assert isinstance(metadata["prompt_context_trimmed"], bool)
 
 


### PR DESCRIPTION
Bumps daemon default max_prompt_context_chars from 20000→30000 for prompt_context budgeting (Issue #35). Updates daemon default assertion tests accordingly.