### PR TITLE
Issue #60 (part 1): canonical serve lifecycle + operator quickstart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 ## Unreleased
 
-- No entries yet.
+### Operator lifecycle UX (Issue #60 part 1)
+- `openclawbrain serve` now supports lifecycle subcommands: `start`, `status`, and `stop`.
+- `serve status` validates socket presence and performs a live `health` ping over the Unix socket.
+- `serve stop` sends daemon `shutdown` over the socket, with launchd/systemd stop commands printed as fallback.
+- Added optional `serve start --launchd` / `--systemd` template output for quick service wiring.
+- Canonical socket-path convention is now documented as `~/.openclawbrain/<agent>/daemon.sock` (`<agent>` from `state.json` parent directory), and startup banner prints the resolved socket path.
+- Added one-page operator lifecycle guide: `docs/operator-quickstart.md` (linked from README).
+- Clarified docs/CLI wording that `serve` is the canonical operator entrypoint and `daemon` is low-level NDJSON worker plumbing.
 
 ## v12.2.6 (2026-03-02)
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 ## Docs
 
 - Operator guide: [docs/operator-guide.md](docs/operator-guide.md)
+- Operator quickstart: [docs/operator-quickstart.md](docs/operator-quickstart.md)
 - OpenClaw integration: [docs/openclaw-integration.md](docs/openclaw-integration.md)
 - Setup guide: [docs/setup-guide.md](docs/setup-guide.md)
 - GitHub repo: https://github.com/jonathangu/openclawbrain
@@ -21,6 +22,7 @@
 OpenClawBrain is designed to be the memory layer for **OpenClaw agents**.
 
 - Canonical operator runbook: **[docs/operator-guide.md](docs/operator-guide.md)**
+- Canonical one-page quickstart: **[docs/operator-quickstart.md](docs/operator-quickstart.md)**
 - Guide: **[docs/openclaw-integration.md](docs/openclaw-integration.md)**
 
 Quickstart (OpenClaw users):
@@ -372,19 +374,20 @@ See `examples/openai_embedder/` for a complete example.
 | `async-route-pg` | Background teacher-shadow routing labels from recent query journal + PG edge updates |
 | `health` | Show graph health metrics |
 | `status` | `openclawbrain status --state brain/state.json [--json]` returns a one-command health overview: version, nodes, edges, tier distribution, daemon status, embedder, decay half-life |
-| `serve` | `openclawbrain serve --state brain/state.json [--socket-path path] [--foreground]` starts the Unix socket service in the foreground |
+| `serve` | `openclawbrain serve start|status|stop --state brain/state.json [--socket-path path]` canonical socket-service lifecycle |
 | `journal` | Show event journal |
 | `doctor` | Run diagnostic checks |
 | `info` | Show brain info (nodes, edges, embedder) |
-| `daemon` | Start persistent worker (JSON-RPC over stdio, state loaded once) |
+| `daemon` | Low-level NDJSON worker (stdio), typically run behind `serve` |
 
 ## State persistence
 
 State writes are atomic (`temp` + `fsync` + `rename`) with `.bak` backup. Crash-safe.
 
-## Persistent Worker (`openclawbrain daemon`)
+## Low-Level Worker (`openclawbrain daemon`)
 
-For production use, run OpenClawBrain as a long-lived daemon so the graph stays hot in memory and query paths avoid repeated startup+reload overhead.
+For production use, prefer `openclawbrain serve`, which manages the daemon worker and socket lifecycle.
+`openclawbrain daemon` is the low-level NDJSON stdio worker.
 
 Why this matters:
 

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -6,6 +6,8 @@ OpenClawBrain is the long-term memory layer for OpenClaw agents: it builds a lea
 ## New agent recipe
 Use the canonical bootstrap SOP when creating a brand-new OpenClaw profile-style setup (new workspace + dedicated brain + launchd + routing):
 - [docs/new-agent-sop.md](new-agent-sop.md)
+Use the one-page lifecycle reference for daily operations:
+- [docs/operator-quickstart.md](operator-quickstart.md)
 Use packaged adapter CLIs for agent hooks (no `~/openclawbrain` clone required):
 - `python3 -m openclawbrain.openclaw_adapter.query_brain ...`
 - `python3 -m openclawbrain.openclaw_adapter.capture_feedback ...`
@@ -22,6 +24,7 @@ What `serve` does:
 - Exposes a Unix socket at `~/.openclawbrain/main/daemon.sock` (for agent `main`).
 - Keeps the daemon hot in memory and restarts it if needed.
 - Uses daemon defaults `--embed-model auto` and `--route-mode learned`.
+- `openclawbrain daemon` remains available as a low-level NDJSON worker for custom integrations.
 
 Daemon embed-model auto behavior:
 - `local:*` states -> local query embeddings.

--- a/docs/operator-quickstart.md
+++ b/docs/operator-quickstart.md
@@ -1,0 +1,79 @@
+# OpenClawBrain Operator Quickstart
+
+This is the canonical operator path for running OpenClawBrain in production.
+
+## Canonical entrypoint
+
+Use `openclawbrain serve` for service lifecycle:
+
+```bash
+openclawbrain serve start --state ~/.openclawbrain/main/state.json
+```
+
+`openclawbrain daemon` is a low-level NDJSON stdio worker used internally by `serve` and custom integrations.
+
+## Socket path convention
+
+Default socket path is:
+
+```text
+~/.openclawbrain/<agent>/daemon.sock
+```
+
+`<agent>` is derived from the directory containing `state.json`.
+
+Example:
+- state: `~/.openclawbrain/main/state.json`
+- socket: `~/.openclawbrain/main/daemon.sock`
+
+`serve start` prints the resolved socket path on startup.
+
+## Start
+
+```bash
+openclawbrain serve start --state ~/.openclawbrain/main/state.json
+```
+
+Optional service templates:
+
+```bash
+openclawbrain serve start --state ~/.openclawbrain/main/state.json --launchd
+openclawbrain serve start --state ~/.openclawbrain/main/state.json --systemd
+```
+
+## Status
+
+`serve status` checks socket existence and performs a health ping over the socket.
+
+```bash
+openclawbrain serve status --state ~/.openclawbrain/main/state.json
+```
+
+## Query
+
+```bash
+python3 -m openclawbrain.socket_client \
+  --socket ~/.openclawbrain/main/daemon.sock \
+  --method query \
+  --params '{"query":"summarize deploy risks","top_k":4}'
+```
+
+## Stop
+
+```bash
+openclawbrain serve stop --state ~/.openclawbrain/main/state.json
+```
+
+This sends daemon `shutdown` over the socket. If the socket is unavailable, the command prints exact launchd/systemd stop commands.
+
+## Troubleshooting
+
+- Stale socket (`daemon.sock` exists but `serve status` fails):
+  - Restart with `openclawbrain serve start --state ...`.
+  - The socket server removes stale sockets on startup.
+- State lock errors (`state.json.lock`):
+  - Another writer is active (daemon/replay/maintenance).
+  - Stop the writer before direct state mutations or use rebuild-then-cutover.
+- Logs:
+  - launchd/systemd log destinations are configured in the unit/plist.
+  - Common defaults are `~/.openclawbrain/<agent>/daemon.stdout.log` and `~/.openclawbrain/<agent>/daemon.stderr.log`.


### PR DESCRIPTION
## Summary
- add `openclawbrain serve start|status|stop` lifecycle UX while keeping `openclawbrain serve --state ...` as default start behavior
- make `serve status` perform real socket health ping and `serve stop` send socket `shutdown` (with launchd/systemd fallback commands)
- add optional `serve start --launchd` / `--systemd` template output
- align socket path convention resolution to `socket_server` default path helper and print the resolved path on startup
- clarify `daemon` as low-level NDJSON worker and position `serve` as canonical operator path
- add one-page doc `docs/operator-quickstart.md` and link from README
- add changelog entry under Unreleased

## Testing
- `PYTHONPATH=. pytest -q`
