### PR TITLE
MEGA rearchitecture: learned runtime routing + storage boundary + unified labels

### DIFF
--- a/docs/core-thesis-ultimate-policy-gradient.md
+++ b/docs/core-thesis-ultimate-policy-gradient.md
@@ -140,8 +140,13 @@ The new async teacher + PG loop makes these mechanisms smarter by producing:
 ### Milestone 1 (shipped)
 - `route_mode=edge+sim`: runtime query-conditioned routing based on embeddings + learned weights + relevance
 
+### Milestone 2 (shipped)
+- Explicit reward-source weighting (`openclawbrain.reward.RewardWeights`) across human/self/harvester/teacher.
+- Replayable route traces in `openclawbrain.trace` + unified labels in `openclawbrain.labels`.
+- Learned runtime route policy in `openclawbrain.route_model` + `route_mode=learned`.
+- Storage boundary interfaces in `openclawbrain.storage` for state/event persistence.
+
 ### Next milestones
-- Add explicit reward-source weighting (human/self/harvester/teacher) as first-class inputs.
 - Add an eval harness that measures: token count, turn count, and retrieval correctness.
 - Add shortcut/pointer edge creation offline (teacher-assisted connect during maintain).
 
@@ -150,7 +155,7 @@ The new async teacher + PG loop makes these mechanisms smarter by producing:
 ## How to run (operator sketch)
 1) Run `async-route-pg` in dry-run and inspect JSON deltas.
 2) Apply to a copied state first.
-3) Enable runtime `route_mode=edge+sim` and compare context size + turn count.
+3) Train `route_model.npz` from traces/labels and enable runtime `route_mode=learned`.
 
 ---
 

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -408,3 +408,43 @@ Why this avoids drift:
 - `sync_registry` writes one canonical registry under `~/.openclaw/credentials/registry`.
 - Each workspace `docs/secret-pointers.md` and `docs/capabilities.md` becomes a symlink to that canonical file.
 - Any refresh updates all workspaces at once because they all reference the same target.
+
+## 17) Learned route model recipe
+
+Generate traces with query vectors:
+
+```bash
+openclawbrain async-route-pg \
+  --state ~/.openclawbrain/main/state.json \
+  --teacher none \
+  --traces-out ~/.openclawbrain/main/route_traces.jsonl \
+  --include-query-vector
+```
+
+Train and save model:
+
+```bash
+openclawbrain train-route-model \
+  --state ~/.openclawbrain/main/state.json \
+  --traces-in ~/.openclawbrain/main/route_traces.jsonl \
+  --labels-in ~/.openclawbrain/main/route_labels.jsonl \
+  --out ~/.openclawbrain/main/route_model.npz \
+  --rank 16 \
+  --epochs 3 \
+  --lr 0.01 \
+  --label-temp 0.5 \
+  --json
+```
+
+Enable at runtime:
+
+```bash
+openclawbrain daemon \
+  --state ~/.openclawbrain/main/state.json \
+  --route-mode learned \
+  --route-model ~/.openclawbrain/main/route_model.npz
+```
+
+Optional exports during replay/harvest:
+- `openclawbrain replay --traces-out ... --labels-out ...`
+- `openclawbrain harvest --traces-out ... --labels-out ...`

--- a/docs/shadow-routing-upg-architecture.md
+++ b/docs/shadow-routing-upg-architecture.md
@@ -84,3 +84,23 @@ Determinism contract:
 5. Apply PG updates using weighted reward scaling.
 
 This split decouples trajectory sampling from supervision so label policies can be rerun deterministically against fixed decision-point sets.
+
+## Mega rearchitecture addendum
+
+New modules and boundaries:
+- `openclawbrain.storage`: state/event persistence interfaces (`StateStore`, `EventStore`) with JSON implementations.
+- `openclawbrain.route_model`: low-rank learned policy scorer with NPZ save/load.
+- `openclawbrain.labels`: unified `LabelRecord` for teacher/human/self supervision.
+
+Runtime learned mode:
+- `route_mode=learned` uses `policy.make_learned_route_fn`.
+- Edge feature vector is `[edge_weight, edge_relevance, 1.0]`.
+- Route scoring is deterministic top-k via model logits with target-id tie-breaks.
+
+Trace/schema updates:
+- `RouteTrace` now supports optional `query_vector`.
+- `async-route-pg --include-query-vector` can emit query vectors into trace JSONL.
+
+Training CLI:
+- `openclawbrain train-route-model --state ... --traces-in ... --out ...`
+- Numpy-only SGD over cross-entropy against teacher/human/self label distributions.

--- a/openclawbrain/labels.py
+++ b/openclawbrain/labels.py
@@ -1,0 +1,136 @@
+"""Unified label records across human/self/teacher supervision sources."""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from .reward import RewardSource
+
+
+@dataclass(frozen=True)
+class LabelRecord:
+    query_id: str
+    decision_point_idx: int
+    candidate_scores: dict[str, float]
+    reward_source: RewardSource
+    weight: float
+    ts: float
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "query_id": self.query_id,
+            "decision_point_idx": int(self.decision_point_idx),
+            "candidate_scores": {str(k): float(v) for k, v in sorted(self.candidate_scores.items())},
+            "reward_source": self.reward_source.value,
+            "weight": float(self.weight),
+            "ts": float(self.ts),
+            "metadata": dict(self.metadata),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "LabelRecord":
+        scores_raw = payload.get("candidate_scores")
+        scores: dict[str, float] = {}
+        if isinstance(scores_raw, dict):
+            for key, value in scores_raw.items():
+                try:
+                    scores[str(key)] = float(value)
+                except (TypeError, ValueError):
+                    continue
+        return cls(
+            query_id=str(payload.get("query_id", "")),
+            decision_point_idx=int(payload.get("decision_point_idx", 0)),
+            candidate_scores=scores,
+            reward_source=RewardSource.parse(payload.get("reward_source"), default=RewardSource.TEACHER),
+            weight=float(payload.get("weight", 1.0)),
+            ts=float(payload.get("ts", 0.0)),
+            metadata=dict(payload.get("metadata", {})) if isinstance(payload.get("metadata"), dict) else {},
+        )
+
+
+def from_human_correction(event: dict[str, Any]) -> LabelRecord | None:
+    target_id = event.get("target_id") or event.get("correct_target_id")
+    if not isinstance(target_id, str) or not target_id:
+        return None
+    query_id = str(event.get("query_id", event.get("chat_id", "")))
+    point_idx = int(event.get("decision_point_idx", 0))
+    score = float(event.get("score", 1.0))
+    return LabelRecord(
+        query_id=query_id,
+        decision_point_idx=point_idx,
+        candidate_scores={target_id: score},
+        reward_source=RewardSource.HUMAN,
+        weight=float(event.get("weight", 1.0)),
+        ts=float(event.get("ts", time.time())),
+        metadata={"kind": "human_correction", **(event.get("metadata", {}) if isinstance(event.get("metadata"), dict) else {})},
+    )
+
+
+def from_self_learning_event(event: dict[str, Any]) -> LabelRecord | None:
+    fired = event.get("fired_ids") or event.get("fired")
+    if not isinstance(fired, list) or not fired:
+        return None
+    candidate_scores = {
+        str(node_id): float(event.get("outcome", -1.0))
+        for node_id in fired
+        if isinstance(node_id, str) and node_id
+    }
+    if not candidate_scores:
+        return None
+    return LabelRecord(
+        query_id=str(event.get("query_id", event.get("chat_id", ""))),
+        decision_point_idx=int(event.get("decision_point_idx", 0)),
+        candidate_scores=candidate_scores,
+        reward_source=RewardSource.SELF,
+        weight=float(event.get("weight", 1.0)),
+        ts=float(event.get("ts", time.time())),
+        metadata={"kind": "self_learning", **(event.get("metadata", {}) if isinstance(event.get("metadata"), dict) else {})},
+    )
+
+
+def from_teacher_output(
+    *,
+    query_id: str,
+    decision_point_idx: int,
+    teacher_scores: dict[str, float],
+    ts: float | None = None,
+    weight: float = 1.0,
+    metadata: dict[str, Any] | None = None,
+) -> LabelRecord:
+    return LabelRecord(
+        query_id=query_id,
+        decision_point_idx=decision_point_idx,
+        candidate_scores={str(k): float(v) for k, v in teacher_scores.items()},
+        reward_source=RewardSource.TEACHER,
+        weight=float(weight),
+        ts=float(ts if ts is not None else time.time()),
+        metadata=dict(metadata or {}),
+    )
+
+
+def write_labels_jsonl(path: str | Path, records: list[LabelRecord]) -> None:
+    destination = Path(path).expanduser()
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with destination.open("w", encoding="utf-8") as handle:
+        for record in records:
+            handle.write(json.dumps(record.to_dict(), ensure_ascii=True, sort_keys=True) + "\n")
+
+
+def read_labels_jsonl(path: str | Path) -> list[LabelRecord]:
+    source = Path(path).expanduser()
+    if not source.exists():
+        return []
+    out: list[LabelRecord] = []
+    for line in source.read_text(encoding="utf-8").splitlines():
+        raw = line.strip()
+        if not raw:
+            continue
+        payload = json.loads(raw)
+        if isinstance(payload, dict):
+            out.append(LabelRecord.from_dict(payload))
+    return out

--- a/openclawbrain/protocol.py
+++ b/openclawbrain/protocol.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-ROUTE_MODES = {"off", "edge", "edge+sim"}
+ROUTE_MODES = {"off", "edge", "edge+sim", "learned"}
 PROTOCOL_VERSION = "v1"
 
 
@@ -52,10 +52,10 @@ def parse_route_mode(value: object) -> str:
     if value is None:
         return "off"
     if not isinstance(value, str):
-        raise ValueError("route_mode must be one of: off, edge, edge+sim")
+        raise ValueError("route_mode must be one of: off, edge, edge+sim, learned")
     mode = value.strip().lower()
     if mode not in ROUTE_MODES:
-        raise ValueError("route_mode must be one of: off, edge, edge+sim")
+        raise ValueError("route_mode must be one of: off, edge, edge+sim, learned")
     return mode
 
 

--- a/openclawbrain/route_model.py
+++ b/openclawbrain/route_model.py
@@ -1,0 +1,134 @@
+"""Low-rank learned routing model."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+
+from .index import VectorIndex
+
+
+@dataclass
+class RouteModel:
+    """Low-rank bilinear route scorer with edge-feature linear terms."""
+
+    r: int
+    A: np.ndarray
+    B: np.ndarray
+    w_feat: np.ndarray
+    b: float
+    T: float
+
+    @property
+    def dq(self) -> int:
+        return int(self.A.shape[0])
+
+    @property
+    def dt(self) -> int:
+        return int(self.B.shape[0])
+
+    @property
+    def df(self) -> int:
+        return int(self.w_feat.shape[0])
+
+    def project_query(self, q_vec: list[float] | np.ndarray) -> np.ndarray:
+        arr = np.asarray(q_vec, dtype=float)
+        if arr.ndim != 1:
+            raise ValueError("query vector must be 1D")
+        if arr.shape[0] == self.dq:
+            return arr @ self.A
+        if arr.shape[0] == self.r and self.dq != self.r:
+            return arr
+        raise ValueError(f"query vector length mismatch: expected {self.dq} or {self.r}, got {arr.shape[0]}")
+
+    def project_target(self, t_vec: list[float] | np.ndarray) -> np.ndarray:
+        arr = np.asarray(t_vec, dtype=float)
+        if arr.ndim != 1:
+            raise ValueError("target vector must be 1D")
+        if arr.shape[0] == self.dt:
+            return arr @ self.B
+        if arr.shape[0] == self.r and self.dt != self.r:
+            return arr
+        raise ValueError(f"target vector length mismatch: expected {self.dt} or {self.r}, got {arr.shape[0]}")
+
+    def score_projected(
+        self,
+        q_proj: list[float] | np.ndarray,
+        t_proj: list[float] | np.ndarray,
+        feat_vec: list[float] | np.ndarray,
+    ) -> float:
+        q_arr = np.asarray(q_proj, dtype=float)
+        t_arr = np.asarray(t_proj, dtype=float)
+        if q_arr.ndim != 1 or q_arr.shape[0] != self.r:
+            raise ValueError(f"projected query length mismatch: expected {self.r}, got {q_arr.shape[0] if q_arr.ndim == 1 else 'nd'}")
+        if t_arr.ndim != 1 or t_arr.shape[0] != self.r:
+            raise ValueError(f"projected target length mismatch: expected {self.r}, got {t_arr.shape[0] if t_arr.ndim == 1 else 'nd'}")
+        feat = np.asarray(feat_vec, dtype=float)
+        if feat.ndim != 1 or feat.shape[0] != self.df:
+            raise ValueError(f"feature vector length mismatch: expected {self.df}, got {feat.shape[0] if feat.ndim == 1 else 'nd'}")
+        denom = self.T if self.T > 0 else 1.0
+        value = float(np.dot(q_arr, t_arr) + np.dot(self.w_feat, feat) + float(self.b)) / denom
+        return float(value)
+
+    def score(
+        self,
+        q_vec: list[float] | np.ndarray,
+        t_vec: list[float] | np.ndarray,
+        feat_vec: list[float] | np.ndarray,
+    ) -> float:
+        q_proj = self.project_query(q_vec)
+        t_proj = self.project_target(t_vec)
+        return self.score_projected(q_proj, t_proj, feat_vec)
+
+    def save_npz(self, path: str | Path) -> None:
+        destination = Path(path).expanduser()
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        np.savez_compressed(
+            destination,
+            r=np.asarray(self.r, dtype=np.int64),
+            A=self.A,
+            B=self.B,
+            w_feat=self.w_feat,
+            b=np.asarray(self.b, dtype=float),
+            T=np.asarray(self.T, dtype=float),
+        )
+
+    @classmethod
+    def load_npz(cls, path: str | Path) -> "RouteModel":
+        payload = np.load(Path(path).expanduser(), allow_pickle=False)
+        return cls(
+            r=int(payload["r"]),
+            A=np.asarray(payload["A"], dtype=float),
+            B=np.asarray(payload["B"], dtype=float),
+            w_feat=np.asarray(payload["w_feat"], dtype=float),
+            b=float(payload["b"]),
+            T=max(1e-6, float(payload["T"])),
+        )
+
+    def precompute_target_projections(self, index: VectorIndex) -> dict[str, np.ndarray]:
+        projections: dict[str, np.ndarray] = {}
+        for node_id, vector in index._vectors.items():
+            try:
+                projections[str(node_id)] = self.project_target(vector)
+            except ValueError:
+                continue
+        return projections
+
+    @classmethod
+    def init_random(
+        cls,
+        dq: int,
+        dt: int,
+        df: int,
+        rank: int,
+    ) -> "RouteModel":
+        if dq <= 0 or dt <= 0 or df <= 0 or rank <= 0:
+            raise ValueError("dq, dt, df, and rank must be positive")
+        rng = np.random.default_rng(0)
+        scale = 0.01
+        A = rng.normal(0.0, scale, size=(dq, rank)).astype(float)
+        B = rng.normal(0.0, scale, size=(dt, rank)).astype(float)
+        w_feat = np.zeros(df, dtype=float)
+        return cls(r=int(rank), A=A, B=B, w_feat=w_feat, b=0.0, T=1.0)

--- a/openclawbrain/socket_client.py
+++ b/openclawbrain/socket_client.py
@@ -204,7 +204,7 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--method", required=True)
     parser.add_argument("--params", default="{}")
     parser.add_argument("--timeout", type=float, default=30.0)
-    parser.add_argument("--route-mode", choices=["off", "edge", "edge+sim"], default="off")
+    parser.add_argument("--route-mode", choices=["off", "edge", "edge+sim", "learned"], default="off")
     parser.add_argument("--route-top-k", type=int, default=5)
     parser.add_argument("--route-alpha-sim", type=float, default=0.5)
     parser.add_argument(

--- a/openclawbrain/storage/__init__.py
+++ b/openclawbrain/storage/__init__.py
@@ -1,0 +1,6 @@
+"""Storage boundary abstractions for state + event persistence."""
+
+from .event_store import EventStore, JsonlEventStore
+from .state_store import StateStore, JsonStateStore
+
+__all__ = ["EventStore", "JsonlEventStore", "StateStore", "JsonStateStore"]

--- a/openclawbrain/storage/event_store.py
+++ b/openclawbrain/storage/event_store.py
@@ -1,0 +1,53 @@
+"""Event journal interface and JSONL implementation."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from ..journal import log_event, read_journal
+
+
+class EventStore(ABC):
+    """Storage boundary for append-only event logs."""
+
+    @abstractmethod
+    def append(self, event: dict[str, object]) -> None:
+        """Append one event record."""
+
+    @abstractmethod
+    def iter_since(self, since_ts: float | None) -> list[dict[str, object]]:
+        """Return events with timestamp >= since_ts (or all events when None)."""
+
+    @abstractmethod
+    def read_last(self, n: int) -> list[dict[str, object]]:
+        """Read last n event records."""
+
+
+class JsonlEventStore(EventStore):
+    """EventStore implementation backed by existing journal helpers."""
+
+    def __init__(self, path: str) -> None:
+        self.path = path
+
+    def append(self, event: dict[str, object]) -> None:
+        log_event(dict(event), journal_path=self.path)
+
+    def iter_since(self, since_ts: float | None) -> list[dict[str, object]]:
+        entries = read_journal(journal_path=self.path)
+        if since_ts is None:
+            return [dict(entry) for entry in entries if isinstance(entry, dict)]
+        out: list[dict[str, object]] = []
+        cutoff = float(since_ts)
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            ts = entry.get("ts")
+            if isinstance(ts, (int, float)) and float(ts) >= cutoff:
+                out.append(dict(entry))
+        return out
+
+    def read_last(self, n: int) -> list[dict[str, object]]:
+        if n <= 0:
+            return []
+        entries = read_journal(journal_path=self.path, last_n=n)
+        return [dict(entry) for entry in entries if isinstance(entry, dict)]

--- a/openclawbrain/storage/state_store.py
+++ b/openclawbrain/storage/state_store.py
@@ -1,0 +1,45 @@
+"""State persistence interface and JSON implementation."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from ..graph import Graph
+from ..index import VectorIndex
+from ..store import load_state, save_state
+
+
+class StateStore(ABC):
+    """Storage boundary for loading/saving graph+index state."""
+
+    @abstractmethod
+    def load(self, path: str) -> tuple[Graph, VectorIndex, dict[str, object]]:
+        """Load state from the given path."""
+
+    @abstractmethod
+    def save(
+        self,
+        path: str,
+        *,
+        graph: Graph,
+        index: VectorIndex,
+        meta: dict[str, object] | None = None,
+    ) -> None:
+        """Persist state to the given path."""
+
+
+class JsonStateStore(StateStore):
+    """StateStore implementation backed by existing JSON helpers."""
+
+    def load(self, path: str) -> tuple[Graph, VectorIndex, dict[str, object]]:
+        return load_state(path)
+
+    def save(
+        self,
+        path: str,
+        *,
+        graph: Graph,
+        index: VectorIndex,
+        meta: dict[str, object] | None = None,
+    ) -> None:
+        save_state(graph=graph, index=index, path=path, meta=meta)

--- a/openclawbrain/trace.py
+++ b/openclawbrain/trace.py
@@ -125,6 +125,7 @@ class RouteTrace:
     traversal_config: dict[str, Any] = field(default_factory=dict)
     route_policy: dict[str, Any] = field(default_factory=dict)
     chat_id: str | None = None
+    query_vector: list[float] | None = None
     decision_points: list[RouteDecisionPoint] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, Any]:
@@ -137,6 +138,7 @@ class RouteTrace:
             "fired_nodes": list(self.fired_nodes),
             "traversal_config": dict(self.traversal_config),
             "route_policy": dict(self.route_policy),
+            "query_vector": list(self.query_vector) if self.query_vector is not None else None,
             "decision_points": [item.to_dict() for item in self.decision_points],
         }
 
@@ -159,6 +161,9 @@ class RouteTrace:
             fired_nodes=[str(item) for item in payload.get("fired_nodes", [])] if isinstance(payload.get("fired_nodes"), list) else [],
             traversal_config=dict(payload.get("traversal_config", {})) if isinstance(payload.get("traversal_config"), dict) else {},
             route_policy=dict(payload.get("route_policy", {})) if isinstance(payload.get("route_policy"), dict) else {},
+            query_vector=[float(item) for item in payload.get("query_vector", [])]
+            if isinstance(payload.get("query_vector"), list)
+            else None,
             decision_points=decision_points,
         )
 

--- a/openclawbrain/train_route_model.py
+++ b/openclawbrain/train_route_model.py
@@ -1,0 +1,297 @@
+"""Train low-rank learned routing model from traces + label records."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+
+from .labels import LabelRecord, read_labels_jsonl
+from .reward import RewardWeights
+from .route_model import RouteModel
+from .trace import RouteDecisionPoint, RouteTrace, route_trace_from_json
+from .store import load_state
+
+
+@dataclass(frozen=True)
+class TrainRouteModelSummary:
+    traces_path: str
+    labels_path: str | None
+    out_path: str
+    rank: int
+    epochs: int
+    lr: float
+    label_temp: float
+    points_total: int
+    points_used: int
+    initial_ce_loss: float
+    final_ce_loss: float
+    epoch_losses: list[float]
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "traces_path": self.traces_path,
+            "labels_path": self.labels_path,
+            "out_path": self.out_path,
+            "rank": self.rank,
+            "epochs": self.epochs,
+            "lr": self.lr,
+            "label_temp": self.label_temp,
+            "points_total": self.points_total,
+            "points_used": self.points_used,
+            "initial_ce_loss": self.initial_ce_loss,
+            "final_ce_loss": self.final_ce_loss,
+            "epoch_losses": list(self.epoch_losses),
+        }
+
+
+def _read_traces(path: str) -> list[RouteTrace]:
+    source = Path(path).expanduser()
+    traces: list[RouteTrace] = []
+    for line in source.read_text(encoding="utf-8").splitlines():
+        raw = line.strip()
+        if not raw:
+            continue
+        traces.append(route_trace_from_json(raw))
+    return traces
+
+
+def _softmax(logits: np.ndarray) -> np.ndarray:
+    stable = logits - np.max(logits)
+    exp = np.exp(stable)
+    denom = np.sum(exp)
+    if denom <= 0:
+        return np.ones_like(logits) / max(1, logits.shape[0])
+    return exp / denom
+
+
+def _labels_index(labels: list[LabelRecord]) -> dict[tuple[str, int], list[LabelRecord]]:
+    indexed: dict[tuple[str, int], list[LabelRecord]] = {}
+    for record in labels:
+        key = (record.query_id, int(record.decision_point_idx))
+        indexed.setdefault(key, []).append(record)
+    return indexed
+
+
+def _teacher_distribution(
+    trace: RouteTrace,
+    point_idx: int,
+    point: RouteDecisionPoint,
+    candidate_ids: list[str],
+    labels_by_key: dict[tuple[str, int], list[LabelRecord]],
+    *,
+    label_temp: float,
+    reward_weights: RewardWeights,
+) -> np.ndarray:
+    scores = {candidate_id: 0.0 for candidate_id in candidate_ids}
+
+    if point.teacher_scores:
+        for target_id, value in point.teacher_scores.items():
+            if target_id in scores:
+                scores[target_id] += float(value)
+    elif point.teacher_choose:
+        for target_id in point.teacher_choose:
+            if target_id in scores:
+                scores[target_id] += 1.0
+    elif point.chosen_target_id in scores:
+        scores[point.chosen_target_id] += 1.0
+
+    for record in labels_by_key.get((trace.query_id, point_idx), []):
+        source_weight = reward_weights.for_source(record.reward_source)
+        total_weight = float(record.weight) * float(source_weight)
+        for target_id, value in record.candidate_scores.items():
+            if target_id in scores:
+                scores[target_id] += total_weight * float(value)
+
+    score_vec = np.asarray([scores[candidate_id] for candidate_id in candidate_ids], dtype=float)
+    if np.allclose(score_vec, 0.0):
+        return np.ones(len(candidate_ids), dtype=float) / max(1, len(candidate_ids))
+    denom = max(1e-6, float(label_temp))
+    return _softmax(score_vec / denom)
+
+
+def _point_logits(
+    model: RouteModel,
+    query_vector: np.ndarray,
+    targets: list[np.ndarray],
+    features: list[np.ndarray],
+) -> tuple[np.ndarray, np.ndarray, list[np.ndarray]]:
+    q_proj = model.project_query(query_vector)
+    target_projs = [model.project_target(t_vec) for t_vec in targets]
+    logits = np.asarray([model.score_projected(q_proj, t_proj, feat_vec) for t_proj, feat_vec in zip(target_projs, features)], dtype=float)
+    return logits, q_proj, target_projs
+
+
+def _collect_points(
+    traces: list[RouteTrace],
+    index_vectors: dict[str, list[float]],
+) -> tuple[int, list[tuple[RouteTrace, int, RouteDecisionPoint, np.ndarray, list[np.ndarray], list[np.ndarray], list[str]]]]:
+    points_total = sum(len(trace.decision_points) for trace in traces)
+    points: list[tuple[RouteTrace, int, RouteDecisionPoint, np.ndarray, list[np.ndarray], list[np.ndarray], list[str]]] = []
+    for trace in traces:
+        if trace.query_vector is None:
+            continue
+        query_vector = np.asarray(trace.query_vector, dtype=float)
+        for point_idx, point in enumerate(trace.decision_points):
+            candidate_ids: list[str] = []
+            targets: list[np.ndarray] = []
+            features: list[np.ndarray] = []
+            for candidate in point.sorted_candidates():
+                target_vector = index_vectors.get(candidate.target_id)
+                if target_vector is None:
+                    continue
+                target_arr = np.asarray(target_vector, dtype=float)
+                if target_arr.ndim != 1:
+                    continue
+                candidate_ids.append(candidate.target_id)
+                targets.append(target_arr)
+                features.append(
+                    np.asarray(
+                        [float(candidate.edge_weight), float(candidate.edge_relevance), 1.0],
+                        dtype=float,
+                    )
+                )
+            if len(candidate_ids) < 2:
+                continue
+            points.append((trace, point_idx, point, query_vector, targets, features, candidate_ids))
+    return points_total, points
+
+
+def evaluate_ce_loss(
+    model: RouteModel,
+    traces: list[RouteTrace],
+    index_vectors: dict[str, list[float]],
+    labels: list[LabelRecord],
+    *,
+    label_temp: float,
+    reward_weights: RewardWeights,
+) -> tuple[float, int, int]:
+    points_total, points = _collect_points(traces, index_vectors)
+    labels_by_key = _labels_index(labels)
+    losses: list[float] = []
+    for trace, point_idx, point, query_vector, targets, features, candidate_ids in points:
+        logits, _q_proj, _target_projs = _point_logits(model, query_vector, targets, features)
+        probs = _softmax(logits)
+        labels_dist = _teacher_distribution(
+            trace,
+            point_idx,
+            point,
+            candidate_ids,
+            labels_by_key,
+            label_temp=label_temp,
+            reward_weights=reward_weights,
+        )
+        loss = -float(np.sum(labels_dist * np.log(np.clip(probs, 1e-12, 1.0))))
+        losses.append(loss)
+    mean_loss = float(np.mean(losses)) if losses else 0.0
+    return mean_loss, points_total, len(points)
+
+
+def train_route_model(
+    *,
+    state_path: str,
+    traces_in: str,
+    labels_in: str | None,
+    out_path: str,
+    rank: int = 16,
+    epochs: int = 3,
+    lr: float = 0.01,
+    label_temp: float = 0.5,
+    reward_weights: RewardWeights | None = None,
+) -> TrainRouteModelSummary:
+    traces = _read_traces(traces_in)
+    labels = read_labels_jsonl(labels_in) if labels_in else []
+    graph, index, _meta = load_state(state_path)
+    _ = graph
+
+    parsed_weights = reward_weights or RewardWeights.from_env()
+    points_total, points = _collect_points(traces, index._vectors)
+    if not points:
+        raise ValueError("no trainable decision points found (need query_vector + >=2 candidates with target vectors)")
+
+    dq = int(points[0][3].shape[0])
+    dt = int(points[0][4][0].shape[0])
+    model = RouteModel.init_random(dq=dq, dt=dt, df=3, rank=max(1, int(rank)))
+
+    labels_by_key = _labels_index(labels)
+    epoch_losses: list[float] = []
+
+    initial_loss, _, points_used = evaluate_ce_loss(
+        model,
+        traces,
+        index._vectors,
+        labels,
+        label_temp=label_temp,
+        reward_weights=parsed_weights,
+    )
+
+    lr_value = float(lr)
+    inv_t = 1.0 / max(1e-6, float(model.T))
+    for _ in range(max(1, int(epochs))):
+        losses: list[float] = []
+        for trace, point_idx, point, query_vector, targets, features, candidate_ids in points:
+            logits, q_proj, target_projs = _point_logits(model, query_vector, targets, features)
+            probs = _softmax(logits)
+            labels_dist = _teacher_distribution(
+                trace,
+                point_idx,
+                point,
+                candidate_ids,
+                labels_by_key,
+                label_temp=label_temp,
+                reward_weights=parsed_weights,
+            )
+
+            grad = probs - labels_dist
+            grad_A = np.zeros_like(model.A)
+            grad_B = np.zeros_like(model.B)
+            grad_w = np.zeros_like(model.w_feat)
+            grad_b = 0.0
+
+            for idx, g_i in enumerate(grad.tolist()):
+                g_scaled = float(g_i) * inv_t
+                grad_A += g_scaled * np.outer(query_vector, target_projs[idx])
+                grad_B += g_scaled * np.outer(targets[idx], q_proj)
+                grad_w += g_scaled * features[idx]
+                grad_b += g_scaled
+
+            model.A -= lr_value * grad_A
+            model.B -= lr_value * grad_B
+            model.w_feat -= lr_value * grad_w
+            model.b -= lr_value * grad_b
+
+            loss = -float(np.sum(labels_dist * np.log(np.clip(probs, 1e-12, 1.0))))
+            losses.append(loss)
+
+        epoch_losses.append(float(np.mean(losses)) if losses else 0.0)
+
+    final_loss, _, _ = evaluate_ce_loss(
+        model,
+        traces,
+        index._vectors,
+        labels,
+        label_temp=label_temp,
+        reward_weights=parsed_weights,
+    )
+
+    model.save_npz(out_path)
+    return TrainRouteModelSummary(
+        traces_path=str(traces_in),
+        labels_path=str(labels_in) if labels_in else None,
+        out_path=str(out_path),
+        rank=int(model.r),
+        epochs=max(1, int(epochs)),
+        lr=lr_value,
+        label_temp=float(label_temp),
+        points_total=points_total,
+        points_used=points_used,
+        initial_ce_loss=float(initial_loss),
+        final_ce_loss=float(final_loss),
+        epoch_losses=epoch_losses,
+    )
+
+
+def write_summary_json(summary: TrainRouteModelSummary) -> str:
+    return json.dumps(summary.to_dict(), indent=2)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "openclawbrain"
 version = "12.2.6"
 description = "Memory graph for AI agents that learns what to retrieve — and what to suppress."
 requires-python = ">=3.10"
-dependencies = ["openai>=1.0"]
+dependencies = ["openai>=1.0", "numpy>=1.24"]
 license = {text = "Apache-2.0"}
 authors = [{name = "Jonathan Gu", email = "jonathangu@gmail.com"}]
 readme = "README.md"

--- a/tests/test_async_route_pg.py
+++ b/tests/test_async_route_pg.py
@@ -125,6 +125,7 @@ def test_run_async_route_pg_dry_run_traces_out_emits_expected_fields(tmp_path: P
         teacher="none",
         apply=False,
         traces_out=str(traces_path),
+        include_query_vector=True,
     )
 
     assert summary.updates_applied == 0
@@ -137,6 +138,7 @@ def test_run_async_route_pg_dry_run_traces_out_emits_expected_fields(tmp_path: P
     assert "traversal_config" in trace
     assert "route_policy" in trace
     assert isinstance(trace["decision_points"], list)
+    assert "query_vector" in trace
     if trace["decision_points"]:
         point = trace["decision_points"][0]
         assert "source_id" in point

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from openclawbrain.labels import (
+    LabelRecord,
+    from_human_correction,
+    from_self_learning_event,
+    from_teacher_output,
+    read_labels_jsonl,
+    write_labels_jsonl,
+)
+from openclawbrain.reward import RewardSource
+
+
+def test_label_record_serialization_roundtrip(tmp_path: Path) -> None:
+    record = LabelRecord(
+        query_id="q1",
+        decision_point_idx=2,
+        candidate_scores={"a": 1.0, "b": -0.5},
+        reward_source=RewardSource.HUMAN,
+        weight=0.8,
+        ts=123.0,
+        metadata={"note": "ok"},
+    )
+    path = tmp_path / "labels.jsonl"
+    write_labels_jsonl(path, [record])
+
+    loaded = read_labels_jsonl(path)
+    assert len(loaded) == 1
+    assert loaded[0] == record
+
+
+def test_label_conversions_human_self_teacher() -> None:
+    human = from_human_correction({"query_id": "q", "decision_point_idx": 1, "target_id": "n1", "ts": 1.0})
+    assert human is not None
+    assert human.reward_source == RewardSource.HUMAN
+    assert human.candidate_scores == {"n1": 1.0}
+
+    self_label = from_self_learning_event(
+        {"query_id": "q", "decision_point_idx": 0, "fired_ids": ["n2"], "outcome": -1.0, "ts": 2.0}
+    )
+    assert self_label is not None
+    assert self_label.reward_source == RewardSource.SELF
+    assert self_label.candidate_scores == {"n2": -1.0}
+
+    teacher = from_teacher_output(query_id="q", decision_point_idx=3, teacher_scores={"n3": 0.5}, ts=3.0)
+    assert teacher.reward_source == RewardSource.TEACHER
+    assert teacher.candidate_scores == {"n3": 0.5}

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -46,6 +46,11 @@ def test_query_params_max_context_defaults_to_prompt_chars() -> None:
     assert params.max_context_chars == 777
 
 
+def test_query_params_accepts_learned_route_mode() -> None:
+    params = QueryParams.from_dict({"query": "alpha", "route_mode": "learned"})
+    assert params.route_mode == "learned"
+
+
 def test_query_params_validation_errors() -> None:
     with pytest.raises(ValueError, match="query must be a non-empty string"):
         QueryParams.from_dict({"query": ""})
@@ -53,7 +58,7 @@ def test_query_params_validation_errors() -> None:
     with pytest.raises(ValueError, match="top_k must be an integer"):
         QueryParams.from_dict({"query": "x", "top_k": "2"})
 
-    with pytest.raises(ValueError, match=r"route_mode must be one of: off, edge, edge\+sim"):
+    with pytest.raises(ValueError, match=r"route_mode must be one of: off, edge, edge\+sim, learned"):
         QueryParams.from_dict({"query": "x", "route_mode": "bad"})
 
     with pytest.raises(ValueError, match="route_use_relevance must be a boolean"):

--- a/tests/test_route_model.py
+++ b/tests/test_route_model.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+from openclawbrain import VectorIndex
+from openclawbrain.route_model import RouteModel
+
+
+def test_route_model_save_load_roundtrip(tmp_path: Path) -> None:
+    model = RouteModel.init_random(dq=4, dt=4, df=3, rank=2)
+    model.w_feat = np.asarray([0.1, -0.2, 0.3], dtype=float)
+    model.b = 0.7
+    model.T = 0.9
+
+    path = tmp_path / "route_model.npz"
+    model.save_npz(path)
+    loaded = RouteModel.load_npz(path)
+
+    assert loaded.r == model.r
+    assert np.allclose(loaded.A, model.A)
+    assert np.allclose(loaded.B, model.B)
+    assert np.allclose(loaded.w_feat, model.w_feat)
+    assert loaded.b == model.b
+    assert loaded.T == model.T
+
+
+def test_route_model_score_is_deterministic() -> None:
+    model = RouteModel.init_random(dq=3, dt=3, df=3, rank=2)
+    q = [0.1, 0.2, 0.3]
+    t = [0.4, 0.5, 0.6]
+    f = [0.7, 0.8, 1.0]
+
+    first = model.score(q, t, f)
+    second = model.score(q, t, f)
+    assert first == second
+
+
+def test_route_model_init_random_shapes_and_projection() -> None:
+    model = RouteModel.init_random(dq=5, dt=7, df=3, rank=4)
+    assert model.A.shape == (5, 4)
+    assert model.B.shape == (7, 4)
+    assert model.w_feat.shape == (3,)
+
+    index = VectorIndex()
+    index.upsert("n1", [1.0] * 7)
+    projections = model.precompute_target_projections(index)
+    assert "n1" in projections
+    assert len(projections["n1"]) == 4

--- a/tests/test_storage_stores.py
+++ b/tests/test_storage_stores.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from openclawbrain import Edge, Graph, Node, VectorIndex
+from openclawbrain.storage import JsonStateStore, JsonlEventStore
+
+
+def test_json_state_store_roundtrip(tmp_path: Path) -> None:
+    graph = Graph()
+    graph.add_node(Node("a", "alpha"))
+    graph.add_node(Node("b", "beta"))
+    graph.add_edge(Edge("a", "b", weight=0.7))
+
+    index = VectorIndex()
+    index.upsert("a", [1.0, 0.0])
+    index.upsert("b", [0.0, 1.0])
+
+    store = JsonStateStore()
+    path = tmp_path / "state.json"
+    store.save(str(path), graph=graph, index=index, meta={"embedder_name": "hash-v1", "embedder_dim": 2})
+
+    loaded_graph, loaded_index, meta = store.load(str(path))
+    assert loaded_graph.get_node("a") is not None
+    assert loaded_graph.get_node("b") is not None
+    assert loaded_graph.edge_count() == 1
+    assert loaded_index._vectors["a"] == [1.0, 0.0]
+    assert meta["embedder_name"] == "hash-v1"
+
+
+def test_jsonl_event_store_roundtrip(tmp_path: Path) -> None:
+    path = tmp_path / "journal.jsonl"
+    store = JsonlEventStore(str(path))
+
+    store.append({"type": "query", "query": "alpha", "fired": ["a"]})
+    store.append({"type": "learn", "fired": ["a"], "outcome": -1.0})
+
+    all_events = store.iter_since(None)
+    assert len(all_events) == 2
+    assert all_events[0]["type"] == "query"
+    assert all_events[1]["type"] == "learn"
+
+    only_recent = store.iter_since(float(all_events[0]["ts"]))
+    assert len(only_recent) >= 1
+
+    last = store.read_last(1)
+    assert len(last) == 1
+    assert last[0]["type"] == "learn"

--- a/tests/test_train_route_model.py
+++ b/tests/test_train_route_model.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from openclawbrain import Edge, Graph, Node, VectorIndex, save_state
+from openclawbrain.reward import RewardSource
+from openclawbrain.trace import RouteCandidate, RouteDecisionPoint, RouteTrace, route_trace_to_json
+from openclawbrain.train_route_model import train_route_model
+
+
+def _write_state(path: Path) -> None:
+    graph = Graph()
+    graph.add_node(Node("seed", "seed"))
+    graph.add_node(Node("target_a", "target a"))
+    graph.add_node(Node("target_b", "target b"))
+    graph.add_edge(Edge("seed", "target_a", weight=0.4, metadata={"relevance": 0.0}))
+    graph.add_edge(Edge("seed", "target_b", weight=0.4, metadata={"relevance": 0.0}))
+
+    index = VectorIndex()
+    index.upsert("seed", [1.0, 0.0])
+    index.upsert("target_a", [1.0, 0.0])
+    index.upsert("target_b", [0.0, 1.0])
+    save_state(graph=graph, index=index, path=str(path), meta={"embedder_name": "hash-v1", "embedder_dim": 2})
+
+
+def _write_traces(path: Path) -> None:
+    traces: list[RouteTrace] = []
+    for idx in range(8):
+        traces.append(
+            RouteTrace(
+                query_id=f"q{idx}",
+                ts=1000.0 + idx,
+                query_text="choose a",
+                seeds=[["seed", 1.0]],
+                fired_nodes=["seed", "target_a"],
+                traversal_config={"max_hops": 15},
+                route_policy={"route_mode": "off"},
+                query_vector=[1.0, 0.0],
+                decision_points=[
+                    RouteDecisionPoint(
+                        query_text="choose a",
+                        source_id="seed",
+                        source_preview="seed",
+                        chosen_target_id="target_a",
+                        candidates=[
+                            RouteCandidate(target_id="target_a", edge_weight=0.4, edge_relevance=0.0),
+                            RouteCandidate(target_id="target_b", edge_weight=0.4, edge_relevance=0.0),
+                        ],
+                        teacher_choose=["target_a"],
+                        teacher_scores={"target_a": 1.0, "target_b": -1.0},
+                        ts=1000.0 + idx,
+                        reward_source=RewardSource.TEACHER,
+                    )
+                ],
+            )
+        )
+
+    path.write_text("\n".join(route_trace_to_json(trace) for trace in traces) + "\n", encoding="utf-8")
+
+
+def test_train_route_model_ce_loss_decreases(tmp_path: Path) -> None:
+    state_path = tmp_path / "state.json"
+    traces_path = tmp_path / "traces.jsonl"
+    out_path = tmp_path / "route_model.npz"
+
+    _write_state(state_path)
+    _write_traces(traces_path)
+
+    summary = train_route_model(
+        state_path=str(state_path),
+        traces_in=str(traces_path),
+        labels_in=None,
+        out_path=str(out_path),
+        rank=2,
+        epochs=1,
+        lr=0.1,
+        label_temp=0.5,
+    )
+    assert out_path.exists()
+    assert summary.points_used > 0
+    assert summary.final_ce_loss < summary.initial_ce_loss


### PR DESCRIPTION
## Summary
- add storage boundary interfaces (`StateStore`/`EventStore`) and JSON implementations
- refactor daemon and async-route-pg to use storage abstractions
- add low-rank numpy `RouteModel` with NPZ persistence and precomputed target projections
- add runtime `route_mode=learned` with deterministic learned route function
- add unified `LabelRecord` module and JSONL read/write helpers
- extend traces with optional `query_vector` and async-route-pg `--include-query-vector`
- add `train-route-model` CLI (numpy SGD, CE objective, JSON summary)
- add replay/harvest `--traces-out` and `--labels-out` emit flags
- update README + architecture/operator/core-thesis docs
- add tests for storage, route_model, labels, learned policy determinism, and train-route-model

## Validation
- `PYTHONPATH=. pytest -q`
- result: `409 passed`
