### PR TITLE
release: 12.2.5 (bootstrap include + authority sync)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## Unreleased
 
+## v12.2.5 (2026-03-01)
+
+### Bootstrap include + authority metadata sync fixes
+- `split_workspace` now always includes OpenClaw bootstrap files and `memory/` notes even when `.gitignore` would otherwise skip them (`SOUL.md`, `AGENTS.md`, `USER.md`, `TOOLS.md`, `MEMORY.md`, `IDENTITY.md`, `HEARTBEAT.md`, `active-tasks.md`, `WORKFLOW_AUTO.md`, and `memory/` paths).
+- Explicit `split_workspace(..., exclude=...)` patterns still take precedence, so operators can intentionally suppress any of these paths.
+- `sync_workspace` now applies authority metadata updates for all current workspace nodes (including unchanged content), without recomputing embeddings.
+- Added sync reporting for metadata-only changes via `nodes_metadata_updated` and included this in sync journal events.
+- Added regression tests for gitignored bootstrap/memory inclusion and unchanged-node authority backfill.
+
 ## v12.2.4 (2026-03-01)
 
 ### CLI lock enforcement + init authority metadata

--- a/openclawbrain/__init__.py
+++ b/openclawbrain/__init__.py
@@ -73,4 +73,4 @@ __all__ = [
     "replay_queries",
 ]
 
-__version__ = "12.2.4"
+__version__ = "12.2.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openclawbrain"
-version = "12.2.4"
+version = "12.2.5"
 description = "Memory graph for AI agents that learns what to retrieve — and what to suppress."
 requires-python = ">=3.10"
 dependencies = ["openai>=1.0"]

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -263,3 +263,21 @@ def test_split_text_file_uses_blank_line_split(tmp_path: Path) -> None:
     graph, texts = split_workspace(str(workspace), file_extensions=(".txt",))
     assert len(graph.nodes()) == 3
     assert len(texts) == 3
+
+
+def test_split_always_includes_bootstrap_and_memory_when_gitignored(tmp_path: Path) -> None:
+    """split includes bootstrap and memory paths even when ignored by .gitignore."""
+    workspace = tmp_path / "split_always_include"
+    memory_dir = workspace / "memory"
+    memory_dir.mkdir(parents=True)
+    (workspace / ".gitignore").write_text("SOUL.md\nmemory/\n", encoding="utf-8")
+    (workspace / "SOUL.md").write_text("# Soul\nFoundational rules.", encoding="utf-8")
+    (memory_dir / "daily.md").write_text("## Log\nEntry", encoding="utf-8")
+
+    graph, texts = split_workspace(str(workspace))
+    node_ids = {node.id for node in graph.nodes()}
+
+    assert "SOUL.md::0" in node_ids
+    assert "memory/daily.md::0" in node_ids
+    assert "SOUL.md::0" in texts
+    assert "memory/daily.md::0" in texts


### PR DESCRIPTION
- split_workspace now always includes bootstrap files + memory/ notes even if .gitignore ignores them.
- sync_workspace backfills authority metadata even for unchanged nodes (no re-embedding) and reports nodes_metadata_updated.
- bump to v12.2.5 + tests.