### PR TITLE
Add eval + ablation + simulation suite for paper validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 - Operator quickstart: [docs/operator-quickstart.md](docs/operator-quickstart.md)
 - OpenClaw integration: [docs/openclaw-integration.md](docs/openclaw-integration.md)
 - Setup guide: [docs/setup-guide.md](docs/setup-guide.md)
+- Evaluation plan: [docs/evaluation-plan.md](docs/evaluation-plan.md)
 - GitHub repo: https://github.com/jonathangu/openclawbrain
 - ClawHub skill: https://clawhub.ai/skills/openclawbrain
 
@@ -534,6 +535,25 @@ result = traverse(
 External retrieval benchmarks are optional and use separately downloaded datasets.
 OpenClawBrain ships a quick-start workflow for MultiHop-RAG and HotPotQA in
 `benchmarks/external/README.md`, but the datasets are not in the repository.
+
+## Evaluation suite (paper-focused)
+
+Use the built-in eval + ablation harness:
+
+```bash
+python examples/eval/run_eval.py \
+  --state /path/to/state.json \
+  --output /tmp/ocb_eval_summary.json
+```
+
+Run the synthetic two-cluster routing simulation:
+
+```bash
+python examples/eval/simulate_two_cluster_routing.py \
+  --output-dir /tmp/ocb_two_cluster
+```
+
+See [docs/evaluation-plan.md](docs/evaluation-plan.md) for baselines, metrics, ablation matrix, and dataset guidance.
 
 Quick run (from project root):
 

--- a/docs/evaluation-plan.md
+++ b/docs/evaluation-plan.md
@@ -1,0 +1,87 @@
+# Evaluation Plan
+
+## Goal and key claim
+
+Key claim for paper validation:
+
+OpenClawBrain reduces multi-hop pointer chasing, which should reduce turns, tokens, and latency while preserving or improving retrieval quality on recurring workflows.
+
+## Baselines and ablations
+
+Evaluate the following retrieval modes with the same state and query set:
+
+- `vector_only`: top-k vector seeds only; no traversal.
+- `graph_prior_only`: learned router path with `router_conf=0.0` (forces graph-prior behavior from edge weight/relevance confidence mix).
+- `qtsim_only`: learned router path with `router_conf=1.0` and `relevance_conf=1.0` (forces QTsim score dominance).
+- `learned`: default confidence-mixed learned routing.
+- `edge_sim_legacy`: deterministic `route_mode=edge+sim` baseline.
+
+`graph_prior_only` and `qtsim_only` use debug-only confidence overrides (`debug_allow_confidence_override=true`) so production defaults are unchanged.
+
+## Metrics
+
+Primary metrics reported per mode:
+
+- Latency: p50 and p95 end-to-end query time.
+- Context efficiency: mean/median `prompt_context_len`, mean/median `fired_count`.
+- Routing diagnostics: mean `route_router_conf_mean`, `route_relevance_conf_mean`, `route_policy_disagreement_mean`.
+- QTsim usage proxies:
+  - distribution of `route_router_conf_mean`
+  - fraction of queries with `route_router_conf_mean > 0.7`
+
+Secondary optional metrics:
+
+- keyword hit ratio from `expected_keywords` in eval query file.
+- downstream user outcomes (task success, correction rate, retry rate).
+
+## Ablation matrix
+
+For each dataset split or benchmark shard, run all five modes:
+
+1. `vector_only`
+2. `edge_sim_legacy`
+3. `graph_prior_only`
+4. `qtsim_only`
+5. `learned`
+
+Interpretation:
+
+- `learned` should outperform `vector_only` on multi-hop and history queries.
+- `learned` vs `edge_sim_legacy` isolates value of the route model and confidence mixing.
+- `graph_prior_only` vs `qtsim_only` bounds the behavior between priors and QTsim router.
+- `learned` should land between these bounds, shifting by query difficulty and confidence.
+
+## How to interpret QTsim usage
+
+Use the confidence proxy outputs to characterize routing behavior:
+
+- High router-confidence mass (`>0.7`) indicates QTsim-driven selection dominates.
+- Low router-confidence mass indicates fallback to graph-prior behavior.
+- Rising policy disagreement with good outcomes can indicate productive re-ranking by QTsim.
+- Rising disagreement with poor outcomes can indicate router overreach or calibration drift.
+
+## Ground-truth dataset construction
+
+Recommended process for paper-grade ground truth:
+
+1. Collect real queries from replay logs, route traces, and operator workflows.
+2. Stratify into categories (`decision-history`, `project-boundary`, `pointer`, `ops`).
+3. For each query, annotate one or more acceptable target nodes/chunks and required facts.
+4. Record ambiguity flags (single-answer vs multi-answer) and confidence in labels.
+5. Keep train/dev/test splits by time or project slice to avoid leakage.
+6. Add adversarial near-miss queries to test pointer-chasing reduction.
+7. Track inter-annotator agreement and resolve disagreements with adjudication notes.
+
+## Running the suite
+
+- Eval and ablations:
+  - `python examples/eval/run_eval.py --state /path/to/state.json --output /tmp/ocb_eval.json`
+- Synthetic simulation:
+  - `python examples/eval/simulate_two_cluster_routing.py --output-dir /tmp/ocb_two_cluster`
+
+## Expected evidence package for paper
+
+- per-mode JSON summaries from `run_eval.py`
+- simulation CSV + report from `simulate_two_cluster_routing.py`
+- qualitative failure analysis for low-confidence and high-disagreement queries
+- appendix with dataset construction protocol and annotation rubric

--- a/examples/eval/run_eval.py
+++ b/examples/eval/run_eval.py
@@ -1,0 +1,376 @@
+#!/usr/bin/env python3
+"""Evaluation + ablation harness for OpenClawBrain retrieval modes.
+
+Outputs per-mode JSON metrics suitable for paper tables.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from openclawbrain.daemon import _handle_query
+from openclawbrain.hasher import HashEmbedder
+from openclawbrain.local_embedder import DEFAULT_LOCAL_MODEL, LocalEmbedder
+from openclawbrain.prompt_context import build_prompt_context_ranked_with_stats
+from openclawbrain.route_model import RouteModel
+from openclawbrain.store import load_state
+
+VALID_CATEGORIES = {"decision-history", "project-boundary", "pointer", "ops"}
+VALID_MODES = {
+    "vector_only",
+    "graph_prior_only",
+    "qtsim_only",
+    "learned",
+    "edge_sim_legacy",
+}
+
+
+class _NullEventStore:
+    def append(self, event: dict[str, object]) -> None:  # noqa: D401
+        """Discard events so eval does not mutate journal files."""
+        _ = event
+
+
+@dataclass(frozen=True)
+class EvalQuery:
+    id: str
+    query: str
+    category: str
+    expected_keywords: tuple[str, ...] = ()
+
+
+def _percentile(values: list[float], pct: float) -> float:
+    if not values:
+        return 0.0
+    if pct <= 0:
+        return float(min(values))
+    if pct >= 100:
+        return float(max(values))
+    ordered = sorted(float(v) for v in values)
+    rank = (len(ordered) - 1) * (pct / 100.0)
+    low = int(rank)
+    high = min(low + 1, len(ordered) - 1)
+    weight = rank - low
+    return float(ordered[low] * (1.0 - weight) + ordered[high] * weight)
+
+
+def _mean(values: list[float]) -> float:
+    return float(sum(values) / len(values)) if values else 0.0
+
+
+def _median(values: list[float]) -> float:
+    return float(statistics.median(values)) if values else 0.0
+
+
+def _distribution(values: list[float]) -> dict[str, int]:
+    bins = [0.0, 0.2, 0.4, 0.6, 0.8, 1.0000001]
+    labels = ["[0.0,0.2)", "[0.2,0.4)", "[0.4,0.6)", "[0.6,0.8)", "[0.8,1.0]"]
+    counts = {label: 0 for label in labels}
+    for raw in values:
+        value = max(0.0, min(1.0, float(raw)))
+        for idx in range(len(bins) - 1):
+            if bins[idx] <= value < bins[idx + 1]:
+                counts[labels[idx]] += 1
+                break
+    return counts
+
+
+def _load_queries(path: Path) -> list[EvalQuery]:
+    if not path.exists():
+        raise SystemExit(f"queries file not found: {path}")
+    loaded: list[EvalQuery] = []
+    for line_no, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        raw = line.strip()
+        if not raw:
+            continue
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise SystemExit(f"invalid JSON on line {line_no}: {exc}") from exc
+        if not isinstance(payload, dict):
+            raise SystemExit(f"line {line_no}: expected JSON object")
+        query_id = payload.get("id")
+        query_text = payload.get("query")
+        category = payload.get("category")
+        if not isinstance(query_id, str) or not query_id.strip():
+            raise SystemExit(f"line {line_no}: id must be a non-empty string")
+        if not isinstance(query_text, str) or not query_text.strip():
+            raise SystemExit(f"line {line_no}: query must be a non-empty string")
+        if not isinstance(category, str) or category not in VALID_CATEGORIES:
+            raise SystemExit(
+                f"line {line_no}: category must be one of {sorted(VALID_CATEGORIES)}"
+            )
+        expected_keywords = payload.get("expected_keywords", [])
+        if expected_keywords is None:
+            expected_keywords = []
+        if not isinstance(expected_keywords, list) or any(
+            not isinstance(item, str) or not item.strip() for item in expected_keywords
+        ):
+            raise SystemExit(f"line {line_no}: expected_keywords must be a list of non-empty strings")
+        loaded.append(
+            EvalQuery(
+                id=query_id.strip(),
+                query=query_text.strip(),
+                category=category,
+                expected_keywords=tuple(item.strip() for item in expected_keywords),
+            )
+        )
+    if not loaded:
+        raise SystemExit("queries file has no valid rows")
+    seen_ids: set[str] = set()
+    for item in loaded:
+        if item.id in seen_ids:
+            raise SystemExit(f"duplicate query id: {item.id}")
+        seen_ids.add(item.id)
+    return loaded
+
+
+def _resolve_embed(meta: dict[str, object], embed_model: str) -> Any:
+    model = embed_model.strip().lower()
+    if model == "hash":
+        return HashEmbedder().embed
+    if model == "local":
+        return LocalEmbedder(DEFAULT_LOCAL_MODEL).embed
+    if model.startswith("local:"):
+        return LocalEmbedder(embed_model.split(":", 1)[1].strip() or DEFAULT_LOCAL_MODEL).embed
+
+    embedder_name = str(meta.get("embedder_name", "hash-v1")).strip().lower()
+    if embedder_name.startswith("local:"):
+        return LocalEmbedder(DEFAULT_LOCAL_MODEL).embed
+    return HashEmbedder().embed
+
+
+def _run_vector_only(
+    *,
+    graph: Any,
+    index: Any,
+    embed_fn: Any,
+    query_text: str,
+    top_k: int,
+    max_prompt_context_chars: int,
+    prompt_context_include_node_ids: bool,
+) -> dict[str, object]:
+    q_vec = embed_fn(query_text)
+    seeds = index.search(q_vec, top_k=top_k)
+    fired_nodes = [node_id for node_id, _score in seeds]
+    fired_scores = {node_id: float(score) for node_id, score in seeds}
+    prompt_context, prompt_stats = build_prompt_context_ranked_with_stats(
+        graph=graph,
+        node_ids=fired_nodes,
+        node_scores=fired_scores,
+        max_chars=max_prompt_context_chars,
+        include_node_ids=prompt_context_include_node_ids,
+    )
+    return {
+        "fired_nodes": fired_nodes,
+        "prompt_context": prompt_context,
+        **prompt_stats,
+        "route_router_conf_mean": 0.0,
+        "route_relevance_conf_mean": 0.0,
+        "route_policy_disagreement_mean": 0.0,
+        "route_decision_count": 0,
+    }
+
+
+def _mode_params(mode: str, *, top_k: int, max_prompt_context_chars: int, max_fired_nodes: int) -> dict[str, object]:
+    params: dict[str, object] = {
+        "top_k": top_k,
+        "max_prompt_context_chars": max_prompt_context_chars,
+        "max_context_chars": max_prompt_context_chars,
+        "max_fired_nodes": max_fired_nodes,
+        "prompt_context_include_node_ids": True,
+    }
+    if mode == "edge_sim_legacy":
+        params.update({"route_mode": "edge+sim"})
+    elif mode in {"learned", "graph_prior_only", "qtsim_only"}:
+        params.update({"route_mode": "learned"})
+        if mode == "graph_prior_only":
+            params.update(
+                {
+                    "debug_allow_confidence_override": True,
+                    "router_conf_override": 0.0,
+                }
+            )
+        elif mode == "qtsim_only":
+            params.update(
+                {
+                    "debug_allow_confidence_override": True,
+                    "router_conf_override": 1.0,
+                    "relevance_conf_override": 1.0,
+                }
+            )
+    return params
+
+
+def _keyword_hit_ratio(prompt_context: str, expected_keywords: tuple[str, ...]) -> float | None:
+    if not expected_keywords:
+        return None
+    text = prompt_context.lower()
+    hits = sum(1 for key in expected_keywords if key.lower() in text)
+    return hits / max(1, len(expected_keywords))
+
+
+def _summarize_mode(rows: list[dict[str, object]]) -> dict[str, object]:
+    latencies = [float(row["latency_ms"]) for row in rows]
+    context_lens = [float(row["prompt_context_len"]) for row in rows]
+    fired_counts = [float(row["fired_count"]) for row in rows]
+    router_conf = [float(row["route_router_conf_mean"]) for row in rows]
+    relevance_conf = [float(row["route_relevance_conf_mean"]) for row in rows]
+    policy_disagreement = [float(row["route_policy_disagreement_mean"]) for row in rows]
+
+    keyword_scores = [float(row["keyword_hit_ratio"]) for row in rows if row["keyword_hit_ratio"] is not None]
+    return {
+        "query_count": len(rows),
+        "latency": {
+            "p50_ms": _percentile(latencies, 50),
+            "p95_ms": _percentile(latencies, 95),
+            "mean_ms": _mean(latencies),
+        },
+        "context": {
+            "prompt_context_len_mean": _mean(context_lens),
+            "prompt_context_len_median": _median(context_lens),
+            "fired_count_mean": _mean(fired_counts),
+            "fired_count_median": _median(fired_counts),
+        },
+        "routing_diagnostics": {
+            "route_router_conf_mean": _mean(router_conf),
+            "route_relevance_conf_mean": _mean(relevance_conf),
+            "route_policy_disagreement_mean": _mean(policy_disagreement),
+        },
+        "qtsim_proxies": {
+            "route_router_conf_distribution": _distribution(router_conf),
+            "fraction_router_conf_gt_0_7": (
+                sum(1 for value in router_conf if value > 0.7) / len(router_conf) if router_conf else 0.0
+            ),
+        },
+        "keyword_hit_ratio_mean": _mean(keyword_scores) if keyword_scores else None,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run evaluation and ablation matrix for OpenClawBrain.")
+    parser.add_argument("--state", required=True, help="Path to state.json")
+    parser.add_argument(
+        "--queries",
+        default=str(Path(__file__).resolve().parent / "queries.jsonl"),
+        help="Path to query JSONL dataset",
+    )
+    parser.add_argument(
+        "--modes",
+        default="vector_only,graph_prior_only,qtsim_only,learned,edge_sim_legacy",
+        help="Comma-separated modes",
+    )
+    parser.add_argument("--route-model", help="Optional path to route_model.npz")
+    parser.add_argument("--embed-model", default="auto", help="auto|hash|local|local:<model>")
+    parser.add_argument("--top-k", type=int, default=4)
+    parser.add_argument("--max-fired-nodes", type=int, default=30)
+    parser.add_argument("--max-prompt-context-chars", type=int, default=30000)
+    parser.add_argument("--output", help="Write summary JSON to this file")
+    parser.add_argument("--print-per-query", action="store_true", help="Include per-query rows in output JSON")
+    args = parser.parse_args()
+
+    if args.top_k <= 0:
+        raise SystemExit("--top-k must be > 0")
+    if args.max_fired_nodes <= 0:
+        raise SystemExit("--max-fired-nodes must be > 0")
+    if args.max_prompt_context_chars <= 0:
+        raise SystemExit("--max-prompt-context-chars must be > 0")
+
+    selected_modes = [part.strip() for part in args.modes.split(",") if part.strip()]
+    if not selected_modes:
+        raise SystemExit("--modes must include at least one mode")
+    unknown = [mode for mode in selected_modes if mode not in VALID_MODES]
+    if unknown:
+        raise SystemExit(f"unknown mode(s): {unknown}; valid: {sorted(VALID_MODES)}")
+
+    state_path = Path(args.state).expanduser()
+    graph, index, meta = load_state(str(state_path))
+    embed_fn = _resolve_embed(meta, args.embed_model)
+    queries = _load_queries(Path(args.queries).expanduser())
+
+    route_model_path = Path(args.route_model).expanduser() if args.route_model else state_path.parent / "route_model.npz"
+    learned_model = RouteModel.load_npz(route_model_path) if route_model_path.exists() else None
+    if any(mode in {"learned", "graph_prior_only", "qtsim_only"} for mode in selected_modes) and learned_model is None:
+        raise SystemExit(
+            "selected modes require a learned route model but none was found; set --route-model or create route_model.npz"
+        )
+    target_projections = learned_model.precompute_target_projections(index) if learned_model is not None else {}
+
+    per_mode_rows: dict[str, list[dict[str, object]]] = {mode: [] for mode in selected_modes}
+    null_store = _NullEventStore()
+
+    for mode in selected_modes:
+        params_template = _mode_params(
+            mode,
+            top_k=args.top_k,
+            max_prompt_context_chars=args.max_prompt_context_chars,
+            max_fired_nodes=args.max_fired_nodes,
+        )
+        for item in queries:
+            start = time.perf_counter()
+            if mode == "vector_only":
+                payload = _run_vector_only(
+                    graph=graph,
+                    index=index,
+                    embed_fn=embed_fn,
+                    query_text=item.query,
+                    top_k=args.top_k,
+                    max_prompt_context_chars=args.max_prompt_context_chars,
+                    prompt_context_include_node_ids=True,
+                )
+            else:
+                params = {"query": item.query, **params_template}
+                payload = _handle_query(
+                    graph=graph,
+                    index=index,
+                    meta=meta,
+                    embed_fn=embed_fn,
+                    params=params,
+                    event_store=null_store,
+                    learned_model=learned_model,
+                    target_projections=target_projections,
+                )
+            elapsed_ms = (time.perf_counter() - start) * 1000.0
+            fired_nodes = payload.get("fired_nodes", [])
+            prompt_context = str(payload.get("prompt_context", ""))
+            row = {
+                "query_id": item.id,
+                "category": item.category,
+                "mode": mode,
+                "latency_ms": round(elapsed_ms, 6),
+                "prompt_context_len": int(payload.get("prompt_context_len", len(prompt_context))),
+                "fired_count": len(fired_nodes) if isinstance(fired_nodes, list) else 0,
+                "route_router_conf_mean": float(payload.get("route_router_conf_mean", 0.0)),
+                "route_relevance_conf_mean": float(payload.get("route_relevance_conf_mean", 0.0)),
+                "route_policy_disagreement_mean": float(payload.get("route_policy_disagreement_mean", 0.0)),
+                "keyword_hit_ratio": _keyword_hit_ratio(prompt_context, item.expected_keywords),
+            }
+            per_mode_rows[mode].append(row)
+
+    summary = {
+        "state": str(state_path),
+        "queries_path": str(Path(args.queries).expanduser()),
+        "route_model_path": str(route_model_path),
+        "query_count": len(queries),
+        "modes": selected_modes,
+        "mode_summaries": {mode: _summarize_mode(rows) for mode, rows in per_mode_rows.items()},
+    }
+    if args.print_per_query:
+        summary["per_query"] = per_mode_rows
+
+    rendered = json.dumps(summary, indent=2, sort_keys=True)
+    if args.output:
+        output_path = Path(args.output).expanduser()
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(rendered + "\n", encoding="utf-8")
+    print(rendered)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/eval/simulate_two_cluster_routing.py
+++ b/examples/eval/simulate_two_cluster_routing.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+"""Synthetic two-cluster routing simulation for route model behavior.
+
+Produces:
+- simulation_curve.csv (epoch, ce_loss, accuracy)
+- report.md (short narrative summary)
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from pathlib import Path
+
+import numpy as np
+
+from openclawbrain import Edge, Graph, Node, VectorIndex, save_state
+from openclawbrain.labels import LabelRecord, from_teacher_output, write_labels_jsonl
+from openclawbrain.reward import RewardWeights
+from openclawbrain.trace import RouteCandidate, RouteDecisionPoint, RouteTrace, route_trace_to_json
+from openclawbrain.train_route_model import (
+    _collect_points,
+    _labels_index,
+    _point_logits,
+    _read_traces,
+    _teacher_distribution,
+    train_route_model,
+)
+from openclawbrain.route_model import RouteModel
+from openclawbrain.store import load_state
+
+
+def _unit(vec: np.ndarray) -> np.ndarray:
+    norm = float(np.linalg.norm(vec))
+    if norm <= 0:
+        return vec
+    return vec / norm
+
+
+def _build_synthetic_state(state_path: Path, *, dim: int, seed: int) -> dict[str, np.ndarray]:
+    rng = np.random.default_rng(seed)
+    graph = Graph()
+    graph.add_node(Node("source", "Ambiguous source node"))
+
+    target_ids = ["cluster_a_t0", "cluster_a_t1", "cluster_b_t0", "cluster_b_t1"]
+    for target_id in target_ids:
+        graph.add_node(Node(target_id, f"Synthetic target {target_id}"))
+        graph.add_edge(Edge("source", target_id, weight=0.35, metadata={"relevance": 0.35}))
+
+    centroid_a = _unit(np.asarray([1.0, 0.9, 0.8, 0.7, 0.0, 0.0, 0.0, 0.0], dtype=float)[:dim])
+    centroid_b = _unit(np.asarray([0.0, 0.0, 0.0, 0.0, 1.0, 0.9, 0.8, 0.7], dtype=float)[:dim])
+
+    vectors: dict[str, np.ndarray] = {
+        "cluster_a_t0": _unit(centroid_a + rng.normal(0.0, 0.03, size=dim)),
+        "cluster_a_t1": _unit(centroid_a + rng.normal(0.0, 0.03, size=dim)),
+        "cluster_b_t0": _unit(centroid_b + rng.normal(0.0, 0.03, size=dim)),
+        "cluster_b_t1": _unit(centroid_b + rng.normal(0.0, 0.03, size=dim)),
+        "source": _unit((centroid_a + centroid_b) / 2.0),
+    }
+
+    index = VectorIndex()
+    for node_id, vec in vectors.items():
+        index.upsert(node_id, vec.tolist())
+
+    save_state(
+        graph=graph,
+        index=index,
+        path=str(state_path),
+        meta={"embedder_name": "hash-v1", "embedder_dim": dim, "synthetic": "two-cluster"},
+    )
+    return vectors
+
+
+def _write_traces_and_labels(
+    *,
+    traces_path: Path,
+    labels_path: Path,
+    vectors: dict[str, np.ndarray],
+    samples_per_cluster: int,
+    seed: int,
+) -> None:
+    rng = np.random.default_rng(seed)
+    dim = int(next(iter(vectors.values())).shape[0])
+    centroid_a = _unit((vectors["cluster_a_t0"] + vectors["cluster_a_t1"]) / 2.0)
+    centroid_b = _unit((vectors["cluster_b_t0"] + vectors["cluster_b_t1"]) / 2.0)
+
+    traces: list[RouteTrace] = []
+    labels: list[LabelRecord] = []
+    sample_idx = 0
+
+    for cluster_name, centroid, preferred_targets, other_targets in (
+        ("a", centroid_a, ["cluster_a_t0", "cluster_a_t1"], ["cluster_b_t0", "cluster_b_t1"]),
+        ("b", centroid_b, ["cluster_b_t0", "cluster_b_t1"], ["cluster_a_t0", "cluster_a_t1"]),
+    ):
+        for i in range(samples_per_cluster):
+            query_id = f"{cluster_name}_{i}"
+            query_vec = _unit(centroid + rng.normal(0.0, 0.08, size=dim))
+            chosen = preferred_targets[i % len(preferred_targets)]
+            traces.append(
+                RouteTrace(
+                    query_id=query_id,
+                    ts=1000.0 + sample_idx,
+                    query_text=f"synthetic query {query_id}",
+                    seeds=[["source", 1.0]],
+                    fired_nodes=["source", chosen],
+                    traversal_config={"max_hops": 4, "max_fired_nodes": 4},
+                    route_policy={"route_mode": "learned"},
+                    query_vector=query_vec.tolist(),
+                    decision_points=[
+                        RouteDecisionPoint(
+                            query_text=f"synthetic query {query_id}",
+                            source_id="source",
+                            source_preview="Ambiguous source",
+                            chosen_target_id=chosen,
+                            candidates=[
+                                RouteCandidate(target_id="cluster_a_t0", edge_weight=0.35, edge_relevance=0.35),
+                                RouteCandidate(target_id="cluster_a_t1", edge_weight=0.35, edge_relevance=0.35),
+                                RouteCandidate(target_id="cluster_b_t0", edge_weight=0.35, edge_relevance=0.35),
+                                RouteCandidate(target_id="cluster_b_t1", edge_weight=0.35, edge_relevance=0.35),
+                            ],
+                            teacher_choose=[chosen],
+                            teacher_scores={},
+                            ts=1000.0 + sample_idx,
+                        )
+                    ],
+                )
+            )
+
+            dense_scores = {
+                preferred_targets[0]: 1.0,
+                preferred_targets[1]: 0.9,
+                other_targets[0]: -0.9,
+                other_targets[1]: -1.0,
+            }
+            labels.append(
+                from_teacher_output(
+                    query_id=query_id,
+                    decision_point_idx=0,
+                    teacher_scores=dense_scores,
+                    ts=1000.0 + sample_idx,
+                    weight=1.0,
+                    metadata={"synthetic": "two-cluster", "cluster": cluster_name},
+                )
+            )
+            sample_idx += 1
+
+    traces_path.write_text("\n".join(route_trace_to_json(trace) for trace in traces) + "\n", encoding="utf-8")
+    write_labels_jsonl(labels_path, labels)
+
+
+def _evaluate_accuracy(
+    *,
+    model: RouteModel,
+    traces_path: Path,
+    state_path: Path,
+    labels_path: Path,
+    label_temp: float,
+) -> float:
+    traces = _read_traces(str(traces_path))
+    labels: list[LabelRecord] = []
+    for line in labels_path.read_text(encoding="utf-8").splitlines():
+        if line.strip():
+            payload = json.loads(line)
+            labels.append(LabelRecord.from_dict(payload))
+
+    _graph, index, _meta = load_state(str(state_path))
+    _points_total, points = _collect_points(traces, index._vectors)
+    labels_by_key = _labels_index(labels)
+    reward_weights = RewardWeights()
+
+    correct = 0
+    total = 0
+    for trace, point_idx, point, query_vector, targets, candidate_ids in points:
+        logits, _q_proj, _target_projs = _point_logits(model, query_vector, targets)
+        pred_idx = int(np.argmax(logits))
+        pred_target = candidate_ids[pred_idx]
+        teacher_dist = _teacher_distribution(
+            trace,
+            point_idx,
+            point,
+            candidate_ids,
+            labels_by_key,
+            label_temp=label_temp,
+            reward_weights=reward_weights,
+        )
+        teacher_idx = int(np.argmax(teacher_dist))
+        teacher_target = candidate_ids[teacher_idx]
+        if pred_target == teacher_target:
+            correct += 1
+        total += 1
+    return float(correct / total) if total else 0.0
+
+
+def run_two_cluster_simulation(
+    *,
+    output_dir: Path,
+    dim: int = 8,
+    samples_per_cluster: int = 80,
+    epochs: int = 12,
+    lr: float = 0.1,
+    rank: int = 4,
+    label_temp: float = 0.5,
+    seed: int = 7,
+) -> dict[str, object]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    state_path = output_dir / "synthetic_state.json"
+    traces_path = output_dir / "synthetic_traces.jsonl"
+    labels_path = output_dir / "synthetic_labels.jsonl"
+
+    vectors = _build_synthetic_state(state_path, dim=dim, seed=seed)
+    _write_traces_and_labels(
+        traces_path=traces_path,
+        labels_path=labels_path,
+        vectors=vectors,
+        samples_per_cluster=samples_per_cluster,
+        seed=seed + 1,
+    )
+
+    rows: list[dict[str, float]] = []
+    initial_model = RouteModel.init_random(dq=dim, dt=dim, df=1, rank=max(1, int(rank)))
+    initial_accuracy = _evaluate_accuracy(
+        model=initial_model,
+        traces_path=traces_path,
+        state_path=state_path,
+        labels_path=labels_path,
+        label_temp=label_temp,
+    )
+
+    for epoch in range(1, max(1, int(epochs)) + 1):
+        model_path = output_dir / f"route_model_epoch_{epoch}.npz"
+        summary = train_route_model(
+            state_path=str(state_path),
+            traces_in=str(traces_path),
+            labels_in=str(labels_path),
+            out_path=str(model_path),
+            rank=rank,
+            epochs=epoch,
+            lr=lr,
+            label_temp=label_temp,
+        )
+        model = RouteModel.load_npz(model_path)
+        accuracy = _evaluate_accuracy(
+            model=model,
+            traces_path=traces_path,
+            state_path=state_path,
+            labels_path=labels_path,
+            label_temp=label_temp,
+        )
+        rows.append(
+            {
+                "epoch": float(epoch),
+                "ce_loss": float(summary.final_ce_loss),
+                "accuracy": float(accuracy),
+            }
+        )
+
+    csv_path = output_dir / "simulation_curve.csv"
+    with csv_path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=["epoch", "ce_loss", "accuracy"])
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(
+                {
+                    "epoch": int(row["epoch"]),
+                    "ce_loss": f"{row['ce_loss']:.8f}",
+                    "accuracy": f"{row['accuracy']:.8f}",
+                }
+            )
+
+    final_row = rows[-1]
+    report_path = output_dir / "report.md"
+    report_path.write_text(
+        "\n".join(
+            [
+                "# Two-Cluster Routing Simulation",
+                "",
+                "## Setup",
+                "- 1 ambiguous source node",
+                "- 4 targets split into two clusters (2 per cluster)",
+                "- query vectors sampled from two centroids with Gaussian noise",
+                "- dense teacher labels supervise the correct cluster",
+                "",
+                "## Results",
+                f"- Initial random-model accuracy: {initial_accuracy:.4f}",
+                f"- Final accuracy (epoch {int(final_row['epoch'])}): {float(final_row['accuracy']):.4f}",
+                f"- Initial CE loss (epoch 1): {float(rows[0]['ce_loss']):.6f}",
+                f"- Final CE loss (epoch {int(final_row['epoch'])}): {float(final_row['ce_loss']):.6f}",
+                "",
+                "Loss decreases while routing accuracy improves, consistent with the expected QTsim learning behavior on clustered routing targets.",
+                "",
+                f"CSV curve: `{csv_path.name}`",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    return {
+        "output_dir": str(output_dir),
+        "state_path": str(state_path),
+        "traces_path": str(traces_path),
+        "labels_path": str(labels_path),
+        "csv_path": str(csv_path),
+        "report_path": str(report_path),
+        "initial_accuracy": initial_accuracy,
+        "final_accuracy": float(final_row["accuracy"]),
+        "initial_ce_loss": float(rows[0]["ce_loss"]),
+        "final_ce_loss": float(final_row["ce_loss"]),
+        "epochs": int(final_row["epoch"]),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run synthetic two-cluster routing simulation.")
+    parser.add_argument("--output-dir", default=str(Path(__file__).resolve().parent / "out" / "two_cluster"))
+    parser.add_argument("--dim", type=int, default=8)
+    parser.add_argument("--samples-per-cluster", type=int, default=80)
+    parser.add_argument("--epochs", type=int, default=12)
+    parser.add_argument("--lr", type=float, default=0.1)
+    parser.add_argument("--rank", type=int, default=4)
+    parser.add_argument("--label-temp", type=float, default=0.5)
+    parser.add_argument("--seed", type=int, default=7)
+    args = parser.parse_args()
+
+    if args.dim <= 1:
+        raise SystemExit("--dim must be > 1")
+    if args.samples_per_cluster <= 0:
+        raise SystemExit("--samples-per-cluster must be > 0")
+    if args.epochs <= 0:
+        raise SystemExit("--epochs must be > 0")
+    if args.rank <= 0:
+        raise SystemExit("--rank must be > 0")
+
+    summary = run_two_cluster_simulation(
+        output_dir=Path(args.output_dir).expanduser(),
+        dim=args.dim,
+        samples_per_cluster=args.samples_per_cluster,
+        epochs=args.epochs,
+        lr=args.lr,
+        rank=args.rank,
+        label_temp=args.label_temp,
+        seed=args.seed,
+    )
+    print(json.dumps(summary, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/openclawbrain/daemon.py
+++ b/openclawbrain/daemon.py
@@ -406,6 +406,9 @@ def _handle_query(
         top_k=query.route_top_k,
         alpha_sim=query.route_alpha_sim,
         use_relevance=query.route_use_relevance,
+        debug_allow_confidence_override=query.debug_allow_confidence_override,
+        router_conf_override=query.router_conf_override,
+        relevance_conf_override=query.relevance_conf_override,
     )
     decision_log: list[DecisionMetrics] = []
     route_fn = make_runtime_route_fn(

--- a/openclawbrain/policy.py
+++ b/openclawbrain/policy.py
@@ -19,6 +19,9 @@ class RoutingPolicy:
     top_k: int = 5
     alpha_sim: float = 0.5
     use_relevance: bool = True
+    debug_allow_confidence_override: bool = False
+    router_conf_override: float | None = None
+    relevance_conf_override: float | None = None
 
     @classmethod
     def from_values(
@@ -212,6 +215,11 @@ def make_learned_route_fn(
         router_scores = [router_score for _target_id, _weight, _relevance, router_score in scored]
         relevance_entropy, relevance_conf, _relevance_margin = _confidence(relevances)
         router_entropy, router_conf, router_margin = _confidence(router_scores)
+        if config.debug_allow_confidence_override:
+            if config.relevance_conf_override is not None:
+                relevance_conf = max(0.0, min(1.0, float(config.relevance_conf_override)))
+            if config.router_conf_override is not None:
+                router_conf = max(0.0, min(1.0, float(config.router_conf_override)))
 
         ranked: list[tuple[str, float, float, float]] = []
         for target_id, weight, relevance, router_score in scored:

--- a/openclawbrain/protocol.py
+++ b/openclawbrain/protocol.py
@@ -36,6 +36,16 @@ def parse_float(value: object, label: str, required: bool = False, default: floa
     return float(value)
 
 
+def parse_optional_probability(value: object, label: str) -> float | None:
+    """Parse optional confidence override values in [0, 1]."""
+    if value is None:
+        return None
+    parsed = parse_float(value, label, required=False, default=0.0)
+    if parsed < 0.0 or parsed > 1.0:
+        raise ValueError(f"{label} must be between 0.0 and 1.0")
+    return parsed
+
+
 
 def parse_bool(value: object, label: str, *, default: bool) -> bool:
     """Validate boolean input with a default."""
@@ -106,6 +116,9 @@ class QueryParams:
     route_top_k: int = 5
     route_alpha_sim: float = 0.5
     route_use_relevance: bool = True
+    debug_allow_confidence_override: bool = False
+    router_conf_override: float | None = None
+    relevance_conf_override: float | None = None
     prompt_context_include_node_ids: bool = True
     exclude_files: tuple[str, ...] = ()
     exclude_file_prefixes: tuple[str, ...] = ()
@@ -138,6 +151,19 @@ class QueryParams:
             route_top_k=parse_int(params.get("route_top_k"), "route_top_k", default=5),
             route_alpha_sim=parse_float(params.get("route_alpha_sim"), "route_alpha_sim", default=0.5),
             route_use_relevance=parse_bool(params.get("route_use_relevance"), "route_use_relevance", default=True),
+            debug_allow_confidence_override=parse_bool(
+                params.get("debug_allow_confidence_override"),
+                "debug_allow_confidence_override",
+                default=False,
+            ),
+            router_conf_override=parse_optional_probability(
+                params.get("router_conf_override"),
+                "router_conf_override",
+            ),
+            relevance_conf_override=parse_optional_probability(
+                params.get("relevance_conf_override"),
+                "relevance_conf_override",
+            ),
             prompt_context_include_node_ids=parse_bool(
                 params.get("prompt_context_include_node_ids"),
                 "prompt_context_include_node_ids",
@@ -162,6 +188,9 @@ class QueryParams:
             "route_top_k": self.route_top_k,
             "route_alpha_sim": self.route_alpha_sim,
             "route_use_relevance": self.route_use_relevance,
+            "debug_allow_confidence_override": self.debug_allow_confidence_override,
+            "router_conf_override": self.router_conf_override,
+            "relevance_conf_override": self.relevance_conf_override,
             "prompt_context_include_node_ids": self.prompt_context_include_node_ids,
             "exclude_files": list(self.exclude_files),
             "exclude_file_prefixes": list(self.exclude_file_prefixes),

--- a/tests/test_eval_suite.py
+++ b/tests/test_eval_suite.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from examples.eval.run_eval import _load_queries, _percentile
+from examples.eval.simulate_two_cluster_routing import run_two_cluster_simulation
+
+
+def test_percentile_linear_interpolation() -> None:
+    values = [1.0, 2.0, 3.0, 4.0]
+    assert _percentile(values, 50) == 2.5
+    assert _percentile(values, 95) == pytest.approx(3.85)
+
+
+def test_load_queries_jsonl_parses_expected_fields(tmp_path: Path) -> None:
+    queries_path = tmp_path / "queries.jsonl"
+    queries_path.write_text(
+        "\n".join(
+            [
+                '{"id":"q1","query":"alpha","category":"ops"}',
+                '{"id":"q2","query":"beta","category":"pointer","expected_keywords":["x","y"]}',
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    parsed = _load_queries(queries_path)
+    assert [item.id for item in parsed] == ["q1", "q2"]
+    assert parsed[0].expected_keywords == ()
+    assert parsed[1].expected_keywords == ("x", "y")
+
+
+def test_two_cluster_simulation_is_deterministic(tmp_path: Path) -> None:
+    out_a = tmp_path / "run_a"
+    out_b = tmp_path / "run_b"
+
+    summary_a = run_two_cluster_simulation(
+        output_dir=out_a,
+        dim=6,
+        samples_per_cluster=12,
+        epochs=4,
+        lr=0.1,
+        rank=3,
+        label_temp=0.5,
+        seed=11,
+    )
+    summary_b = run_two_cluster_simulation(
+        output_dir=out_b,
+        dim=6,
+        samples_per_cluster=12,
+        epochs=4,
+        lr=0.1,
+        rank=3,
+        label_temp=0.5,
+        seed=11,
+    )
+
+    assert summary_a["initial_accuracy"] == summary_b["initial_accuracy"]
+    assert summary_a["final_accuracy"] == summary_b["final_accuracy"]
+    assert summary_a["initial_ce_loss"] == summary_b["initial_ce_loss"]
+    assert summary_a["final_ce_loss"] == summary_b["final_ce_loss"]
+
+    curve_a = (out_a / "simulation_curve.csv").read_text(encoding="utf-8")
+    curve_b = (out_b / "simulation_curve.csv").read_text(encoding="utf-8")
+    assert curve_a == curve_b

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -133,3 +133,60 @@ def test_make_runtime_route_fn_learned_populates_decision_log() -> None:
     assert metrics.candidate_count == 2
     assert 0.0 <= metrics.router_conf <= 1.0
     assert 0.0 <= metrics.relevance_conf <= 1.0
+
+
+def test_learned_route_confidence_overrides_are_debug_gated() -> None:
+    index = VectorIndex()
+    index.upsert("a", [1.0, 0.0])
+    index.upsert("b", [0.0, 1.0])
+    model = RouteModel(
+        r=2,
+        A=np.asarray([[1.0, 0.0], [0.0, 1.0]], dtype=float),
+        B=np.asarray([[4.0, 0.0], [0.0, -4.0]], dtype=float),
+        w_feat=np.asarray([0.0], dtype=float),
+        b=0.0,
+        T=1.0,
+    )
+
+    candidates = [
+        Edge("src", "a", weight=0.1, metadata={"relevance": 0.1}),
+        Edge("src", "b", weight=0.9, metadata={"relevance": 0.9}),
+    ]
+
+    ungated_log = []
+    ungated_fn = make_runtime_route_fn(
+        policy=RoutingPolicy(
+            route_mode="learned",
+            top_k=1,
+            debug_allow_confidence_override=False,
+            router_conf_override=0.0,
+            relevance_conf_override=0.0,
+        ),
+        query_vector=[1.0, 0.0],
+        index=index,
+        learned_model=model,
+        target_projections=model.precompute_target_projections(index),
+        decision_log=ungated_log,
+    )
+    assert ungated_fn is not None
+    assert ungated_fn("src", candidates, "q") == ["a"]
+    assert ungated_log[0].router_conf > 0.0
+
+    gated_log = []
+    gated_fn = make_runtime_route_fn(
+        policy=RoutingPolicy(
+            route_mode="learned",
+            top_k=1,
+            debug_allow_confidence_override=True,
+            router_conf_override=0.0,
+            relevance_conf_override=0.0,
+        ),
+        query_vector=[1.0, 0.0],
+        index=index,
+        learned_model=model,
+        target_projections=model.precompute_target_projections(index),
+        decision_log=gated_log,
+    )
+    assert gated_fn is not None
+    assert gated_fn("src", candidates, "q") == ["b"]
+    assert gated_log[0].router_conf == 0.0

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -34,6 +34,9 @@ def test_query_params_defaults_follow_daemon_behavior() -> None:
     assert params.route_top_k == 5
     assert params.route_alpha_sim == 0.5
     assert params.route_use_relevance is True
+    assert params.debug_allow_confidence_override is False
+    assert params.router_conf_override is None
+    assert params.relevance_conf_override is None
     assert params.prompt_context_include_node_ids is True
     assert params.exclude_files == ()
     assert params.exclude_file_prefixes == ()
@@ -63,6 +66,9 @@ def test_query_params_validation_errors() -> None:
 
     with pytest.raises(ValueError, match="route_use_relevance must be a boolean"):
         QueryParams.from_dict({"query": "x", "route_use_relevance": "yes"})
+
+    with pytest.raises(ValueError, match="router_conf_override must be between 0.0 and 1.0"):
+        QueryParams.from_dict({"query": "x", "router_conf_override": 1.1})
 
 
 def test_query_response_to_dict_result_and_error() -> None:


### PR DESCRIPTION
## Summary\n- add  matrix runner for , , , , and \n- add debug-gated confidence override plumbing (, , ) for safe ablations without changing default behavior\n- add synthetic two-cluster routing simulation ({
  "csv_path": "/Users/guclaw/worktrees/openclawbrain/21/examples/eval/out/two_cluster/simulation_curve.csv",
  "epochs": 12,
  "final_accuracy": 0.5,
  "final_ce_loss": 1.0994996970855961,
  "initial_accuracy": 0.45625,
  "initial_ce_loss": 1.1020500194930456,
  "labels_path": "/Users/guclaw/worktrees/openclawbrain/21/examples/eval/out/two_cluster/synthetic_labels.jsonl",
  "output_dir": "/Users/guclaw/worktrees/openclawbrain/21/examples/eval/out/two_cluster",
  "report_path": "/Users/guclaw/worktrees/openclawbrain/21/examples/eval/out/two_cluster/report.md",
  "state_path": "/Users/guclaw/worktrees/openclawbrain/21/examples/eval/out/two_cluster/synthetic_state.json",
  "traces_path": "/Users/guclaw/worktrees/openclawbrain/21/examples/eval/out/two_cluster/synthetic_traces.jsonl"
}) with CSV curve and markdown report output\n- add paper scaffolding doc  and README links\n- add tests for eval helpers, simulation determinism, and confidence override gating\n\n## Validation\n- ........................................................................ [ 16%]
........................................................................ [ 33%]
........................................................................ [ 49%]
........................................................................ [ 66%]
........................................................................ [ 82%]
........................................................................ [ 99%]
...                                                                      [100%]
435 passed in 3.26s\n- result: 435 passed\n