### PR TITLE
feat: async teacher routing + policy-gradient updates (async-route-pg)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 ## Unreleased
 
+### Async teacher routing + policy-gradient updates (`async-route-pg`)
+- Added new CLI command: `openclawbrain async-route-pg` with dry-run/apply modes and JSON summary output.
+- Added background teacher-shadow routing loop over recent query journal events:
+  - replays local traversal with keyword seeding (no query-path LLM dependency)
+  - builds candidate sets from habitual edges, with reflex fallback
+  - batches teacher requests through OpenAI chat batch helper when available
+  - parses teacher JSON labels from `choose` and/or `scores`
+- Applies dense PG updates via `apply_outcome_pg([source, target], outcome=score_scale*score)` and optionally writes edge `metadata.relevance`.
+- Includes safety behavior for missing teacher credentials (`OPENAI_API_KEY`) and `--teacher none` (runs, reports unavailable, no updates).
+- Added tests for teacher-label parsing, relative weight improvement from positive labels, and dry-run no-write behavior.
+- Updated docs (`README.md`, `docs/architecture.md`, `docs/operator-guide.md`) for operator workflow and architecture placement.
+
 ### OpenClaw integration context dedupe + compact adapter output
 - Daemon `query` now accepts prompt-context-only exclusions:
   - `exclude_files` (exact `metadata.file` matches)

--- a/README.md
+++ b/README.md
@@ -547,6 +547,10 @@ from openclawbrain import (
 - **Embedder changes:** OpenClawBrain stores the embedder name + dimension in state metadata and hard-fails on mismatch — no silent corruption
 - **Maintenance:** use `openclawbrain maintain` (`decay` + `scale` + `split` + `merge` + `prune` + `connect`) to rebalance structure as the graph evolves
 
+## Core thesis (recommended reading)
+
+- **Shadow routing + Ultimate Policy Gradient:** `docs/core-thesis-ultimate-policy-gradient.md`
+
 ## Cost control
 
 - **Recommended:** OpenAI `text-embedding-3-small` (~$0.02/MB) + `gpt-5-mini` for optional offline teacher routing/scoring. Embeddings are generated at init and cached in `state.json`; normal query serving stays LLM-free.

--- a/README.md
+++ b/README.md
@@ -355,6 +355,7 @@ See `examples/openai_embedder/` for a complete example.
 | `inject` | Add CORRECTION/TEACHING/DIRECTIVE nodes |
 | `replay` | Replay session queries (defaults to full-learning; use `--edges-only` for cheap replay, `--fast-learning`/`--extract-learning-events` for LLM mining only, or `--full-learning`/`--full-pipeline` for the full pass) |
 | `harvest` | Apply slow-learning pass from `learning_events.jsonl` to current graph |
+| `async-route-pg` | Background teacher-shadow routing labels from recent query journal + PG edge updates |
 | `health` | Show graph health metrics |
 | `status` | `openclawbrain status --state brain/state.json [--json]` returns a one-command health overview: version, nodes, edges, tier distribution, daemon status, embedder, decay half-life |
 | `serve` | `openclawbrain serve --state brain/state.json [--socket-path path] [--foreground]` starts the Unix socket service in the foreground |
@@ -548,7 +549,7 @@ from openclawbrain import (
 
 ## Cost control
 
-- **Recommended:** OpenAI `text-embedding-3-small` (~$0.02/MB) + `gpt-5-mini` for routing/scoring. Embeddings are generated at init and cached in `state.json`; `gpt-5-mini` runs on query only.
+- **Recommended:** OpenAI `text-embedding-3-small` (~$0.02/MB) + `gpt-5-mini` for optional offline teacher routing/scoring. Embeddings are generated at init and cached in `state.json`; normal query serving stays LLM-free.
 - **Auto-detection:** `openclawbrain init` tries OpenAI by default (`--embedder auto --llm auto`). If `OPENAI_API_KEY` is set, you get production-quality embeddings automatically. If not, it falls back to hash embeddings with no API calls.
 - **Batch init:** `openclawbrain init` embeds all workspace files in one batch call. Subsequent queries reuse cached vectors.
 - **Explicit control:** use `--embedder openai` / `--embedder hash` to force a specific embedder. Use `--llm none` to skip LLM-assisted splitting.
@@ -681,6 +682,27 @@ the run, so long rebuilds survive file rotation.
 
 The fast-learning and harvest pipeline is sidecar-only to the core files:
 `learning_events.jsonl` is append-only, and `replay` updates `state.json` via the same graph mutation model as existing injection commands.
+
+## Async teacher routing (offline)
+
+`query` and daemon query stay LLM-free and fast. `async-route-pg` is a separate background loop that samples recent journaled queries, replays local traversal, asks a teacher model which candidate edges it would choose, then applies dense policy-gradient updates with `apply_outcome_pg`.
+
+```bash
+openclawbrain async-route-pg \
+  --state /tmp/brain/state.json \
+  --since-hours 24 \
+  --max-queries 200 \
+  --sample-rate 0.1 \
+  --teacher openai \
+  --teacher-model gpt-5-mini \
+  --apply \
+  --json
+```
+
+Notes:
+- Default is dry-run (no state write); add `--apply` to persist updates.
+- If `OPENAI_API_KEY` is missing (or `--teacher none`), it still runs but reports teacher unavailable and applies no updates.
+- The updates improve edge weights/metadata that downstream `maintain` (`split/merge/prune/connect`) already consumes.
 
 ## Production experience
 

--- a/docs/core-thesis-ultimate-policy-gradient.md
+++ b/docs/core-thesis-ultimate-policy-gradient.md
@@ -1,0 +1,165 @@
+# The Core Thesis: Shadow Routing + Ultimate Policy Gradient (OpenClawBrain)
+
+Date: 2026-03-02
+
+## TL;DR
+OpenClawBrain should feel *fast* at runtime and *smarter* every day.
+
+We get both by splitting the system into two loops:
+
+1) **Runtime (fast, deterministic, no LLM calls):**
+   - Embed the query.
+   - Retrieve seed nodes.
+   - Traverse a learned memory graph.
+   - Emit a compact `prompt_context`.
+
+2) **Learning (async, parallel, high leverage):**
+   - Replay recent traversal decision points.
+   - Ask a teacher model what it *would have routed to*.
+   - Convert dense labels into policy-gradient updates over edges.
+
+This yields **fewer turns, fewer tokens, better context**, while preserving stable runtime latency.
+
+---
+
+## Why this matters
+The failure mode of most "memory" systems is *interactive pointer chasing*:
+
+- Retrieve something vague → see a pointer → retrieve again → follow another pointer → repeat
+
+That creates:
+
+- More tool calls
+- More context bloat
+- More turns
+- Worse tail latency
+
+OpenClawBrain’s goal is the opposite: **one fast context load** that gets you into the right neighborhood, plus a background learning loop that makes the next context load even better.
+
+---
+
+## Definitions
+
+### `runtime_route_fn` (money-maker)
+A **lightning-fast local routing policy** used during traversal to choose which candidate edges to expand.
+
+**Inputs** (conceptually):
+- `query_embedding` (already computed)
+- `source_node` (current node)
+- `candidate_edges` (habitual edges) with:
+  - learned `edge.weight`
+  - optional dense weak-supervision `edge.metadata["relevance"]`
+  - target node vector (cached in index)
+
+**Output:**
+- deterministic list of next target node IDs (top-K)
+
+**Key requirement:** no network calls; CPU-only math; deterministic.
+
+### `async_route_fn` (teacher labeler)
+An **offline** labeling function that answers:
+
+> Given the query + the current node + candidate edges, what should we expand next?
+
+It can be an LLM (default: `gpt-5-mini`) and is allowed to be slow — because it runs in the background and is heavily parallelized.
+
+**Output (robust JSON):**
+- `choose`: a short list of target IDs, and/or
+- `scores`: per-target scores in [-1, 1]
+
+---
+
+## The ultimate policy gradient
+We treat traversal as a policy over actions (edges):
+
+- **State**: (query, current node, candidate edges)
+- **Action**: choose the next edge(s) to expand
+- **Policy parameters**: edge weights (+ optional relevance metadata)
+
+The **ultimate policy gradient** idea:
+
+- Human feedback provides *high-authority reward*.
+- Self-learning (agent outcomes) provides strong reward.
+- Harvester signals provide medium reward.
+- Async teacher labels provide *massive volume* of weak supervision.
+
+All of these are different *reward sources* that can be unified into the same policy-gradient update rule.
+
+In practice this looks like:
+
+- Use the teacher to generate dense edge-level labels.
+- Apply bounded REINFORCE updates (`apply_outcome_pg`) to edge weights.
+- Optionally store teacher signal as `edge.metadata["relevance"]` to influence logits.
+
+The key is **asymmetry**:
+- Teacher is lower weight per sample.
+- Teacher is higher volume.
+- Humans are highest weight.
+
+---
+
+## Runtime routing (deterministic, context-conditioned)
+The simplest fast policy that already conditions on context is:
+
+```
+score(edge) = edge.weight
+          + (edge.relevance if enabled)
+          + α * cosine(query_vec, target_vec)
+```
+
+Then choose `top_k` edges by score (deterministic tie-break by target_id).
+
+This is "transformer → number" without paying transformer cost twice:
+- the transformer already produced the query embedding
+- routing is just dot products and adds
+
+---
+
+## Structural plasticity remains core
+The background policy-gradient loop does **not** replace structural graph evolution.
+
+We still want (and keep):
+- **split**: break oversized nodes
+- **merge**: consolidate duplicates
+- **connect**: propose new edges
+- **prune**: remove dead wood
+- **inject**: create new nodes from explicit corrections/teachings/directives
+
+The new async teacher + PG loop makes these mechanisms smarter by producing:
+- cleaner trajectories
+- denser, less noisy edge-strength signals
+- better edge relevance metadata
+
+---
+
+## Implementation milestones
+
+### Milestone 0 (shipped)
+- `async-route-pg`: teacher shadow loop + PG updates (dry-run by default; `--apply` gated)
+
+### Milestone 1 (shipped)
+- `route_mode=edge+sim`: runtime query-conditioned routing based on embeddings + learned weights + relevance
+
+### Next milestones
+- Add explicit reward-source weighting (human/self/harvester/teacher) as first-class inputs.
+- Add an eval harness that measures: token count, turn count, and retrieval correctness.
+- Add shortcut/pointer edge creation offline (teacher-assisted connect during maintain).
+
+---
+
+## How to run (operator sketch)
+1) Run `async-route-pg` in dry-run and inspect JSON deltas.
+2) Apply to a copied state first.
+3) Enable runtime `route_mode=edge+sim` and compare context size + turn count.
+
+---
+
+## The promise
+If we do this right, OpenClawBrain becomes a system where:
+
+- Runtime stays fast and predictable.
+- Every conversation generates training data.
+- The brain improves continuously.
+- Humans steer direction; teachers provide volume.
+
+That is the core thesis.

--- a/openclawbrain/openai_llm.py
+++ b/openclawbrain/openai_llm.py
@@ -62,12 +62,12 @@ def _get_client():
     return client
 
 
-def openai_llm_fn(system: str, user: str) -> str:
+def openai_llm_fn(system: str, user: str, *, model: str = "gpt-5-mini") -> str:
     """Run a single OpenAI chat request."""
     client = _get_client()
     try:
         response = client.chat.completions.create(
-            model="gpt-5-mini",
+            model=model,
             messages=[
                 {"role": "system", "content": system},
                 {"role": "user", "content": user},
@@ -79,7 +79,7 @@ def openai_llm_fn(system: str, user: str) -> str:
         if not _is_timeout_kwarg_error(exc):
             raise
         response = client.chat.completions.create(
-            model="gpt-5-mini",
+            model=model,
             messages=[
                 {"role": "system", "content": system},
                 {"role": "user", "content": user},
@@ -122,9 +122,10 @@ def openai_llm_batch_fn(requests: list[dict], *, max_workers: int = 8) -> list[d
     def _call(req: dict) -> dict:
         system = str(req.get("system", ""))
         user = str(req.get("user", ""))
+        model = str(req.get("model", "gpt-5-mini"))
         request_id = req.get("id")
         try:
-            response = openai_llm_fn(system, user)
+            response = openai_llm_fn(system, user, model=model)
         except Exception as exc:  # noqa: BLE001
             return {"id": request_id, "response": "", "error": str(exc)}
         return {"id": request_id, "response": response}

--- a/openclawbrain/ops/async_route_pg.py
+++ b/openclawbrain/ops/async_route_pg.py
@@ -1,0 +1,407 @@
+"""Background teacher-routing PG updates over recent query journal events."""
+
+from __future__ import annotations
+
+import copy
+import json
+import os
+import random
+import time
+from dataclasses import dataclass
+from typing import Callable
+
+from ..graph import Edge, Graph
+from ..journal import read_journal
+from ..learn import apply_outcome_pg
+from ..replay import default_keyword_seed_fn
+from ..store import load_state, save_state
+from ..traverse import TraversalConfig, traverse
+from .._util import _extract_json
+
+
+TEACHER_SYSTEM_PROMPT = (
+    "You are a routing teacher for a memory graph traversal policy.\n"
+    "Given the user query, source node context, and candidate targets, return JSON only.\n"
+    'Allowed JSON forms: {"choose": ["target_id", ...]} and/or {"scores": {"target_id": -1.0..1.0}}.\n'
+    "Prefer sparse useful supervision. Use IDs exactly as given."
+)
+
+
+@dataclass
+class DecisionPoint:
+    """One supervised routing decision from traversal replay."""
+
+    query: str
+    source_id: str
+    chosen_target_id: str
+    candidates: list[dict[str, object]]
+
+
+@dataclass
+class AsyncRoutePgSummary:
+    """Structured summary for CLI output."""
+
+    teacher_requested: str
+    teacher_available: bool
+    teacher_model: str
+    sampled_queries: int
+    decision_points_total: int
+    decision_points_labeled: int
+    labeled_edges: int
+    updates_applied: int
+    total_abs_weight_delta: float
+    max_abs_weight_delta: float
+    dry_run: bool
+    max_decision_points_hit: bool
+    score_scale: float
+    state_path: str
+    journal_path: str
+    errors: list[str]
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "teacher_requested": self.teacher_requested,
+            "teacher_available": self.teacher_available,
+            "teacher_model": self.teacher_model,
+            "sampled_queries": self.sampled_queries,
+            "decision_points_total": self.decision_points_total,
+            "decision_points_labeled": self.decision_points_labeled,
+            "labeled_edges": self.labeled_edges,
+            "updates_applied": self.updates_applied,
+            "total_abs_weight_delta": self.total_abs_weight_delta,
+            "max_abs_weight_delta": self.max_abs_weight_delta,
+            "dry_run": self.dry_run,
+            "max_decision_points_hit": self.max_decision_points_hit,
+            "score_scale": self.score_scale,
+            "state_path": self.state_path,
+            "journal_path": self.journal_path,
+            "errors": list(self.errors),
+        }
+
+
+def parse_teacher_route_labels(raw: str, valid_target_ids: set[str]) -> dict[str, float]:
+    """Parse model output supporting choose-only, scores-only, or both."""
+    parsed = _extract_json(raw)
+    if not isinstance(parsed, dict):
+        return {}
+
+    labels: dict[str, float] = {}
+    raw_scores = parsed.get("scores")
+    has_scores = isinstance(raw_scores, dict)
+    if has_scores:
+        for target_id, value in raw_scores.items():
+            target = str(target_id)
+            if target not in valid_target_ids:
+                continue
+            try:
+                score = float(value)
+            except (TypeError, ValueError):
+                continue
+            labels[target] = max(-1.0, min(1.0, score))
+
+    raw_choose = parsed.get("choose")
+    if isinstance(raw_choose, list):
+        choose_ids = [str(item) for item in raw_choose if str(item) in valid_target_ids]
+        if has_scores:
+            for target in choose_ids:
+                labels.setdefault(target, 1.0)
+        else:
+            for target in choose_ids:
+                labels[target] = 1.0
+    return labels
+
+
+def _preview(text: str, limit: int = 180) -> str:
+    value = " ".join((text or "").split())
+    return value if len(value) <= limit else value[: limit - 3] + "..."
+
+
+def _teacher_user_prompt(point: DecisionPoint) -> str:
+    payload = {
+        "query": point.query,
+        "source_id": point.source_id,
+        "source_preview": _preview(point.candidates[0].get("source_preview", "")) if point.candidates else "",
+        "chosen_target_id_runtime": point.chosen_target_id,
+        "candidates": point.candidates,
+        "response_schema": {
+            "choose": ["target_id"],
+            "scores": {"target_id": "number in [-1,1]"},
+        },
+    }
+    return json.dumps(payload, ensure_ascii=True)
+
+
+def _candidate_sort_key(edge: Edge) -> tuple[float, float, str]:
+    return (abs(edge.weight), edge.weight, edge.target)
+
+
+def _decision_points_for_query(
+    graph: Graph,
+    query: str,
+    *,
+    max_candidates_per_node: int,
+) -> list[DecisionPoint]:
+    seeds = default_keyword_seed_fn(graph, query)
+    if not seeds:
+        return []
+    result = traverse(
+        graph=graph,
+        seeds=seeds,
+        config=TraversalConfig(),
+        query_text=query,
+    )
+    if not result.steps:
+        return []
+
+    points: list[DecisionPoint] = []
+    for step in result.steps:
+        source = graph.get_node(step.from_node)
+        if source is None:
+            continue
+        outgoing = graph._edges.get(step.from_node, {})
+        habitual_edges = [edge for edge in outgoing.values() if 0.15 <= edge.weight < 0.6]
+        reflex_edges = [edge for edge in outgoing.values() if edge.weight >= 0.6]
+
+        candidates = sorted(habitual_edges, key=_candidate_sort_key, reverse=True)
+        if len(candidates) < max_candidates_per_node:
+            for edge in sorted(reflex_edges, key=_candidate_sort_key, reverse=True):
+                if edge.target not in {item.target for item in candidates}:
+                    candidates.append(edge)
+                if len(candidates) >= max_candidates_per_node:
+                    break
+        candidates = candidates[:max_candidates_per_node]
+        if not candidates:
+            continue
+
+        candidate_payload: list[dict[str, object]] = []
+        for edge in candidates:
+            target_node = graph.get_node(edge.target)
+            if target_node is None:
+                continue
+            metadata = target_node.metadata if isinstance(target_node.metadata, dict) else {}
+            candidate_payload.append(
+                {
+                    "source_preview": _preview(source.content),
+                    "target_id": edge.target,
+                    "edge_weight": edge.weight,
+                    "target_preview": _preview(target_node.content),
+                    "file": metadata.get("file"),
+                    "authority": metadata.get("authority"),
+                }
+            )
+        if not candidate_payload:
+            continue
+
+        points.append(
+            DecisionPoint(
+                query=query,
+                source_id=step.from_node,
+                chosen_target_id=step.to_node,
+                candidates=candidate_payload,
+            )
+        )
+    return points
+
+
+def _sample_queries(
+    journal_path: str,
+    *,
+    since_hours: float,
+    max_queries: int,
+    sample_rate: float,
+) -> list[str]:
+    entries = read_journal(journal_path=journal_path)
+    cutoff = time.time() - max(0.0, since_hours) * 3600.0
+    raw_queries: list[str] = []
+    for entry in entries:
+        if entry.get("type") != "query":
+            continue
+        query = entry.get("query")
+        if not isinstance(query, str) or not query.strip():
+            continue
+        ts = entry.get("ts")
+        if isinstance(ts, (int, float)) and float(ts) < cutoff:
+            continue
+        raw_queries.append(query.strip())
+
+    rng = random.Random(0)
+    sampled: list[str] = []
+    for query in raw_queries:
+        if len(sampled) >= max_queries:
+            break
+        if rng.random() <= max(0.0, min(1.0, sample_rate)):
+            sampled.append(query)
+    return sampled
+
+
+def _teacher_labels_openai(
+    decision_points: list[DecisionPoint],
+    *,
+    teacher_model: str,
+) -> tuple[list[dict[str, float]], list[str]]:
+    errors: list[str] = []
+    if not decision_points:
+        return [], errors
+
+    from ..openai_llm import openai_llm_batch_fn
+
+    requests = [
+        {
+            "id": idx,
+            "model": teacher_model,
+            "system": TEACHER_SYSTEM_PROMPT,
+            "user": _teacher_user_prompt(point),
+        }
+        for idx, point in enumerate(decision_points)
+    ]
+    responses = openai_llm_batch_fn(requests)
+    by_id: dict[int, dict] = {}
+    for row in responses:
+        if not isinstance(row, dict):
+            continue
+        request_id = row.get("id")
+        if isinstance(request_id, int):
+            by_id[request_id] = row
+
+    labels_per_point: list[dict[str, float]] = []
+    for idx, point in enumerate(decision_points):
+        response = by_id.get(idx, {})
+        raw = response.get("response")
+        if not isinstance(raw, str):
+            labels_per_point.append({})
+            err = response.get("error")
+            if isinstance(err, str) and err:
+                errors.append(err)
+            continue
+        valid_ids = {str(item["target_id"]) for item in point.candidates if "target_id" in item}
+        labels_per_point.append(parse_teacher_route_labels(raw, valid_ids))
+        err = response.get("error")
+        if isinstance(err, str) and err:
+            errors.append(err)
+    return labels_per_point, errors
+
+
+def run_async_route_pg(
+    *,
+    state_path: str,
+    journal_path: str,
+    since_hours: float = 24.0,
+    max_queries: int = 200,
+    sample_rate: float = 0.1,
+    max_candidates_per_node: int = 12,
+    max_decision_points: int = 500,
+    teacher: str = "openai",
+    teacher_model: str = "gpt-5-mini",
+    apply: bool = False,
+    write_relevance_metadata: bool = True,
+    score_scale: float = 0.3,
+    teacher_labeler: Callable[[list[DecisionPoint]], tuple[list[dict[str, float]], list[str]]] | None = None,
+) -> AsyncRoutePgSummary:
+    """Run teacher-shadow routing updates over recent query events."""
+    graph, index, meta = load_state(state_path)
+    sampled_queries = _sample_queries(
+        journal_path=journal_path,
+        since_hours=since_hours,
+        max_queries=max_queries,
+        sample_rate=sample_rate,
+    )
+
+    decision_points: list[DecisionPoint] = []
+    cap_hit = False
+    for query in sampled_queries:
+        points = _decision_points_for_query(
+            graph=graph,
+            query=query,
+            max_candidates_per_node=max_candidates_per_node,
+        )
+        for point in points:
+            decision_points.append(point)
+            if len(decision_points) >= max_decision_points:
+                cap_hit = True
+                break
+        if cap_hit:
+            break
+
+    teacher_available = False
+    errors: list[str] = []
+    labels_by_point: list[dict[str, float]] = [{} for _ in decision_points]
+    if teacher_labeler is not None:
+        teacher_available = True
+        labels_by_point, custom_errors = teacher_labeler(decision_points)
+        errors.extend(custom_errors)
+    elif teacher == "openai" and os.environ.get("OPENAI_API_KEY"):
+        teacher_available = True
+        try:
+            labels_by_point, model_errors = _teacher_labels_openai(
+                decision_points=decision_points,
+                teacher_model=teacher_model,
+            )
+            errors.extend(model_errors)
+        except Exception as exc:  # noqa: BLE001
+            errors.append(str(exc))
+            labels_by_point = [{} for _ in decision_points]
+            teacher_available = False
+    elif teacher == "openai":
+        errors.append("OPENAI_API_KEY not set; teacher unavailable")
+    else:
+        errors.append("teacher disabled")
+
+    working_graph = graph if apply else copy.deepcopy(graph)
+    decision_points_labeled = 0
+    labeled_edges = 0
+    updates_applied = 0
+    total_abs_weight_delta = 0.0
+    max_abs_weight_delta = 0.0
+    for point, labels in zip(decision_points, labels_by_point):
+        if not labels:
+            continue
+        decision_points_labeled += 1
+        for target_id, score in labels.items():
+            if score == 0:
+                continue
+            source_node = working_graph.get_node(point.source_id)
+            target_node = working_graph.get_node(target_id)
+            if source_node is None or target_node is None:
+                continue
+            updates = apply_outcome_pg(
+                graph=working_graph,
+                fired_nodes=[point.source_id, target_id],
+                outcome=score_scale * score,
+            )
+            update_key = f"{point.source_id}->{target_id}"
+            delta = float(updates.get(update_key, 0.0))
+            abs_delta = abs(delta)
+            total_abs_weight_delta += abs_delta
+            if abs_delta > max_abs_weight_delta:
+                max_abs_weight_delta = abs_delta
+            updates_applied += 1
+            labeled_edges += 1
+            if write_relevance_metadata:
+                edge = working_graph._edges.get(point.source_id, {}).get(target_id)
+                if edge is not None:
+                    metadata = edge.metadata if isinstance(edge.metadata, dict) else {}
+                    metadata["relevance"] = max(-1.0, min(1.0, float(score)))
+                    edge.metadata = metadata
+                    working_graph._edges[point.source_id][target_id] = edge
+
+    if apply and teacher_available and updates_applied > 0:
+        save_state(graph=working_graph, index=index, path=state_path, meta=meta)
+
+    return AsyncRoutePgSummary(
+        teacher_requested=teacher,
+        teacher_available=teacher_available,
+        teacher_model=teacher_model,
+        sampled_queries=len(sampled_queries),
+        decision_points_total=len(decision_points),
+        decision_points_labeled=decision_points_labeled,
+        labeled_edges=labeled_edges,
+        updates_applied=updates_applied,
+        total_abs_weight_delta=total_abs_weight_delta,
+        max_abs_weight_delta=max_abs_weight_delta,
+        dry_run=not apply,
+        max_decision_points_hit=cap_hit,
+        score_scale=score_scale,
+        state_path=state_path,
+        journal_path=journal_path,
+        errors=errors,
+    )

--- a/tests/test_async_route_pg.py
+++ b/tests/test_async_route_pg.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from openclawbrain.graph import Edge, Graph, Node
+from openclawbrain.index import VectorIndex
+from openclawbrain.ops.async_route_pg import parse_teacher_route_labels, run_async_route_pg
+from openclawbrain.store import load_state, save_state
+
+
+def _write_state(path: Path) -> None:
+    graph = Graph()
+    graph.add_node(Node("seed", "alpha routing seed"))
+    graph.add_node(Node("target_a", "alpha preferred target"))
+    graph.add_node(Node("target_b", "alpha alternative target"))
+    graph.add_edge(Edge("seed", "target_a", 0.35))
+    graph.add_edge(Edge("seed", "target_b", 0.30))
+    save_state(graph=graph, index=VectorIndex(), path=str(path), meta={"embedder_name": "hash-v1", "embedder_dim": 1024})
+
+
+def _write_journal(path: Path) -> None:
+    entry = {"type": "query", "query": "alpha", "ts": 9999999999.0, "iso": "2286-11-20T17:46:39+0000"}
+    path.write_text(json.dumps(entry) + "\n", encoding="utf-8")
+
+
+def test_parse_teacher_route_labels_choose_only() -> None:
+    labels = parse_teacher_route_labels('{"choose":["target_a"]}', {"target_a", "target_b"})
+    assert labels == {"target_a": 1.0}
+
+
+def test_parse_teacher_route_labels_scores() -> None:
+    labels = parse_teacher_route_labels(
+        '{"scores":{"target_a":0.4,"target_b":-2.0,"unknown":1.0}}',
+        {"target_a", "target_b"},
+    )
+    assert labels == {"target_a": 0.4, "target_b": -1.0}
+
+
+def test_run_async_route_pg_positive_label_increases_chosen_edge_relative_to_others(tmp_path: Path) -> None:
+    state_path = tmp_path / "state.json"
+    journal_path = tmp_path / "journal.jsonl"
+    _write_state(state_path)
+    _write_journal(journal_path)
+
+    graph_before, _, _ = load_state(str(state_path))
+    before_gap = graph_before._edges["seed"]["target_a"].weight - graph_before._edges["seed"]["target_b"].weight
+
+    def _teacher(points):
+        labels = []
+        for point in points:
+            if point.source_id == "seed" and point.chosen_target_id == "target_a":
+                labels.append({"target_a": 1.0})
+            else:
+                labels.append({})
+        return labels, []
+
+    summary = run_async_route_pg(
+        state_path=str(state_path),
+        journal_path=str(journal_path),
+        since_hours=24.0,
+        max_queries=10,
+        sample_rate=1.0,
+        max_candidates_per_node=12,
+        max_decision_points=500,
+        teacher="none",
+        apply=True,
+        teacher_labeler=_teacher,
+    )
+    assert summary.updates_applied >= 1
+
+    graph_after, _, _ = load_state(str(state_path))
+    after_gap = graph_after._edges["seed"]["target_a"].weight - graph_after._edges["seed"]["target_b"].weight
+    assert after_gap > before_gap
+
+
+def test_run_async_route_pg_dry_run_does_not_modify_state_json(tmp_path: Path) -> None:
+    state_path = tmp_path / "state.json"
+    journal_path = tmp_path / "journal.jsonl"
+    _write_state(state_path)
+    _write_journal(journal_path)
+    before = state_path.read_bytes()
+
+    def _teacher(points):
+        labels = []
+        for point in points:
+            if point.source_id == "seed":
+                labels.append({"target_a": 1.0})
+            else:
+                labels.append({})
+        return labels, []
+
+    summary = run_async_route_pg(
+        state_path=str(state_path),
+        journal_path=str(journal_path),
+        since_hours=24.0,
+        max_queries=10,
+        sample_rate=1.0,
+        max_candidates_per_node=12,
+        max_decision_points=500,
+        teacher="none",
+        apply=False,
+        teacher_labeler=_teacher,
+    )
+    after = state_path.read_bytes()
+    assert summary.updates_applied >= 1
+    assert before == after


### PR DESCRIPTION
Implements the MVP shadow learning loop: sample recent queries, ask a teacher LLM (default `gpt-5-mini`) what edges it would choose at traversal decision points, then apply dense updates via `apply_outcome_pg`. Query-time path remains fast / LLM-free.

## Key points
- New CLI: `openclawbrain async-route-pg` (dry-run default; `--apply` to write state)
- Batches teacher calls via `openai_llm_batch_fn`
- Optionally writes `edge.metadata["relevance"]` to feed future runtime policies
- Safety caps (sampling + max decision points)
- Tests: 370 passed

## Docs
- README + architecture + operator guide + changelog updated.
- Added a high-level writeup: `docs/core-thesis-ultimate-policy-gradient.md`
