### PR TITLE
docs: rename QRsim term to QTsim

### DIFF
--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -35,12 +35,12 @@ Daemon embed-model auto behavior:
 
 Route-mode behavior:
 - Default is `learned`.
-- `openclawbrain init` writes `route_model.npz` beside `state.json` (QRsim-only identity starter model).
+- `openclawbrain init` writes `route_model.npz` beside `state.json` (QTsim-only identity starter model).
 - If `route_model.npz` is missing/unloadable, daemon gracefully falls back to `edge+sim`.
 - Runtime `learned` scoring is confidence-adaptive:
   - Graph prior: `graph_prior_i = rel_conf*r_i + (1-rel_conf)*w_i`.
-  - Router term (`QRsim`): route model projected query-target score (plus bias), without direct edge weight/relevance features.
-  - Final mix: `final_i = router_conf*QRsim_i + (1-router_conf)*graph_prior_i`.
+  - Router term (`QTsim`): Query-Target Similarity term from route-model projected query-target score (plus bias), without direct edge weight/relevance features.
+  - Final mix: `final_i = router_conf*QTsim_i + (1-router_conf)*graph_prior_i`.
   - `rel_conf` and `router_conf` come from normalized entropy over candidate softmax scores (margin fallback on very small candidate sets).
 
 ## 3) Confirm it's ON
@@ -460,7 +460,7 @@ openclawbrain train-route-model \
   --json
 ```
 
-`train-route-model` learns the QRsim router from route traces plus labels (teacher/human/self RL-derived supervision), then writes `route_model.npz` for runtime learned routing.
+`train-route-model` learns the QTsim router from route traces plus labels (teacher/human/self RL-derived supervision), then writes `route_model.npz` for runtime learned routing.
 
 Enable at runtime:
 

--- a/docs/shadow-routing-upg-architecture.md
+++ b/docs/shadow-routing-upg-architecture.md
@@ -113,15 +113,15 @@ New modules and boundaries:
 
 Runtime learned mode:
 - `route_mode=learned` uses `policy.make_learned_route_fn`.
-- `QRsim` is the route-model term: projected query/target similarity plus bias only.
+- `QTsim` is the Query-Target Similarity term: route-model projected query/target similarity plus bias only.
 - Graph prior is explicit and separate: `graph_prior_i = rel_conf*r_i + (1-rel_conf)*w_i`.
   - `w_i = edge.weight`
   - `r_i = edge.metadata.relevance` (default `0`)
   - `rel_conf = 1 - H_norm(softmax(r))`, with margin fallback for very small candidate sets.
-- Router confidence is similarly computed from `QRsim` logits:
-  - `router_conf = 1 - H_norm(softmax(QRsim))`, with margin fallback for very small candidate sets.
+- Router confidence is similarly computed from `QTsim` logits:
+  - `router_conf = 1 - H_norm(softmax(QTsim))`, with margin fallback for very small candidate sets.
 - Final runtime score mixes both policies by confidence:
-  - `final_i = router_conf*QRsim_i + (1-router_conf)*graph_prior_i`
+  - `final_i = router_conf*QTsim_i + (1-router_conf)*graph_prior_i`
 - Runtime ranking remains deterministic top-k with target-id tie-breaks.
 
 Trace/schema updates:
@@ -131,4 +131,4 @@ Trace/schema updates:
 Training CLI:
 - `openclawbrain train-route-model --state ... --traces-in ... --out ...`
 - Numpy-only SGD over cross-entropy against teacher/human/self label distributions.
-- `train-route-model` trains the `QRsim` router from traces + labels (distillation and RL-derived labels), with constant edge features so weight/relevance are not direct router inputs.
+- `train-route-model` trains the `QTsim` router from traces + labels (distillation and RL-derived labels), with constant edge features so weight/relevance are not direct router inputs.

--- a/openclawbrain/route_model.py
+++ b/openclawbrain/route_model.py
@@ -135,7 +135,7 @@ class RouteModel:
 
     @classmethod
     def init_identity(cls, d: int, df: int = 1) -> "RouteModel":
-        """Initialize an identity-like QRsim-only model."""
+        """Initialize an identity-like QTsim-only model."""
         if d <= 0 or df <= 0:
             raise ValueError("d and df must be positive")
         A = np.eye(d, dtype=float)


### PR DESCRIPTION
## Summary
- rename query-target similarity/router term references from  to 
- clarify definition text as Query-Target Similarity term (route-model projected query/target similarity + bias)
- update  wording to  in docs/comment strings

## Validation
- ........................................................................ [ 16%]
........................................................................ [ 33%]
........................................................................ [ 50%]
........................................................................ [ 66%]
........................................................................ [ 83%]
.......................................................................  [100%]
431 passed in 3.11s