### PR TITLE
feat(daemon): runtime route_mode=edge+sim (query-conditioned route_fn)

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,12 @@ Example request/response:
 echo '{"id":"req-1","method":"query","params":{"query":"how to deploy","top_k":4,"chat_id":"telegram:123"}}' | openclawbrain daemon --state ~/.openclawbrain/main/state.json
 ```
 
+Enable deterministic query-conditioned habitual routing (no LLM calls on query path):
+
+```bash
+echo '{"id":"req-2","method":"query","params":{"query":"how to deploy","top_k":4,"route_mode":"edge+sim","route_top_k":5,"route_alpha_sim":0.5,"route_use_relevance":true}}' | openclawbrain daemon --state ~/.openclawbrain/main/state.json
+```
+
 ```json
 {"id":"req-1","result":{"fired_nodes":["a"],"context":"...","seeds":[["a",0.96]],"embed_query_ms":1.1,"traverse_ms":2.4,"total_ms":3.5}}
 ```


### PR DESCRIPTION
Re-opens the runtime route policy changes on top of main (the original PR was based on feat/async-route-pg, which is now merged).\n\n## What\n- New daemon query params:\n  - route_mode: off | edge | edge+sim\n  - route_top_k (default 5)\n  - route_alpha_sim (default 0.5)\n  - route_use_relevance (default true)\n- Deterministic scoring: weight + (optional edge.metadata.relevance) + alpha * cosine(query_vec, target_vec)\n- Deterministic top-k selection with target_id tie-break\n\n## Why\nCloses the loop with async-route-pg: teacher labels populate edge.relevance and PG updates weights; runtime routing can now condition on the query embedding while staying LLM-free.\n\n## Tests\n- Added deterministic route_fn test\n- Added daemon query integration test\n