### PR TITLE
Issue #60 (part 2): replay mode UX + checkpoint/resume semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@
 - Added one-page operator lifecycle guide: `docs/operator-quickstart.md` (linked from README).
 - Clarified docs/CLI wording that `serve` is the canonical operator entrypoint and `daemon` is low-level NDJSON worker plumbing.
 
+### Replay mode UX + checkpoint semantics (Issue #60 part 2)
+- Added explicit replay mode selection: `openclawbrain replay --mode {edges-only,fast-learning,full}`.
+- Legacy replay flags remain supported and map to mode for backward compatibility:
+  - `--edges-only` -> `--mode edges-only`
+  - `--fast-learning` / `--extract-learning-events` -> `--mode fast-learning`
+  - `--full-learning` / `--full-pipeline` -> `--mode full`
+- Changed replay default mode behavior:
+  - Omitting mode now defaults to `edges-only` (never silently defaults to full).
+  - Replay prints an explicit note when this default is applied.
+- Added replay checkpoint/resume flag semantics:
+  - `--checkpoint <path>`
+  - `--resume`
+  - `--fresh` / `--no-checkpoint` (with `--ignore-checkpoint` kept as a legacy alias)
+- Replay startup output now includes selected mode and checkpoint path.
+- Added replay help epilog with mode-level cost/time expectations.
+- Updated operator docs for explicit mode and fresh/resume checkpoint semantics.
+- Added CLI tests for legacy-flag-to-mode mapping and default mode behavior.
+
 ## v12.2.6 (2026-03-02)
 
 ### async-route-pg: shadow teacher routing + policy-gradient updates

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -71,6 +71,12 @@ openclawbrain replay \
 
 Then keep serving from the daemon state.
 
+Replay mode quick guidance:
+- `--mode edges-only` (default when omitted): cheapest/fastest, no LLM mining, no harvest.
+- `--mode fast-learning`: LLM transcript mining + injection only; usually the slowest and most expensive stage.
+- `--mode full`: fast-learning + edge replay + harvest; highest end-to-end runtime/cost.
+- Legacy flags still work and map to mode: `--edges-only`, `--fast-learning` (`--extract-learning-events`), `--full-learning` (`--full-pipeline`).
+
 ### no-drama rebuild_then_cutover
 Use when you need single-writer safety during rebuild and minimal cutover downtime.
 
@@ -114,9 +120,11 @@ jq . ~/.openclawbrain/main/replay_checkpoint.json
 ```
 
 Flag meanings:
+- `--mode {edges-only,fast-learning,full}`: explicit replay mode. If omitted, replay defaults to `edges-only` and prints a startup note.
 - `--checkpoint <path>`: checkpoint file location.
 - `--resume`: continue from saved per-session line offsets.
-- `--ignore-checkpoint`: start from scratch even if checkpoint exists.
+- `--fresh` / `--no-checkpoint`: start from scratch even if checkpoint exists.
+- `--ignore-checkpoint`: legacy alias for `--fresh`.
 - `--checkpoint-every-seconds N`: periodic time-based checkpointing.
 - `--checkpoint-every N`: checkpoint every N replay windows/merge batches.
 - `--stop-after-fast-learning`: end after fast-learning phase (for quick cutover).
@@ -126,6 +134,7 @@ Flag meanings:
 - Replay emits a progress heartbeat every 30 seconds by default; add `--progress-every N` for per-item cadence.
 - Use `--quiet` to suppress replay banners/progress when scripting.
 - Replay phase: stderr shows `Loaded <N> interactions from session files`; with `--progress-every`, shows `[replay] <done>/<total> (<pct>%)`.
+- Startup banner includes selected `mode` and `checkpoint` path.
 - Replay completion: `Replayed <n>/<total> queries, <m> cross-file edges created`
 - Full-learning completion (`--full-learning`): final line includes harvest summary, e.g. `harvest: tasks=<k>, damped_edges=<x>`.
 


### PR DESCRIPTION
## Summary
- add explicit `replay --mode {edges-only,fast-learning,full}` with legacy flag mapping for backwards compatibility
- change omitted mode behavior to default to `edges-only` with an explicit note (never silently defaults to full)
- add checkpoint semantics flags `--fresh` / `--no-checkpoint` (keep `--ignore-checkpoint` as legacy alias)
- print replay mode + checkpoint path in startup UX and show-checkpoint text output
- add replay help epilog with mode cost/time expectations
- update operator docs for mode selection + resume/fresh semantics
- add CLI tests for legacy flag mapping and no-flags default behavior
- add changelog entry

## Testing
- `PYTHONPATH=. pytest -q tests/test_cli.py -k "replay"`
