### PR TITLE
feat: local embeddings + route_mode=learned default OOTB

### DIFF
--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -21,13 +21,19 @@ What `serve` does:
 - Starts the long-lived `openclawbrain daemon` worker.
 - Exposes a Unix socket at `~/.openclawbrain/main/daemon.sock` (for agent `main`).
 - Keeps the daemon hot in memory and restarts it if needed.
-- Uses daemon default `--embed-model auto` for query embeddings.
+- Uses daemon defaults `--embed-model auto` and `--route-mode learned`.
 
 Daemon embed-model auto behavior:
-- `hash-v1` states -> hash query embeddings (offline).
-- Non-hash states -> OpenAI query embeddings (`text-embedding-3-small`).
-- Force offline mode: `--embed-model hash`.
-- Force explicit model: `--embed-model <model>` (for example `text-embedding-3-small`).
+- `local:*` states -> local query embeddings.
+- `hash-v1` states -> hash query embeddings.
+- OpenAI states -> no OpenAI call in `auto`; require explicit `--embed-model openai:<model>`.
+- Force offline mode: `--embed-model hash` or `--embed-model local`.
+- Force explicit OpenAI model: `--embed-model openai:text-embedding-3-small`.
+
+Route-mode behavior:
+- Default is `learned`.
+- `openclawbrain init` writes `route_model.npz` beside `state.json` (identity-like starter model).
+- If `route_model.npz` is missing/unloadable, daemon gracefully falls back to `edge+sim`.
 
 ## 3) Confirm it's ON
 
@@ -174,7 +180,8 @@ Force query embed-model when needed:
 
 ```bash
 openclawbrain daemon --state ~/.openclawbrain/main/state.json --embed-model hash
-openclawbrain daemon --state ~/.openclawbrain/main/state.json --embed-model text-embedding-3-small
+openclawbrain daemon --state ~/.openclawbrain/main/state.json --embed-model local
+openclawbrain daemon --state ~/.openclawbrain/main/state.json --embed-model openai:text-embedding-3-small
 ```
 
 Operational notes:
@@ -188,7 +195,7 @@ Operational notes:
 |---|---|---|
 | `status` says `Daemon: not running` | service not started, crashed, or wrong state path | `openclawbrain serve --state ~/.openclawbrain/main/state.json` then `openclawbrain status --state ~/.openclawbrain/main/state.json` |
 | `daemon.sock` missing | service never started or wrong agent/state directory | `ls -la ~/.openclawbrain/main` and restart `openclawbrain serve` with the same `--state` |
-| embedder/dimension mismatch on daemon query | forced wrong `--embed-model` for this state | remove override and use auto; for direct daemon run use `openclawbrain daemon --state ~/.openclawbrain/main/state.json --embed-model auto` |
+| embedder/dimension mismatch on daemon query | forced wrong `--embed-model` for this state | use `--embed-model auto` for local/hash states, or explicit OpenAI mode for OpenAI states: `--embed-model openai:text-embedding-3-small` |
 | Replay fails with lock/single-writer message | another process holds `state.json.lock` | stop the other writer, use `examples/ops/rebuild_then_cutover.sh ...`, or expert override with `--force` / `OPENCLAWBRAIN_STATE_LOCK_FORCE=1` |
 | Replay restarts from old work | checkpoint not used, wrong path, or intentionally ignored | run with `--resume --checkpoint ~/.openclawbrain/main/replay_checkpoint.json`; inspect with `openclawbrain replay --state ~/.openclawbrain/main/state.json --show-checkpoint --resume` |
 | `LLM required for fast-learning` | no OpenAI client/key configured for fast-learning mining | set `OPENAI_API_KEY` or run `--edges-only` replay path |

--- a/openclawbrain/__init__.py
+++ b/openclawbrain/__init__.py
@@ -9,6 +9,7 @@ from .maintain import MaintenanceReport, run_maintenance, prune_edges, prune_orp
 from .learn import LearningConfig, apply_outcome, apply_outcome_pg, maybe_create_node
 from .inject import inject_batch, inject_correction, inject_node
 from .hasher import HashEmbedder, default_embed, default_embed_batch
+from .local_embedder import LocalEmbedder
 from .score import score_retrieval
 from .connect import apply_connections, suggest_connections
 from .merge import apply_merge, suggest_merges
@@ -29,6 +30,7 @@ __all__ = [
     "TraversalConfig",
     "TraversalResult",
     "HashEmbedder",
+    "LocalEmbedder",
     "default_embed",
     "default_embed_batch",
     "DecayConfig",

--- a/openclawbrain/local_embedder.py
+++ b/openclawbrain/local_embedder.py
@@ -1,0 +1,74 @@
+"""Local ONNX embedder wrapper with normalized vectors."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+DEFAULT_LOCAL_MODEL = "BAAI/bge-small-en-v1.5"
+DEFAULT_LOCAL_MODEL_TAG = "bge-small-en-v1.5"
+
+_MODEL_CACHE: dict[str, object] = {}
+
+
+def _normalize(vec: object) -> list[float]:
+    arr = np.asarray(vec, dtype=float)
+    if arr.ndim != 1:
+        raise ValueError("embedding output must be a 1D vector")
+    norm = float(np.linalg.norm(arr))
+    if norm > 0:
+        arr = arr / norm
+    return [float(v) for v in arr.tolist()]
+
+
+@dataclass
+class LocalEmbedder:
+    """Fast local embedder powered by `fastembed`."""
+
+    model_name: str = DEFAULT_LOCAL_MODEL
+    _dim: int | None = None
+
+    @property
+    def name(self) -> str:
+        model_tag = self.model_name.rsplit("/", 1)[-1]
+        return f"local:{model_tag}"
+
+    @property
+    def dim(self) -> int:
+        if self._dim is None:
+            self._dim = len(self.embed(""))
+        return self._dim
+
+    def _model(self):
+        cached = _MODEL_CACHE.get(self.model_name)
+        if cached is not None:
+            return cached
+        try:
+            from fastembed import TextEmbedding
+        except ImportError as exc:
+            raise ImportError("fastembed is required for local embeddings") from exc
+        model = TextEmbedding(model_name=self.model_name)
+        _MODEL_CACHE[self.model_name] = model
+        return model
+
+    def embed(self, text: str) -> list[float]:
+        vectors = list(self._model().embed([text]))
+        if not vectors:
+            raise RuntimeError("local embedder returned no vectors")
+        normalized = _normalize(vectors[0])
+        self._dim = len(normalized)
+        return normalized
+
+    def embed_batch(self, texts: list[tuple[str, str]]) -> dict[str, list[float]]:
+        if not texts:
+            return {}
+        ids = [node_id for node_id, _ in texts]
+        contents = [content for _, content in texts]
+        vectors = list(self._model().embed(contents))
+        if len(vectors) != len(ids):
+            raise RuntimeError("local embedder batch size mismatch")
+        normalized_vectors = [_normalize(vector) for vector in vectors]
+        if normalized_vectors:
+            self._dim = len(normalized_vectors[0])
+        return dict(zip(ids, normalized_vectors))

--- a/openclawbrain/openai_embeddings.py
+++ b/openclawbrain/openai_embeddings.py
@@ -5,9 +5,6 @@ from __future__ import annotations
 import os
 import sys
 
-import openai
-
-
 # Conservative limit: OpenAI allows 300K tokens per request.
 # ~4 chars per token, use 250K tokens (1M chars) as buffer.
 _MAX_CHARS_PER_CALL = 200_000  # ~50K tokens, well under OpenAI's 300K limit
@@ -23,7 +20,11 @@ class OpenAIEmbedder:
     def __init__(self) -> None:
         """  init  ."""
         api_key = os.environ.get("OPENAI_API_KEY")
-        self.client = openai.OpenAI(api_key=api_key)
+        try:
+            from openai import OpenAI
+        except ImportError as exc:
+            raise ImportError("openai is not installed. Install with `pip install openclawbrain[openai]`.") from exc
+        self.client = OpenAI(api_key=api_key)
 
     def embed(self, text: str) -> list[float]:
         """embed."""

--- a/openclawbrain/profile.py
+++ b/openclawbrain/profile.py
@@ -24,7 +24,7 @@ class ProfilePaths:
 class ProfilePolicy:
     max_prompt_context_chars: int = 30000
     max_fired_nodes: int = 30
-    route_mode: str = "off"
+    route_mode: str = "learned"
     route_top_k: int = 5
     route_alpha_sim: float = 0.5
     route_use_relevance: bool = True
@@ -122,7 +122,7 @@ class BrainProfile:
                 "policy.max_fired_nodes",
                 default=30,
             )
-            route_mode = parse_route_mode(raw_policy.get("route_mode"))
+            route_mode = parse_route_mode(raw_policy.get("route_mode", "learned"))
             route_top_k = parse_int(
                 raw_policy.get("route_top_k"),
                 "policy.route_top_k",

--- a/openclawbrain/route_model.py
+++ b/openclawbrain/route_model.py
@@ -132,3 +132,18 @@ class RouteModel:
         B = rng.normal(0.0, scale, size=(dt, rank)).astype(float)
         w_feat = np.zeros(df, dtype=float)
         return cls(r=int(rank), A=A, B=B, w_feat=w_feat, b=0.0, T=1.0)
+
+    @classmethod
+    def init_identity(cls, d: int, df: int = 3) -> "RouteModel":
+        """Initialize an identity-like model that approximates edge+sim routing."""
+        if d <= 0 or df <= 0:
+            raise ValueError("d and df must be positive")
+        A = np.eye(d, dtype=float)
+        B = np.eye(d, dtype=float)
+        w_feat = np.zeros(df, dtype=float)
+        if df >= 2:
+            w_feat[0] = 1.0
+            w_feat[1] = 1.0
+        elif df == 1:
+            w_feat[0] = 1.0
+        return cls(r=int(d), A=A, B=B, w_feat=w_feat, b=0.0, T=1.0)

--- a/openclawbrain/socket_server.py
+++ b/openclawbrain/socket_server.py
@@ -23,7 +23,7 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--embed-model", default="auto")
     parser.add_argument("--max-prompt-context-chars", type=int, default=30000)
     parser.add_argument("--max-fired-nodes", type=int, default=30)
-    parser.add_argument("--route-mode", choices=["off", "edge", "edge+sim", "learned"], default="off")
+    parser.add_argument("--route-mode", choices=["off", "edge", "edge+sim", "learned"], default="learned")
     parser.add_argument("--route-top-k", type=int, default=5)
     parser.add_argument("--route-alpha-sim", type=float, default=0.5)
     parser.add_argument("--route-use-relevance", choices=["true", "false"], default="true")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "openclawbrain"
 version = "12.2.6"
 description = "Memory graph for AI agents that learns what to retrieve — and what to suppress."
 requires-python = ">=3.10"
-dependencies = ["openai>=1.0", "numpy>=1.24"]
+dependencies = ["fastembed>=0.3", "numpy>=1.24"]
 license = {text = "Apache-2.0"}
 authors = [{name = "Jonathan Gu", email = "jonathangu@gmail.com"}]
 readme = "README.md"

--- a/tests/test_local_embedder.py
+++ b/tests/test_local_embedder.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import importlib
+import math
+import sys
+import types
+
+
+def test_local_embedder_embed_is_normalized_and_sets_dim(monkeypatch) -> None:
+    class FakeTextEmbedding:
+        def __init__(self, model_name: str) -> None:
+            self.model_name = model_name
+
+        def embed(self, texts: list[str]):
+            for text in texts:
+                scale = float(len(text) or 1)
+                yield [3.0 * scale, 4.0 * scale, 0.0, 0.0]
+
+    fake_fastembed = types.ModuleType("fastembed")
+    fake_fastembed.TextEmbedding = FakeTextEmbedding
+    monkeypatch.setitem(sys.modules, "fastembed", fake_fastembed)
+
+    module_name = "openclawbrain.local_embedder"
+    sys.modules.pop(module_name, None)
+    module = importlib.import_module(module_name)
+    module._MODEL_CACHE.clear()
+
+    embedder = module.LocalEmbedder()
+    vec = embedder.embed("hello")
+    assert len(vec) == 4
+    assert embedder.dim == 4
+    assert math.isclose(sum(v * v for v in vec), 1.0, rel_tol=1e-6)
+
+
+def test_local_embedder_embed_batch_is_normalized(monkeypatch) -> None:
+    class FakeTextEmbedding:
+        def __init__(self, model_name: str) -> None:
+            self.model_name = model_name
+
+        def embed(self, texts: list[str]):
+            for idx, _text in enumerate(texts):
+                yield [1.0 + idx, 0.0, 0.0]
+
+    fake_fastembed = types.ModuleType("fastembed")
+    fake_fastembed.TextEmbedding = FakeTextEmbedding
+    monkeypatch.setitem(sys.modules, "fastembed", fake_fastembed)
+
+    module_name = "openclawbrain.local_embedder"
+    sys.modules.pop(module_name, None)
+    module = importlib.import_module(module_name)
+    module._MODEL_CACHE.clear()
+
+    embedder = module.LocalEmbedder()
+    vectors = embedder.embed_batch([("a", "alpha"), ("b", "beta")])
+    assert set(vectors) == {"a", "b"}
+    assert embedder.dim == 3
+    assert math.isclose(sum(v * v for v in vectors["a"]), 1.0, rel_tol=1e-6)
+    assert math.isclose(sum(v * v for v in vectors["b"]), 1.0, rel_tol=1e-6)

--- a/tests/test_route_model.py
+++ b/tests/test_route_model.py
@@ -48,3 +48,13 @@ def test_route_model_init_random_shapes_and_projection() -> None:
     projections = model.precompute_target_projections(index)
     assert "n1" in projections
     assert len(projections["n1"]) == 4
+
+
+def test_route_model_init_identity_matches_expected_defaults() -> None:
+    model = RouteModel.init_identity(d=3, df=3)
+    assert model.r == 3
+    assert np.allclose(model.A, np.eye(3))
+    assert np.allclose(model.B, np.eye(3))
+    assert np.allclose(model.w_feat, np.asarray([1.0, 1.0, 0.0]))
+    assert model.b == 0.0
+    assert model.T == 1.0


### PR DESCRIPTION
Make OpenClawBrain fast/offline by default.

## Changes
- Required deps: `fastembed` + `numpy` (OpenAI is optional-only)
- New `LocalEmbedder` (default model: `BAAI/bge-small-en-v1.5`), L2-normalized vectors
- `init --embedder auto` now prefers local -> hash (no OpenAI)
- daemon `--embed-model auto` uses local when state meta is local; OpenAI only when explicitly set `openai:<model>`
- `RouteModel.init_identity` and `init` writes default `route_model.npz`
- Default route_mode is now `learned` with graceful fallback to `edge+sim`
- Docs updated (README/setup/operator)

## Tests
`PYTHONPATH=. pytest -q` → 416 passed
