### PR TITLE
Confidence-adaptive routing: graph prior vs QRsim + RL-native metrics

### DIFF
--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -32,8 +32,13 @@ Daemon embed-model auto behavior:
 
 Route-mode behavior:
 - Default is `learned`.
-- `openclawbrain init` writes `route_model.npz` beside `state.json` (identity-like starter model).
+- `openclawbrain init` writes `route_model.npz` beside `state.json` (QRsim-only identity starter model).
 - If `route_model.npz` is missing/unloadable, daemon gracefully falls back to `edge+sim`.
+- Runtime `learned` scoring is confidence-adaptive:
+  - Graph prior: `graph_prior_i = rel_conf*r_i + (1-rel_conf)*w_i`.
+  - Router term (`QRsim`): route model projected query-target score (plus bias), without direct edge weight/relevance features.
+  - Final mix: `final_i = router_conf*QRsim_i + (1-router_conf)*graph_prior_i`.
+  - `rel_conf` and `router_conf` come from normalized entropy over candidate softmax scores (margin fallback on very small candidate sets).
 
 ## 3) Confirm it's ON
 
@@ -442,6 +447,8 @@ openclawbrain train-route-model \
   --label-temp 0.5 \
   --json
 ```
+
+`train-route-model` learns the QRsim router from route traces plus labels (teacher/human/self RL-derived supervision), then writes `route_model.npz` for runtime learned routing.
 
 Enable at runtime:
 

--- a/openclawbrain/cli.py
+++ b/openclawbrain/cli.py
@@ -1155,7 +1155,7 @@ def cmd_init(args: argparse.Namespace) -> int:
     if not isinstance(resolved_embedder_dim, int):
         resolved_embedder_dim = embedder_dim
     if isinstance(resolved_embedder_dim, int) and resolved_embedder_dim > 0:
-        RouteModel.init_identity(d=resolved_embedder_dim, df=3).save_npz(route_model_path)
+        RouteModel.init_identity(d=resolved_embedder_dim, df=1).save_npz(route_model_path)
     else:
         raise SystemExit("could not determine embedder dimension for route_model initialization")
     index_path = output_dir / "index.json"

--- a/openclawbrain/policy.py
+++ b/openclawbrain/policy.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from typing import Callable
 
@@ -37,12 +38,72 @@ class RoutingPolicy:
         )
 
 
+@dataclass(frozen=True)
+class DecisionMetrics:
+    """Per-source learned-routing decision telemetry."""
+
+    router_entropy: float
+    router_conf: float
+    router_margin: float
+    relevance_entropy: float
+    relevance_conf: float
+    chosen_edge: tuple[str, str]
+    graph_prior_score: float
+    router_score_raw: float
+    final_score: float
+    candidate_count: int
+    policy_disagreement: float
+
 
 def _parse_use_relevance(value: object) -> bool:
     if not isinstance(value, bool):
         raise ValueError("route_use_relevance must be a boolean")
     return value
 
+
+def _softmax(values: list[float]) -> list[float]:
+    if not values:
+        return []
+    max_value = max(values)
+    exp_values = [math.exp(value - max_value) for value in values]
+    denom = sum(exp_values)
+    if denom <= 0:
+        return [1.0 / len(values)] * len(values)
+    return [value / denom for value in exp_values]
+
+
+def _normalized_entropy(probs: list[float]) -> float:
+    n = len(probs)
+    if n <= 1:
+        return 0.0
+    entropy = -sum(prob * math.log(max(prob, 1e-12)) for prob in probs)
+    normalized = entropy / math.log(float(n))
+    return max(0.0, min(1.0, normalized))
+
+
+def _margin(probs: list[float]) -> float:
+    if not probs:
+        return 0.0
+    if len(probs) == 1:
+        return 1.0
+    ordered = sorted(probs, reverse=True)
+    return max(0.0, min(1.0, ordered[0] - ordered[1]))
+
+
+def _confidence(values: list[float]) -> tuple[float, float, float]:
+    probs = _softmax(values)
+    entropy = _normalized_entropy(probs)
+    margin = _margin(probs)
+    conf = margin if len(values) <= 3 else (1.0 - entropy)
+    return entropy, max(0.0, min(1.0, conf)), margin
+
+
+def _constant_feature_vector(df: int) -> list[float]:
+    if df <= 0:
+        raise ValueError("route model feature dimension must be positive")
+    values = [0.0] * df
+    values[-1] = 1.0
+    return values
 
 
 def make_runtime_route_fn(
@@ -52,6 +113,7 @@ def make_runtime_route_fn(
     index: VectorIndex,
     learned_model: RouteModel | None = None,
     target_projections: dict[str, object] | None = None,
+    decision_log: list[DecisionMetrics] | None = None,
 ) -> Callable[[str | None, list[object], str], list[str]] | None:
     """Build deterministic local route policy for habitual candidates."""
     if policy.route_mode == "off":
@@ -65,6 +127,7 @@ def make_runtime_route_fn(
             index=index,
             config=policy,
             query_vector=query_vector,
+            decision_log=decision_log,
         )
 
     use_similarity = policy.route_mode == "edge+sim"
@@ -105,9 +168,11 @@ def make_learned_route_fn(
     index: VectorIndex,
     config: RoutingPolicy,
     query_vector: list[float],
+    decision_log: list[DecisionMetrics] | None = None,
 ) -> Callable[[str | None, list[object], str], list[str]]:
     """Build deterministic learned route function using low-rank scoring."""
     q_proj = model.project_query(query_vector)
+    feat_vec = _constant_feature_vector(model.df)
 
     def _target_proj(target_id: str):
         cached = target_projections.get(target_id)
@@ -121,7 +186,8 @@ def make_learned_route_fn(
         return projected
 
     def _route_fn(_source_id: str | None, candidates: list[object], _query_text: str) -> list[str]:
-        ranked: list[tuple[str, float]] = []
+        source_id = _source_id or ""
+        scored: list[tuple[str, float, float, float]] = []
         for edge in candidates:
             target_id = str(getattr(edge, "target", ""))
             if not target_id:
@@ -129,16 +195,50 @@ def make_learned_route_fn(
             t_proj = _target_proj(target_id)
             if t_proj is None:
                 continue
+            weight = float(getattr(edge, "weight", 0.0))
             metadata = getattr(edge, "metadata", None)
             relevance = 0.0
             if isinstance(metadata, dict):
                 raw_relevance = metadata.get("relevance", 0.0)
                 if isinstance(raw_relevance, (int, float)):
                     relevance = float(raw_relevance)
-            features = [float(getattr(edge, "weight", 0.0)), relevance, 1.0]
-            score = model.score_projected(q_proj, t_proj, features)
-            ranked.append((target_id, score))
-        ranked.sort(key=lambda item: (-item[1], item[0]))
-        return [target_id for target_id, _ in ranked[: config.top_k]]
+            router_score = model.score_projected(q_proj, t_proj, feat_vec)
+            scored.append((target_id, weight, relevance, router_score))
+
+        if not scored:
+            return []
+
+        relevances = [relevance for _target_id, _weight, relevance, _router_score in scored]
+        router_scores = [router_score for _target_id, _weight, _relevance, router_score in scored]
+        relevance_entropy, relevance_conf, _relevance_margin = _confidence(relevances)
+        router_entropy, router_conf, router_margin = _confidence(router_scores)
+
+        ranked: list[tuple[str, float, float, float]] = []
+        for target_id, weight, relevance, router_score in scored:
+            graph_prior = (relevance_conf * relevance) + ((1.0 - relevance_conf) * weight)
+            final_score = (router_conf * router_score) + ((1.0 - router_conf) * graph_prior)
+            ranked.append((target_id, graph_prior, router_score, final_score))
+
+        ranked.sort(key=lambda item: (-item[3], item[0]))
+
+        if decision_log is not None and ranked:
+            chosen_target, chosen_graph_prior, chosen_router, chosen_final = ranked[0]
+            decision_log.append(
+                DecisionMetrics(
+                    router_entropy=router_entropy,
+                    router_conf=router_conf,
+                    router_margin=router_margin,
+                    relevance_entropy=relevance_entropy,
+                    relevance_conf=relevance_conf,
+                    chosen_edge=(source_id, chosen_target),
+                    graph_prior_score=chosen_graph_prior,
+                    router_score_raw=chosen_router,
+                    final_score=chosen_final,
+                    candidate_count=len(ranked),
+                    policy_disagreement=abs(chosen_router - chosen_graph_prior),
+                )
+            )
+
+        return [target_id for target_id, _graph_prior, _router, _final in ranked[: config.top_k]]
 
     return _route_fn

--- a/openclawbrain/route_model.py
+++ b/openclawbrain/route_model.py
@@ -134,16 +134,11 @@ class RouteModel:
         return cls(r=int(rank), A=A, B=B, w_feat=w_feat, b=0.0, T=1.0)
 
     @classmethod
-    def init_identity(cls, d: int, df: int = 3) -> "RouteModel":
-        """Initialize an identity-like model that approximates edge+sim routing."""
+    def init_identity(cls, d: int, df: int = 1) -> "RouteModel":
+        """Initialize an identity-like QRsim-only model."""
         if d <= 0 or df <= 0:
             raise ValueError("d and df must be positive")
         A = np.eye(d, dtype=float)
         B = np.eye(d, dtype=float)
         w_feat = np.zeros(df, dtype=float)
-        if df >= 2:
-            w_feat[0] = 1.0
-            w_feat[1] = 1.0
-        elif df == 1:
-            w_feat[0] = 1.0
         return cls(r=int(d), A=A, B=B, w_feat=w_feat, b=0.0, T=1.0)

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import numpy as np
 
 from openclawbrain import Edge, VectorIndex
-from openclawbrain.policy import RoutingPolicy, make_runtime_route_fn
+from openclawbrain.policy import RoutingPolicy, _confidence, make_runtime_route_fn
 from openclawbrain.route_model import RouteModel
 
 
@@ -87,3 +87,49 @@ def test_make_runtime_route_fn_learned_is_deterministic() -> None:
     second = route_fn("src", list(reversed(candidates)), "q")
     assert first == ["a"]
     assert second == ["a"]
+
+
+def test_confidence_outputs_bounds() -> None:
+    entropy, conf, margin = _confidence([0.2, 0.2, 0.2, 0.2])
+    assert 0.0 <= entropy <= 1.0
+    assert 0.0 <= conf <= 1.0
+    assert 0.0 <= margin <= 1.0
+
+
+def test_make_runtime_route_fn_learned_populates_decision_log() -> None:
+    index = VectorIndex()
+    index.upsert("a", [1.0, 0.0])
+    index.upsert("b", [0.0, 1.0])
+    model = RouteModel(
+        r=2,
+        A=np.asarray([[1.0, 0.0], [0.0, 1.0]], dtype=float),
+        B=np.asarray([[5.0, 0.0], [0.0, -5.0]], dtype=float),
+        w_feat=np.asarray([10.0, 10.0, 0.0], dtype=float),
+        b=0.0,
+        T=1.0,
+    )
+    decision_log = []
+    route_fn = make_runtime_route_fn(
+        policy=RoutingPolicy(route_mode="learned", top_k=1, alpha_sim=0.5, use_relevance=True),
+        query_vector=[1.0, 0.0],
+        index=index,
+        learned_model=model,
+        target_projections=model.precompute_target_projections(index),
+        decision_log=decision_log,
+    )
+    assert route_fn is not None
+    chosen = route_fn(
+        "src",
+        [
+            Edge("src", "b", weight=0.99, metadata={"relevance": 0.99}),
+            Edge("src", "a", weight=0.01, metadata={"relevance": 0.01}),
+        ],
+        "q",
+    )
+    assert chosen == ["a"]
+    assert len(decision_log) == 1
+    metrics = decision_log[0]
+    assert metrics.chosen_edge == ("src", "a")
+    assert metrics.candidate_count == 2
+    assert 0.0 <= metrics.router_conf <= 1.0
+    assert 0.0 <= metrics.relevance_conf <= 1.0

--- a/tests/test_route_model.py
+++ b/tests/test_route_model.py
@@ -55,6 +55,6 @@ def test_route_model_init_identity_matches_expected_defaults() -> None:
     assert model.r == 3
     assert np.allclose(model.A, np.eye(3))
     assert np.allclose(model.B, np.eye(3))
-    assert np.allclose(model.w_feat, np.asarray([1.0, 1.0, 0.0]))
+    assert np.allclose(model.w_feat, np.asarray([0.0, 0.0, 0.0]))
     assert model.b == 0.0
     assert model.T == 1.0


### PR DESCRIPTION
## Summary\n- implement learned runtime decomposition into graph prior and QRsim router score\n- add confidence-adaptive mixing using entropy (with margin fallback for small candidate sets)\n- add DecisionMetrics instrumentation and daemon route_* summary fields in query response + journal metadata\n- make learned router backward-compatible with legacy route_model.npz feature dims via constant feature vectors\n- switch RouteModel identity/init defaults to QRsim-only (df=1, zero feature weights)\n- update train-route-model to learn QRsim with constant features while remaining compatible with df=3 models\n- update architecture/operator docs\n- expand tests for confidence bounds, decision logging, daemon summaries, and legacy df compatibility\n\n## Validation\n- ........................................................................ [ 17%]
........................................................................ [ 34%]
........................................................................ [ 51%]
........................................................................ [ 68%]
........................................................................ [ 85%]
............................................................             [100%]
420 passed in 3.19s\n  - 420 passed\n