### PR TITLE
Add route-mode params support to socket client and OpenClaw adapter query

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,20 @@ ExecStart=/usr/bin/env openclawbrain serve --state /home/YOUR_USER/.openclawbrai
 python3 -m openclawbrain.socket_client --socket ~/.openclawbrain/main/daemon.sock --method health --params "{}"
 ```
 
+OpenClaw adapter query example with runtime routing (`route_mode=edge+sim`):
+
+```bash
+python3 -m openclawbrain.openclaw_adapter.query_brain \
+  ~/.openclawbrain/main/state.json \
+  "summarize prior deploy failures" \
+  --chat-id "chat-123" \
+  --format prompt \
+  --route-mode edge+sim \
+  --route-top-k 5 \
+  --route-alpha-sim 0.5 \
+  --route-use-relevance
+```
+
 **OpenClawBrain learns from your agent feedback, so wrong answers get suppressed instead of resurfacing.** It builds a memory graph over your workspace, remembers what worked, and routes future answers through learned paths.
 
 - Pure Python 3.10+ core (no vector DB). The package currently installs the OpenAI SDK by default; hash-embedder mode runs offline.

--- a/docs/openclaw-integration.md
+++ b/docs/openclaw-integration.md
@@ -171,6 +171,11 @@ python3 -m openclawbrain.openclaw_adapter.query_brain ~/.openclawbrain/AGENT/sta
 ```
 Always pass `--chat-id` so fired nodes are logged for later learning/corrections.
 Use `--exclude-recent-memory <today-note> <yesterday-note>` only when those files are already loaded by OpenClaw in the same prompt and you want to avoid duplication.
+To enable runtime route policy in daemon mode, use:
+```bash
+python3 -m openclawbrain.openclaw_adapter.query_brain ~/.openclawbrain/AGENT/state.json '<summary of user message>' --chat-id '<chat_id from inbound metadata>' --format prompt --route-mode edge+sim --route-top-k 5 --route-alpha-sim 0.5 --route-use-relevance
+```
+`--route-*` flags are daemon-query controls; local `state.json` fallback keeps existing traversal behavior.
 
 **Capture feedback** (canonical always-on path; same turn, no "log this" phrasing needed):
 ```bash

--- a/tests/test_socket_client_cli.py
+++ b/tests/test_socket_client_cli.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from openclawbrain import socket_client as socket_client_module
+
+
+def test_socket_client_query_method_includes_route_params(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    class FakeClient:
+        def __init__(self, socket_path: str, timeout: float = 30.0) -> None:
+            captured["socket_path"] = socket_path
+            captured["timeout"] = timeout
+
+        def __enter__(self) -> "FakeClient":
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+        def request(self, method: str, params: dict[str, object] | None = None) -> dict[str, object]:
+            captured["method"] = method
+            captured["params"] = dict(params or {})
+            return {"ok": True}
+
+    monkeypatch.setattr(socket_client_module, "OCBClient", FakeClient)
+
+    code = socket_client_module._main(
+        [
+            "--socket",
+            "/tmp/daemon.sock",
+            "--method",
+            "query",
+            "--params",
+            '{"query":"alpha","top_k":3}',
+            "--route-mode",
+            "edge+sim",
+            "--route-top-k",
+            "8",
+            "--route-alpha-sim",
+            "0.2",
+            "--no-route-use-relevance",
+        ]
+    )
+
+    assert code == 0
+    assert captured["socket_path"] == "/tmp/daemon.sock"
+    assert captured["method"] == "query"
+    assert captured["params"] == {
+        "query": "alpha",
+        "top_k": 3,
+        "route_mode": "edge+sim",
+        "route_top_k": 8,
+        "route_alpha_sim": 0.2,
+        "route_use_relevance": False,
+    }
+
+
+def test_socket_client_non_query_method_does_not_add_route_params(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    class FakeClient:
+        def __init__(self, socket_path: str, timeout: float = 30.0) -> None:
+            captured["socket_path"] = socket_path
+            captured["timeout"] = timeout
+
+        def __enter__(self) -> "FakeClient":
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+        def request(self, method: str, params: dict[str, object] | None = None) -> dict[str, object]:
+            captured["method"] = method
+            captured["params"] = dict(params or {})
+            return {"status": "ok"}
+
+    monkeypatch.setattr(socket_client_module, "OCBClient", FakeClient)
+
+    code = socket_client_module._main(
+        [
+            "--socket",
+            "/tmp/daemon.sock",
+            "--method",
+            "health",
+            "--params",
+            "{}",
+        ]
+    )
+
+    assert code == 0
+    assert captured["socket_path"] == "/tmp/daemon.sock"
+    assert captured["method"] == "health"
+    assert captured["params"] == {}


### PR DESCRIPTION
## Summary
- add `route_mode`, `route_top_k`, `route_alpha_sim`, and `route_use_relevance` support to `openclawbrain.socket_client` query calls and CLI
- add `--route-mode`, `--route-top-k`, `--route-alpha-sim`, and `--route-use-relevance/--no-route-use-relevance` flags to `openclawbrain.openclaw_adapter.query_brain` and pass them through in daemon/socket mode
- document runtime route usage with copy/paste `query_brain` examples in `docs/openclaw-integration.md` and `README.md`
- add tests to verify route params are forwarded to daemon requests (monkeypatched, no network)

## Testing
- `PYTHONPATH=. pytest -q`
