### PR TITLE
fix(daemon): embed-model auto-detect from state metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 - Habitual-edge selection now combines learned edge weights, optional edge relevance metadata, and query-to-target cosine similarity with deterministic ranking.
 - Query serving remains local/LLM-free while benefiting from updated routing priors.
 
+### Daemon: embed-model auto-detect (hash vs OpenAI)
+- `openclawbrain daemon` now defaults to `--embed-model auto`, which resolves the query embedder from `state.json` metadata.
+- Fixes OOTB daemon queries for hash-based states (prevents 1024 vs 1536 dimension mismatch).
+
 ### Docs: new core thesis (`Ultimate Policy Gradient`)
 - Added `docs/core-thesis-ultimate-policy-gradient.md` as the canonical thesis/reference doc.
 - Documents the shadow-routing-to-runtime loop and operational rollout guidance.

--- a/README.md
+++ b/README.md
@@ -384,6 +384,11 @@ Start it with:
 openclawbrain daemon --state ~/.openclawbrain/main/state.json
 ```
 
+Embedding mode defaults to `--embed-model auto`:
+- For `hash-v1` state metadata, daemon queries use hash embeddings (offline-safe).
+- For non-hash metadata, daemon queries use OpenAI embeddings (`text-embedding-3-small`).
+- Use `--embed-model hash` to force hash embeddings, or pass a model name to force OpenAI.
+
 Protocol:
 
 - Transport: `stdin`/`stdout` with newline-delimited JSON (NDJSON).

--- a/openclawbrain/cli.py
+++ b/openclawbrain/cli.py
@@ -243,7 +243,7 @@ def _build_parser() -> argparse.ArgumentParser:
 
     d = sub.add_parser("daemon")
     d.add_argument("--state")
-    d.add_argument("--embed-model", default="text-embedding-3-small")
+    d.add_argument("--embed-model", default="auto")
     d.add_argument("--auto-save-interval", type=int, default=10)
 
     serve = sub.add_parser("serve", help="Run the OpenClawBrain socket service in the foreground")

--- a/openclawbrain/socket_server.py
+++ b/openclawbrain/socket_server.py
@@ -20,7 +20,7 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(prog="openclawbrain.socket_server")
     parser.add_argument("--state", required=True)
     parser.add_argument("--socket-path")
-    parser.add_argument("--embed-model", default="text-embedding-3-small")
+    parser.add_argument("--embed-model", default="auto")
     parser.add_argument("--auto-save-interval", type=int, default=10)
     parser.add_argument("--force", action="store_true", help="Bypass state lock (expert use)")
     parser.add_argument("--verbose", action="store_true", help="Enable verbose logging")


### PR DESCRIPTION
Fixes OOTB daemon queries for hash-based states by changing default embed behavior to auto-detect from `state.json` metadata.

## Problem
If a state was built with `--embedder hash` (dim=1024), running `openclawbrain daemon` previously defaulted to OpenAI embeddings (`text-embedding-3-small`, dim=1536), causing:
- `query embedding dimension mismatch: expected 1024, got 1536`

This also broke `route_mode=edge+sim` unless operators found a workaround.

## Fix
- Default `--embed-model` is now `auto` (daemon + socket_server + CLI passthrough).
- Resolution logic:
  - `auto`: if `meta.embedder_name == "hash-v1"` → use hash embedder (offline-safe)
  - otherwise → use OpenAI embeddings (`text-embedding-3-small`)
  - `hash`: force hash embedder
  - any other string: treat as OpenAI embedding model name
- On `reload`, daemon re-resolves the embedder from the newly loaded state.

## Tests
- Added unit tests for `_resolve_embed_fn`.
- `PYTHONPATH=. pytest -q` → 374 passed.

## Docs
- README and CHANGELOG updated.
