### PR TITLE
release: 12.2.3 polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 ## Unreleased
 
+## v12.2.3 (2026-03-01)
+
+### Prompt-context and replay polish
+- Added prompt-context telemetry in query outputs for operator visibility (`prompt_context_len`, max chars, trim/drop stats, included/dropped ids).
+- Increased default `max_prompt_context_chars` to `30000`.
+- Set daemon query default `max_fired_nodes` to `30`.
+- Added ranked prompt-context ordering by authority first, then score, then deterministic source order.
+- Added `examples/eval/prompt_context_eval.py` harness for offline trim/drop evaluation.
+- Replay timestamp persistence now falls back to wall-clock time when replay succeeds but interaction timestamps are missing:
+  - `last_replayed_ts` is set from `time.time()`
+  - `last_replayed_ts_source` is set to `wall_clock`
+  - CLI persists both fields in state meta when available
+
 ### Single-writer state lock (issue #25)
 - Added `openclawbrain/state_lock.py`: advisory file lock (`fcntl.flock`) to enforce single-writer safety for `state.json`.
 - Writer commands (`replay`, `maintain`, `compact`, `sync`) and `socket_server`/`daemon` acquire the lock before writing.

--- a/openclawbrain/__init__.py
+++ b/openclawbrain/__init__.py
@@ -18,7 +18,7 @@ from .split import generate_summaries, split_workspace
 from .sync import DEFAULT_AUTHORITY_MAP, SyncReport, sync_workspace
 from .store import ManagedState, load_state, save_state
 from .traverse import TraversalResult, TraversalConfig, traverse
-from .prompt_context import build_prompt_context
+from .prompt_context import build_prompt_context, build_prompt_context_ranked_with_stats, build_prompt_context_with_stats
 
 __all__ = [
     "Node",
@@ -40,6 +40,8 @@ __all__ = [
     "prune_orphan_nodes",
     "traverse",
     "build_prompt_context",
+    "build_prompt_context_with_stats",
+    "build_prompt_context_ranked_with_stats",
     "ManagedState",
     "split_workspace",
     "generate_summaries",
@@ -71,4 +73,4 @@ __all__ = [
     "replay_queries",
 ]
 
-__version__ = "12.2.2"
+__version__ = "12.2.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openclawbrain"
-version = "12.2.1"
+version = "12.2.3"
 description = "Memory graph for AI agents that learns what to retrieve — and what to suppress."
 requires-python = ">=3.10"
 dependencies = ["openai>=1.0"]

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -243,6 +243,19 @@ def test_replay_strengthens_edges() -> None:
     assert graph._edges["a"]["b"].weight > 0.5
 
 
+def test_replay_queries_uses_wall_clock_timestamp_when_query_ts_missing() -> None:
+    """Replay fallback uses wall-clock timestamp when no per-query ts is available."""
+    graph = Graph()
+    graph.add_node(Node("a", "alpha chunk", metadata={"file": "a.md"}))
+    graph.add_node(Node("b", "beta chunk", metadata={"file": "a.md"}))
+    graph.add_edge(Edge("a", "b", 0.5))
+    stats = replay_queries(graph=graph, queries=["alpha"], config=TraversalConfig(max_hops=1))
+
+    assert stats["queries_replayed"] == 1
+    assert isinstance(stats["last_replayed_ts"], float)
+    assert stats["last_replayed_ts_source"] == "wall_clock"
+
+
 def test_replay_creates_cross_file_edges() -> None:
     """test replay creates cross file edges."""
     graph = Graph()


### PR DESCRIPTION
Bumps to v12.2.3 and polishes operator UX:

- Replay: when replay succeeds but per-query timestamps are missing, fall back to wall-clock time.time() for last_replayed_ts and persist last_replayed_ts_source.
- CLI persists last_replayed_ts_source in state meta.
- Export prompt_context helper APIs in public __init__.
- Update CHANGELOG and pyproject version.

Tests: 344 passed.
