### PR TITLE
PR1: introduce protocol/policy boundaries and refactor daemon query routing

### DIFF
--- a/docs/shadow-routing-upg-architecture.md
+++ b/docs/shadow-routing-upg-architecture.md
@@ -1,0 +1,44 @@
+# Shadow Routing + Ultimate Policy Gradient (PR 1)
+
+This PR introduces explicit protocol and policy boundaries without changing CLI/API behavior.
+
+## Two timescales
+
+- Runtime fast path: synchronous daemon query handling (`query`) with deterministic retrieval and routing decisions.
+- Async teacher updates: background/ops flows (`async_route_pg` and related maintenance/learning tasks) that improve edge policy over time.
+
+The runtime path must remain low-latency and deterministic. Teacher updates can be slower and can aggregate broader evidence.
+
+## Route function contracts
+
+- `runtime_route_fn`: deterministic function used during traversal to rank habitual edge candidates for a single query.
+  - Inputs: source id, candidate edges, query text.
+  - Behavior: deterministic sort by score, then target id tie-break.
+  - Ownership: `openclawbrain.policy.make_runtime_route_fn`.
+
+- `async_route_fn`: teacher-side policy update behavior (outside this PR), used to adjust route behavior based on delayed outcomes.
+  - Inputs/outputs may evolve with teacher signals and reward decomposition.
+  - Must not break runtime determinism contract.
+
+## Why protocol + policy modules
+
+- `openclawbrain.protocol`:
+  - Adds versioned request/response helpers and typed query parameter parsing (`QueryRequest`, `QueryParams`, `QueryResponse`).
+  - Centralizes validation and conversion from raw dicts.
+  - Keeps error semantics deterministic and consistent.
+
+- `openclawbrain.policy`:
+  - Isolates routing policy shape (`RoutingPolicy`) from daemon request handling.
+  - Encapsulates deterministic runtime routing function construction.
+  - Makes policy behavior testable without daemon process setup.
+
+This split keeps daemon focused on orchestration, while protocol and policy remain independently testable modules.
+
+## Next PRs
+
+- Reward-source weighting:
+  - Separate reward channels (user correction, task success, explicit directives) with configurable weighting.
+- Traces and decision-point schema:
+  - Add structured trace artifacts for route decisions and teacher supervision.
+- Storage boundary:
+  - Introduce clearer persistence interfaces so runtime state and async training state can evolve independently.

--- a/openclawbrain/policy.py
+++ b/openclawbrain/policy.py
@@ -1,0 +1,86 @@
+"""Deterministic runtime routing policy for daemon traversal."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+from .index import VectorIndex
+from .protocol import parse_float, parse_int, parse_route_mode
+
+
+@dataclass(frozen=True)
+class RoutingPolicy:
+    """Runtime edge routing options for habitual traversal."""
+
+    route_mode: str = "off"
+    top_k: int = 5
+    alpha_sim: float = 0.5
+    use_relevance: bool = True
+
+    @classmethod
+    def from_values(
+        cls,
+        *,
+        route_mode: object,
+        top_k: object,
+        alpha_sim: object,
+        use_relevance: object,
+    ) -> "RoutingPolicy":
+        """Validate and normalize policy fields."""
+        return cls(
+            route_mode=parse_route_mode(route_mode),
+            top_k=parse_int(top_k, "route_top_k", default=5),
+            alpha_sim=parse_float(alpha_sim, "route_alpha_sim", default=0.5),
+            use_relevance=True if use_relevance is None else _parse_use_relevance(use_relevance),
+        )
+
+
+
+def _parse_use_relevance(value: object) -> bool:
+    if not isinstance(value, bool):
+        raise ValueError("route_use_relevance must be a boolean")
+    return value
+
+
+
+def make_runtime_route_fn(
+    *,
+    policy: RoutingPolicy,
+    query_vector: list[float],
+    index: VectorIndex,
+) -> Callable[[str | None, list[object], str], list[str]] | None:
+    """Build deterministic local route policy for habitual candidates."""
+    if policy.route_mode == "off":
+        return None
+
+    use_similarity = policy.route_mode == "edge+sim"
+
+    def _score(edge: object) -> float:
+        # `traverse` passes graph.Edge values; keep this function generic for tests.
+        weight = float(getattr(edge, "weight", 0.0))
+        relevance = 0.0
+        if policy.use_relevance:
+            metadata = getattr(edge, "metadata", None)
+            if isinstance(metadata, dict):
+                raw_relevance = metadata.get("relevance", 0.0)
+                if isinstance(raw_relevance, (int, float)):
+                    relevance = float(raw_relevance)
+
+        similarity = 0.0
+        if use_similarity:
+            target_id = str(getattr(edge, "target", ""))
+            target_vector = index._vectors.get(target_id)
+            if target_vector is not None:
+                similarity = VectorIndex.cosine(query_vector, target_vector)
+
+        return weight + relevance + (policy.alpha_sim * similarity)
+
+    def _route_fn(_source_id: str | None, candidates: list[object], _query_text: str) -> list[str]:
+        ranked = sorted(
+            ((str(getattr(edge, "target", "")), _score(edge)) for edge in candidates),
+            key=lambda item: (-item[1], item[0]),
+        )
+        return [target_id for target_id, _score_value in ranked[: policy.top_k] if target_id]
+
+    return _route_fn

--- a/openclawbrain/protocol.py
+++ b/openclawbrain/protocol.py
@@ -1,0 +1,221 @@
+"""Versioned protocol helpers for daemon NDJSON requests/responses."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+ROUTE_MODES = {"off", "edge", "edge+sim"}
+PROTOCOL_VERSION = "v1"
+
+
+
+def parse_int(value: object, label: str, default: int | None = None, min_value: int = 1) -> int:
+    """Validate integer input."""
+    if value is None:
+        if default is None:
+            raise ValueError(f"{label} is required")
+        return default
+    if not isinstance(value, int):
+        raise ValueError(f"{label} must be an integer")
+    if value < min_value:
+        raise ValueError(f"{label} must be >= {min_value}")
+    return value
+
+
+
+def parse_float(value: object, label: str, required: bool = False, default: float | None = None) -> float:
+    """Validate float input."""
+    if value is None:
+        if not required:
+            if default is None:
+                raise ValueError(f"{label} is required")
+            return default
+        raise ValueError(f"{label} is required")
+    if not isinstance(value, (int, float)):
+        raise ValueError(f"{label} must be a number")
+    return float(value)
+
+
+
+def parse_bool(value: object, label: str, *, default: bool) -> bool:
+    """Validate boolean input with a default."""
+    if value is None:
+        return default
+    if not isinstance(value, bool):
+        raise ValueError(f"{label} must be a boolean")
+    return value
+
+
+
+def parse_route_mode(value: object) -> str:
+    """Validate route mode."""
+    if value is None:
+        return "off"
+    if not isinstance(value, str):
+        raise ValueError("route_mode must be one of: off, edge, edge+sim")
+    mode = value.strip().lower()
+    if mode not in ROUTE_MODES:
+        raise ValueError("route_mode must be one of: off, edge, edge+sim")
+    return mode
+
+
+
+def parse_str_list(value: object, label: str, required: bool = True) -> list[str]:
+    """Parse a JSON list of non-empty strings."""
+    if value is None:
+        if required:
+            raise ValueError(f"{label} is required")
+        return []
+    if not isinstance(value, list):
+        raise ValueError(f"{label} must be a list")
+    entries: list[str] = []
+    for item in value:
+        if not isinstance(item, str) or not item.strip():
+            raise ValueError(f"{label} must only contain non-empty strings")
+        entries.append(item)
+    if not entries and required:
+        raise ValueError(f"{label} must not be empty")
+    return entries
+
+
+
+def parse_chat_id(value: object, label: str, required: bool = True) -> str | None:
+    """Parse optional chat_id with non-empty normalization."""
+    if value is None:
+        if required:
+            raise ValueError(f"{label} is required")
+        return None
+    if not isinstance(value, str):
+        raise ValueError(f"{label} must be a string")
+    normalized = value.strip()
+    if required and not normalized:
+        raise ValueError(f"{label} is required")
+    return normalized if normalized else None
+
+
+@dataclass(frozen=True)
+class QueryParams:
+    """Typed query params used by daemon query routing/execution."""
+
+    query: str
+    top_k: int = 4
+    max_prompt_context_chars: int = 30000
+    max_context_chars: int = 30000
+    max_fired_nodes: int = 30
+    route_mode: str = "off"
+    route_top_k: int = 5
+    route_alpha_sim: float = 0.5
+    route_use_relevance: bool = True
+    prompt_context_include_node_ids: bool = True
+    exclude_files: tuple[str, ...] = ()
+    exclude_file_prefixes: tuple[str, ...] = ()
+    chat_id: str | None = None
+
+    @classmethod
+    def from_dict(cls, params: dict[str, object]) -> "QueryParams":
+        """Build validated params from raw JSON dict."""
+        query_text = params.get("query")
+        if not isinstance(query_text, str) or not query_text.strip():
+            raise ValueError("query must be a non-empty string")
+
+        top_k = parse_int(params.get("top_k"), "top_k", default=4)
+
+        max_prompt_chars = params.get("max_prompt_context_chars")
+        if not isinstance(max_prompt_chars, int):
+            max_prompt_chars = 30000
+
+        max_context_chars = params.get("max_context_chars")
+        if not isinstance(max_context_chars, int):
+            max_context_chars = max_prompt_chars
+
+        return cls(
+            query=query_text,
+            top_k=top_k,
+            max_prompt_context_chars=max_prompt_chars,
+            max_context_chars=max_context_chars,
+            max_fired_nodes=parse_int(params.get("max_fired_nodes"), "max_fired_nodes", default=30),
+            route_mode=parse_route_mode(params.get("route_mode")),
+            route_top_k=parse_int(params.get("route_top_k"), "route_top_k", default=5),
+            route_alpha_sim=parse_float(params.get("route_alpha_sim"), "route_alpha_sim", default=0.5),
+            route_use_relevance=parse_bool(params.get("route_use_relevance"), "route_use_relevance", default=True),
+            prompt_context_include_node_ids=parse_bool(
+                params.get("prompt_context_include_node_ids"),
+                "prompt_context_include_node_ids",
+                default=True,
+            ),
+            exclude_files=tuple(parse_str_list(params.get("exclude_files"), "exclude_files", required=False)),
+            exclude_file_prefixes=tuple(
+                parse_str_list(params.get("exclude_file_prefixes"), "exclude_file_prefixes", required=False)
+            ),
+            chat_id=parse_chat_id(params.get("chat_id"), "chat_id", required=False),
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        """Convert to JSON-serializable dict."""
+        return {
+            "query": self.query,
+            "top_k": self.top_k,
+            "max_prompt_context_chars": self.max_prompt_context_chars,
+            "max_context_chars": self.max_context_chars,
+            "max_fired_nodes": self.max_fired_nodes,
+            "route_mode": self.route_mode,
+            "route_top_k": self.route_top_k,
+            "route_alpha_sim": self.route_alpha_sim,
+            "route_use_relevance": self.route_use_relevance,
+            "prompt_context_include_node_ids": self.prompt_context_include_node_ids,
+            "exclude_files": list(self.exclude_files),
+            "exclude_file_prefixes": list(self.exclude_file_prefixes),
+            "chat_id": self.chat_id,
+        }
+
+
+@dataclass(frozen=True)
+class QueryRequest:
+    """Versioned daemon request wrapper for query calls."""
+
+    id: object
+    method: str
+    params: dict[str, object]
+    protocol_version: str = PROTOCOL_VERSION
+
+    @classmethod
+    def from_dict(cls, request: object) -> "QueryRequest":
+        """Parse and validate one daemon request envelope."""
+        if not isinstance(request, dict):
+            raise ValueError("request must be a JSON object")
+        req_id = request.get("id")
+        method = request.get("method")
+        params = request.get("params", {})
+        if not isinstance(params, dict):
+            raise ValueError("params must be a JSON object")
+        if not isinstance(method, str):
+            raise ValueError("method must be a string")
+        return cls(id=req_id, method=method, params=params)
+
+    def query_params(self) -> QueryParams:
+        """Parse query params using protocol v1 schema."""
+        return QueryParams.from_dict(self.params)
+
+
+@dataclass(frozen=True)
+class QueryResponse:
+    """Versioned daemon response envelope for query and other methods."""
+
+    id: object
+    result: object | None = None
+    error: dict[str, object] | None = None
+    protocol_version: str = PROTOCOL_VERSION
+
+    def __post_init__(self) -> None:
+        has_result = self.result is not None
+        has_error = self.error is not None
+        if has_result and has_error:
+            raise ValueError("response cannot include both result and error")
+        if not has_result and not has_error:
+            raise ValueError("response must include result or error")
+
+    def to_dict(self) -> dict[str, object]:
+        """Convert envelope to NDJSON-compatible dict."""
+        if self.error is not None:
+            return {"id": self.id, "error": self.error}
+        return {"id": self.id, "result": self.result}

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from openclawbrain import Edge, VectorIndex
+from openclawbrain.policy import RoutingPolicy, make_runtime_route_fn
+
+
+def test_make_runtime_route_fn_off_returns_none() -> None:
+    index = VectorIndex()
+    route_fn = make_runtime_route_fn(policy=RoutingPolicy(route_mode="off"), query_vector=[1.0], index=index)
+    assert route_fn is None
+
+
+def test_make_runtime_route_fn_edge_sim_is_deterministic_with_tiebreak() -> None:
+    index = VectorIndex()
+    index.upsert("a", [1.0, 0.0])
+    index.upsert("b", [1.0, 0.0])
+    index.upsert("c", [0.0, 1.0])
+
+    route_fn = make_runtime_route_fn(
+        policy=RoutingPolicy(route_mode="edge+sim", top_k=2, alpha_sim=0.5, use_relevance=True),
+        query_vector=[1.0, 0.0],
+        index=index,
+    )
+    assert route_fn is not None
+
+    candidates = [
+        Edge("src", "b", weight=0.4, metadata={"relevance": 0.0}),
+        Edge("src", "a", weight=0.4, metadata={"relevance": 0.0}),
+        Edge("src", "c", weight=0.4, metadata={"relevance": 0.0}),
+    ]
+
+    chosen_first = route_fn("src", candidates, "q")
+    chosen_second = route_fn("src", list(reversed(candidates)), "q")
+
+    assert chosen_first == ["a", "b"]
+    assert chosen_second == ["a", "b"]
+
+
+def test_make_runtime_route_fn_edge_mode_ignores_similarity() -> None:
+    index = VectorIndex()
+    index.upsert("high-sim", [1.0, 0.0])
+    index.upsert("low-sim", [0.0, 1.0])
+
+    route_fn = make_runtime_route_fn(
+        policy=RoutingPolicy(route_mode="edge", top_k=1, alpha_sim=100.0, use_relevance=False),
+        query_vector=[1.0, 0.0],
+        index=index,
+    )
+    assert route_fn is not None
+
+    candidates = [
+        Edge("src", "high-sim", weight=0.1),
+        Edge("src", "low-sim", weight=0.9),
+    ]
+    assert route_fn("src", candidates, "q") == ["low-sim"]

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import pytest
+
+from openclawbrain.protocol import QueryParams, QueryRequest, QueryResponse
+
+
+def test_query_request_from_dict_parses_envelope() -> None:
+    request = QueryRequest.from_dict({"id": "1", "method": "query", "params": {"query": "alpha"}})
+    assert request.id == "1"
+    assert request.method == "query"
+    assert request.params == {"query": "alpha"}
+
+
+def test_query_request_from_dict_validates_shape() -> None:
+    with pytest.raises(ValueError, match="request must be a JSON object"):
+        QueryRequest.from_dict("bad")
+
+    with pytest.raises(ValueError, match="params must be a JSON object"):
+        QueryRequest.from_dict({"id": 1, "method": "query", "params": []})
+
+    with pytest.raises(ValueError, match="method must be a string"):
+        QueryRequest.from_dict({"id": 1, "method": None, "params": {}})
+
+
+def test_query_params_defaults_follow_daemon_behavior() -> None:
+    params = QueryParams.from_dict({"query": "alpha"})
+    assert params.query == "alpha"
+    assert params.top_k == 4
+    assert params.max_prompt_context_chars == 30000
+    assert params.max_context_chars == 30000
+    assert params.max_fired_nodes == 30
+    assert params.route_mode == "off"
+    assert params.route_top_k == 5
+    assert params.route_alpha_sim == 0.5
+    assert params.route_use_relevance is True
+    assert params.prompt_context_include_node_ids is True
+    assert params.exclude_files == ()
+    assert params.exclude_file_prefixes == ()
+    assert params.chat_id is None
+
+
+def test_query_params_max_context_defaults_to_prompt_chars() -> None:
+    params = QueryParams.from_dict({"query": "alpha", "max_prompt_context_chars": 777})
+    assert params.max_prompt_context_chars == 777
+    assert params.max_context_chars == 777
+
+
+def test_query_params_validation_errors() -> None:
+    with pytest.raises(ValueError, match="query must be a non-empty string"):
+        QueryParams.from_dict({"query": ""})
+
+    with pytest.raises(ValueError, match="top_k must be an integer"):
+        QueryParams.from_dict({"query": "x", "top_k": "2"})
+
+    with pytest.raises(ValueError, match=r"route_mode must be one of: off, edge, edge\+sim"):
+        QueryParams.from_dict({"query": "x", "route_mode": "bad"})
+
+    with pytest.raises(ValueError, match="route_use_relevance must be a boolean"):
+        QueryParams.from_dict({"query": "x", "route_use_relevance": "yes"})
+
+
+def test_query_response_to_dict_result_and_error() -> None:
+    ok = QueryResponse(id="1", result={"x": 1}).to_dict()
+    assert ok == {"id": "1", "result": {"x": 1}}
+
+    err = QueryResponse(id="1", error={"code": -1, "message": "bad"}).to_dict()
+    assert err == {"id": "1", "error": {"code": -1, "message": "bad"}}
+
+    with pytest.raises(ValueError, match="response must include result or error"):
+        QueryResponse(id="1")


### PR DESCRIPTION
## Summary
This is PR 1 of the incremental rearchitecture around shadow routing + ultimate policy gradient, focused on clean runtime boundaries with no CLI/API breakage.

### What changed
- Added `openclawbrain.protocol` (v1 helpers):
  - `QueryRequest` envelope parsing for daemon NDJSON requests.
  - `QueryParams` typed query schema/validation (`route_mode`, `route_top_k`, `route_alpha_sim`, `route_use_relevance`, `max_fired_nodes`, etc.).
  - `QueryResponse` envelope helper for deterministic result/error serialization.
  - Kept validation error strings identical where previously defined; otherwise made parsing errors more explicit in one place.

- Added `openclawbrain.policy`:
  - `RoutingPolicy` dataclass (`route_mode`, `top_k`, `alpha_sim`, `use_relevance`).
  - `make_runtime_route_fn(...)` that builds the deterministic habitual-edge route function.
  - Preserves deterministic tie-break behavior (score desc, target id asc).

- Refactored `openclawbrain/daemon.py`:
  - Request parsing now uses protocol envelope helper.
  - Query params now parsed through `QueryParams.from_dict(...)`.
  - Runtime route_fn now built via policy module.
  - Response emission now uses protocol response helper.
  - Added a thin compatibility wrapper for `_build_query_route_fn` to avoid churn in existing tests/internal callers.

- Added docs: `docs/shadow-routing-upg-architecture.md`
  - Two timescales: runtime fast path vs async teacher updates.
  - `runtime_route_fn` vs `async_route_fn` contracts.
  - Why protocol/policy boundaries are introduced now.
  - Next PR directions (reward-source weighting, traces/decision-point schema, storage boundary).

- Added tests:
  - `tests/test_protocol.py`
  - `tests/test_policy.py`

## Compatibility / behavior
- No external dependencies added.
- Determinism preserved for runtime routing decisions.
- Public CLI/API behavior remains stable; daemon method names and response envelope shape remain unchanged (`{id, result}` / `{id, error}`).

## Validation
- Full test suite passes:
  - `383 passed in 6.25s`
