### PR TITLE
docs: audit operator docs + README for OOTB success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Unreleased
 
+### Docs: operator OOTB audit
+- Updated README and operator-facing docs to standardize lifecycle commands on `openclawbrain serve start|status|stop`.
+- Clarified replay operator semantics around `--mode {edges-only,fast-learning,full}` and checkpoint controls (`--resume`, `--fresh`, `--checkpoint`).
+- Clarified OOTB defaults: `init` uses local embeddings first (`fastembed`) with hash fallback; OpenAI embeddings remain explicit/optional.
+- Clarified route-mode defaults/overrides: daemon defaults to `--route-mode learned`, with `edge+sim` fallback when `route_model.npz` is unavailable.
+- Removed hardcoded operator/prod size/performance snapshots from README that can become stale.
+
 ### Operator lifecycle UX (Issue #60 part 1)
 - `openclawbrain serve` now supports lifecycle subcommands: `start`, `status`, and `stop`.
 - `serve status` validates socket presence and performs a live `health` ping over the Unix socket.

--- a/README.md
+++ b/README.md
@@ -10,11 +10,13 @@
 
 ## Docs
 
-- Operator guide: [docs/operator-guide.md](docs/operator-guide.md)
-- Operator quickstart: [docs/operator-quickstart.md](docs/operator-quickstart.md)
+- Operator quickstart (start here): [docs/operator-quickstart.md](docs/operator-quickstart.md)
+- Operator guide (deep dive): [docs/operator-guide.md](docs/operator-guide.md)
+- Shadow routing architecture: [docs/shadow-routing-upg-architecture.md](docs/shadow-routing-upg-architecture.md)
+- Evaluation plan: [docs/evaluation-plan.md](docs/evaluation-plan.md)
+- QTsim math appendix: [docs/ultimate-policy-gradient-routing-math.md](docs/ultimate-policy-gradient-routing-math.md)
 - OpenClaw integration: [docs/openclaw-integration.md](docs/openclaw-integration.md)
 - Setup guide: [docs/setup-guide.md](docs/setup-guide.md)
-- Evaluation plan: [docs/evaluation-plan.md](docs/evaluation-plan.md)
 - GitHub repo: https://github.com/jonathangu/openclawbrain
 - ClawHub skill: https://clawhub.ai/skills/openclawbrain
 
@@ -31,7 +33,7 @@ Quickstart (OpenClaw users):
 ```bash
 pip install openclawbrain
 openclawbrain init --workspace ~/.openclaw/workspace --output ~/.openclawbrain/main
-openclawbrain serve --state ~/.openclawbrain/main/state.json
+openclawbrain serve start --state ~/.openclawbrain/main/state.json
 ```
 
 Production Deployment (socket):
@@ -39,7 +41,7 @@ Production Deployment (socket):
 Use LaunchAgent/systemd to keep the socket server running:
 
 ```bash
-openclawbrain serve --state ~/.openclawbrain/main/state.json
+openclawbrain serve start --state ~/.openclawbrain/main/state.json
 ```
 
 macOS (`~/Library/LaunchAgents/com.openclawbrain.daemon.plist`):
@@ -50,6 +52,7 @@ macOS (`~/Library/LaunchAgents/com.openclawbrain.daemon.plist`):
   <string>/usr/bin/env</string>
   <string>openclawbrain</string>
   <string>serve</string>
+  <string>start</string>
   <string>--state</string>
   <string>/Users/YOU/.openclawbrain/main/state.json</string>
 </array>
@@ -59,7 +62,7 @@ Linux (`/etc/systemd/system/openclawbrain-daemon.service`):
 
 ```ini
 [Service]
-ExecStart=/usr/bin/env openclawbrain serve --state /home/YOUR_USER/.openclawbrain/main/state.json
+ExecStart=/usr/bin/env openclawbrain serve start --state /home/YOUR_USER/.openclawbrain/main/state.json
 ```
 
 ```bash
@@ -104,58 +107,30 @@ See also: [Setup Guide](docs/setup-guide.md) for a complete local configuration 
 
 - Static retrieval vs learned routing: OpenClawBrain continuously updates node-to-node edges so good routes strengthen and bad routes decay.
 - No correction propagation vs inhibitory edges: incorrect context can be actively suppressed and forgotten less often than in similarity-only systems.
-- Bulk context load vs targeted traversal: context windows stay focused (roughly 52KB → 3-13KB in typical sessions) by following likely retrieval routes.
+- Bulk context load vs targeted traversal: context windows stay focused by following likely retrieval routes.
 - No structural maintenance vs prune/merge/compact: OpenClawBrain includes scheduled maintenance commands to keep the graph healthy and compact.
 - No protection vs constitutional anchors: anchor critical nodes with authority so operational instructions do not drift.
 
-## 5-minute quickstart (A→B learning story)
+## 5-minute operator path (OOTB)
 
 ```bash
-# 1. Build a brain from the sample workspace
-openclawbrain init --workspace examples/sample_workspace --output /tmp/brain
-Large texts are automatically rechunked to stay under embedding model limits (12K chars). No content is skipped or truncated.
+# 1) init (default embedder auto -> local fastembed -> hash fallback)
+openclawbrain init --workspace ~/.openclaw/workspace --output ~/.openclawbrain/main
 
-# 2. Check state health
-openclawbrain doctor --state /tmp/brain/state.json
-# output
-# PASS: python_version
-# PASS: state_file_exists
-# PASS: state_json_valid
-# Summary: 8/9 checks passed
+# 2) start service
+openclawbrain serve start --state ~/.openclawbrain/main/state.json
 
-# 3. Query (text output includes node IDs)
-openclawbrain query "how do I deploy" --state /tmp/brain/state.json --top 3 --json
-# output (abbrev.)
-# {"fired": ["deploy.md::0", "deploy.md::1", "deploy.md::2"], ...}
+# 3) status check
+openclawbrain serve status --state ~/.openclawbrain/main/state.json
 
-# 4. Teach it (good path)
-openclawbrain learn --state /tmp/brain/state.json --outcome 1.0 --fired-ids "deploy.md::0,deploy.md::1"
-# output
-# {"edges_updated": 2, "max_weight_delta": 0.155}
-#
-# `learn` defaults to `apply_outcome_pg()` for full-policy updates.
-# `apply_outcome()` remains available for simpler sparse updates.
+# 4) query example (daemon socket)
+python3 -m openclawbrain.socket_client \
+  --socket ~/.openclawbrain/main/daemon.sock \
+  --method query \
+  --params '{"query":"summarize deploy rollback policy","top_k":4}'
 
-# 5. Inject a correction
-openclawbrain inject --state /tmp/brain/state.json \
-  --id "fix::1" --content "Never skip CI for hotfixes" --type CORRECTION
-
-# 5b. Add new knowledge (no correction needed, just a new fact)
-openclawbrain inject --state /tmp/brain/state.json \
-  --id "teaching::monitoring-tip" \
-  --content "Check Grafana dashboards before every deploy" \
-  --type TEACHING
-
-# 6. Query again and see the route change
-openclawbrain query "can I skip CI" --state /tmp/brain/state.json --top 3
-# output
-# fix::1
-# ~~~~~~
-# Never skip CI for hotfixes
-# ...
-
-# 7. Re-check health for a quick signal
-openclawbrain health --state /tmp/brain/state.json
+# 5) stop service
+openclawbrain serve stop --state ~/.openclawbrain/main/state.json
 ```
 
 ## Correcting mistakes (the main workflow)
@@ -319,9 +294,9 @@ openclawbrain query "incident runbook for deploy failures" --state /tmp/brain/st
 | Cold start | Hash embeddings, no API key | Needs embedding service | Needs prior episodes | Needs configured tiers |
 | State | Single `state.json` file | External DB | Prompt history | Multi-tier storage |
 
-## Real embeddings + LLM routing (OpenAI)
+## Optional OpenAI embeddings + LLM routing
 
-Production deployments use:
+If you want API-backed embeddings/teacher labeling, use:
 
 - **Embeddings:** `text-embedding-3-small` (1536-dim)
 - **LLM routing/scoring:** `gpt-5-mini`
@@ -370,7 +345,7 @@ See `examples/openai_embedder/` for a complete example.
 | `compact` | Compact old daily notes into graph nodes |
 | `sync` | Incremental re-embed after file changes |
 | `inject` | Add CORRECTION/TEACHING/DIRECTIVE nodes |
-| `replay` | Replay session queries (defaults to full-learning; use `--edges-only` for cheap replay, `--fast-learning`/`--extract-learning-events` for LLM mining only, or `--full-learning`/`--full-pipeline` for the full pass) |
+| `replay` | Replay session queries (`--mode edges-only` default, plus `--mode fast-learning` or `--mode full`; use `--resume`/`--fresh`/`--checkpoint` to control checkpoint behavior) |
 | `harvest` | Apply slow-learning pass from `learning_events.jsonl` to current graph |
 | `async-route-pg` | Background teacher-shadow routing labels from recent query journal + PG edge updates |
 | `health` | Show graph health metrics |
@@ -393,7 +368,7 @@ For production use, prefer `openclawbrain serve`, which manages the daemon worke
 Why this matters:
 
 - First load initializes `state.json` once, then keeps the process and index warm.
-- Saves about 100-800ms per call versus shelling out per query (production measure: ~504ms per warm query path on Mac Mini M4 Pro).
+- Saves process startup/reload overhead versus one-shot CLI calls.
 - Reduces memory churn and tail latency under steady traffic.
 
 Start it with:
@@ -452,11 +427,6 @@ Current limitations:
 - Per-chat mutation APIs remain scoped through request payloads (`chat_id`) and adapter-layer bookkeeping.
 - Concurrent writers are serialized by the socket transport lock and one active request at a time.
 
-Production timing (Mac Mini M4 Pro, OpenAI embeddings):
-- MAIN (1,158 nodes): 397ms embed + 107ms traverse = **504ms total**
-- PELICAN (582 nodes): 634ms embed + 51ms traverse = **685ms total**
-- BOUNTIFUL (285 nodes): 404ms embed + 27ms traverse = **431ms total**
-
 See `examples/ops/client_example.py` for a Python client and `docs/architecture.md` for protocol details.
 
 ## True Policy Gradient (apply_outcome_pg)
@@ -496,13 +466,6 @@ Full derivation: https://jonathangu.com/openclawbrain/gu2016/
 | Soft teaching | openclawbrain inject --type TEACHING |
 | Wrong retrieval | daemon `correction` (graph-only, no rebuild) |
 | New rule | Edit AGENTS.md or SOUL.md |
-
-## Production stats (current)
-
-- MAIN: 1,160 nodes, 2,551 edges, 43 learnings
-- PELICAN: 555 nodes, 2,211 edges, 181 learnings
-- BOUNTIFUL: 289 nodes, 1,101 edges, 35 learnings
-- CORMORANT: 1,672 nodes, ~7,100 edges, 22 learnings (first external user!)
 
 ## Traversal defaults
 
@@ -593,7 +556,7 @@ from openclawbrain import (
 ## State lifecycle
 
 - **Where it lives:** a single `state.json` file (portable, version-controllable)
-- **How big:** ~180KB for 20 nodes (hash), ~60MB for 1,600 nodes (OpenAI embeddings)
+- **How big:** depends on workspace size and embedder (`hash` smaller, dense embeddings larger)
 - **When to rebuild:** after major workspace restructuring or embedder changes
 - **Embedder changes:** OpenClawBrain stores the embedder name + dimension in state metadata and hard-fails on mismatch — no silent corruption
 - **Maintenance:** use `openclawbrain maintain` (`decay` + `scale` + `split` + `merge` + `prune` + `connect`) to rebalance structure as the graph evolves
@@ -612,8 +575,8 @@ from openclawbrain import (
 
 ## Warm start from sessions
 
-If you have prior conversation logs, replay them. By default, `replay` runs the
-full learning pipeline (LLM transcript mining + edge replay + harvest):
+If you have prior conversation logs, replay them. By default, `replay` runs
+`--mode edges-only` (cheap/fast, no LLM, no harvest):
 
 ```bash
 openclawbrain replay --state /tmp/brain/state.json --sessions ./sessions/
@@ -645,10 +608,8 @@ openclawbrain replay \
 - `--tool-result-allowlist` (comma-separated tool names)
 - `--tool-result-max-chars` (max allowlisted tool text appended per user query)
 
-This is equivalent to passing `--full-learning` (alias: `--full-pipeline`) explicitly. Decay is enabled
-during replay by default and the harvest pass runs
-(`decay,scale,split,merge,prune,connect`), so unrelated edges weaken while
-active paths are reinforced.
+To run the full pipeline explicitly, use `--mode full` (or legacy alias
+`--full-learning` / `--full-pipeline`).
 
 For cheap edge-only replay (no LLM, no harvest):
 
@@ -656,7 +617,7 @@ For cheap edge-only replay (no LLM, no harvest):
 openclawbrain replay \
   --state /tmp/brain/state.json \
   --sessions ./sessions/ \
-  --edges-only
+  --mode edges-only
 ```
 
 For transcript-backed fast-learning only (no harvest):
@@ -665,7 +626,7 @@ For transcript-backed fast-learning only (no harvest):
 openclawbrain replay \
   --state /tmp/brain/state.json \
   --sessions ./sessions/ \
-  --fast-learning \
+  --mode fast-learning \
   --resume \
   --workers 4 \
   --checkpoint /tmp/brain/replay_checkpoint.json
@@ -678,7 +639,7 @@ For cutover-friendly startup (inject quickly, then start daemon immediately):
 openclawbrain replay \
   --state /tmp/brain/state.json \
   --sessions ./sessions/ \
-  --fast-learning \
+  --mode fast-learning \
   --stop-after-fast-learning \
   --checkpoint /tmp/brain/replay_checkpoint.json
 ```
@@ -690,7 +651,7 @@ For durable long replays with periodic progress/checkpoint/state persistence:
 openclawbrain replay \
   --state /tmp/brain/state.json \
   --sessions ./sessions/ \
-  --edges-only \
+  --mode edges-only \
   --resume \
   --checkpoint /tmp/brain/replay_checkpoint.json \
   --checkpoint-every-seconds 60 \
@@ -709,7 +670,7 @@ For simple true-parallel replay v0:
 openclawbrain replay \
   --state /tmp/brain/state.json \
   --sessions ./sessions/ \
-  --edges-only \
+  --mode edges-only \
   --replay-workers 4 \
   --checkpoint-every 1
 ```
@@ -725,7 +686,7 @@ To enable decay during an edges-only replay:
 openclawbrain replay \
   --state /tmp/brain/state.json \
   --sessions ./sessions/ \
-  --edges-only \
+  --mode edges-only \
   --decay-during-replay \
   --decay-interval 10
 ```
@@ -823,16 +784,6 @@ openclawbrain daemon \
 Replay/harvest now optionally emit route traces + labels:
 - `openclawbrain replay --traces-out ... --labels-out ...`
 - `openclawbrain harvest --traces-out ... --labels-out ...`
-
-## Production experience
-
-Three brains run in production on a Mac Mini M4 Pro:
-
-| Brain | Nodes | Edges | Learning Corrections | Sessions Replayed |
-|-------|-------|-------|---------------------|-------------------|
-| MAIN | 1,142 | 2,814 | 43 | 215 |
-| PELICAN | 512 | 1,984 | 181 | 183 |
-| BOUNTIFUL | 273 | 1,073 | 35 | 300 |
 
 ## Design Tenets
 

--- a/docs/openclaw-integration.md
+++ b/docs/openclaw-integration.md
@@ -39,10 +39,12 @@ OpenClawBrain stores everything in a single portable file:
 - Python **3.10+**
 - `pip install openclawbrain`
 - Daemon query embedding mode defaults to `--embed-model auto`:
+  - `local:*` states use local query embeddings (fastembed, offline by default).
   - `hash-v1` states use hash query embeddings (offline, no OpenAI call).
-  - Non-hash states use OpenAI query embeddings with `text-embedding-3-small` (`OPENAI_API_KEY` required in daemon environment).
+  - OpenAI states do not auto-call OpenAI; use `--embed-model openai:<model>` explicitly when needed.
   - Force hash mode: `--embed-model hash`.
-  - Force explicit model: `--embed-model text-embedding-3-small` (or another compatible model).
+  - Force local mode: `--embed-model local`.
+  - Force explicit OpenAI model: `--embed-model openai:text-embedding-3-small`.
 
 Install:
 
@@ -141,7 +143,7 @@ BRAIN_DIR=~/.openclawbrain/main
 mkdir -p "$BRAIN_DIR"
 
 # Create/overwrite state.json inside the output directory
-# By default, init auto-detects OpenAI (uses it if OPENAI_API_KEY is set, falls back to hash otherwise)
+# By default, init uses embedder auto -> local fastembed -> hash fallback.
 openclawbrain init --workspace "$WORKSPACE" --output "$BRAIN_DIR"
 
 # Quick health signal
@@ -261,22 +263,23 @@ This aligns retrieval output with OpenClawBrain’s context-efficiency goal: pre
 ### Option A: run it manually (smoke test)
 
 ```bash
-openclawbrain serve --state ~/.openclawbrain/main/state.json
+openclawbrain serve start --state ~/.openclawbrain/main/state.json
 ```
 
 The daemon speaks NDJSON over `stdin`/`stdout`.
 
 - Protocol: each line is one JSON request with `id`, `method`, and `params`.
 - Response: one JSON object with matching `id` and either `result` or `error`.
-- Start-up cost is paid once (state loaded at process start); expected savings are 100-800ms on hot-path calls, with production measurement at ~504ms on Mac Mini M4 Pro.
+- Start-up cost is paid once (state loaded at process start), so steady-state query/learn calls avoid repeated reload overhead.
 
 Supported methods: `query`, `learn`, `last_fired`, `learn_by_chat_id`, `capture_feedback`, `maintain`, `health`, `info`, `save`, `reload`, `shutdown`, `inject`, `correction`.
 
 Daemon embed-model default and overrides:
 - Default is `--embed-model auto`.
+- `local:*` state metadata => local query embeddings.
 - `hash-v1` state metadata => hash query embeddings (offline).
-- Non-hash state metadata => OpenAI query embeddings with `text-embedding-3-small`.
-- Force modes with `--embed-model hash` or `--embed-model <model>`.
+- OpenAI state metadata => no OpenAI call in auto; use `--embed-model openai:<model>` explicitly.
+- Force modes with `--embed-model hash` or `--embed-model local`.
 
 Example request and reply:
 
@@ -308,6 +311,7 @@ Create `~/Library/LaunchAgents/com.openclawbrain.daemon.plist`:
     <string>/usr/bin/env</string>
     <string>openclawbrain</string>
     <string>serve</string>
+    <string>start</string>
     <string>--state</string>
     <string>/Users/YOU/.openclawbrain/main/state.json</string>
   </array>
@@ -360,7 +364,7 @@ Type=simple
 User=YOUR_USER
 WorkingDirectory=/home/YOUR_USER
 Environment=OPENAI_API_KEY=YOUR_KEY_HERE
-ExecStart=/usr/bin/env openclawbrain serve --state /home/YOUR_USER/.openclawbrain/main/state.json
+ExecStart=/usr/bin/env openclawbrain serve start --state /home/YOUR_USER/.openclawbrain/main/state.json
 Restart=always
 RestartSec=1
 
@@ -411,7 +415,7 @@ OpenClawBrain ships an OpenClaw adapter that logs fired IDs per chat.
 
 That’s the ergonomic way to do “same-turn correction” inside OpenClaw.
 
-For full-history rebuilds, replay your sessions (full-learning is the default; explicit alias pair: `--full-learning` / `--full-pipeline`):
+For full-history rebuilds, replay your sessions. Default mode is `edges-only`; use `--mode full` for full-learning + replay + harvest:
 
 ```bash
 openclawbrain replay \
@@ -442,17 +446,17 @@ openclawbrain replay \
 
 This does:
 
-- replay query edges from session history (with decay enabled by default)
-- LLM transcript mining into `learning::` nodes (`--fast-learning` / `--extract-learning-events` behavior)
-- slow-learning maintenance pass (`harvest`) with decay/scale/split/merge/prune/connect
+- replay query edges from session history (`--mode edges-only`)
+- optional LLM transcript mining into `learning::` nodes (`--mode fast-learning`)
+- optional full pass (`--mode full`) adding harvest tasks (`decay,scale,split,merge,prune,connect`)
 
-For cheap edge-only replay (no LLM, no harvest), use `--edges-only`:
+For cheap edge-only replay (no LLM, no harvest), use `--mode edges-only`:
 
 ```bash
 openclawbrain replay \
   --state ~/.openclawbrain/main/state.json \
   --sessions /path/to/sessions \
-  --edges-only
+  --mode edges-only
 ```
 
 To enable decay during an edges-only replay, add `--decay-during-replay`:
@@ -461,7 +465,7 @@ To enable decay during an edges-only replay, add `--decay-during-replay`:
 openclawbrain replay \
   --state ~/.openclawbrain/main/state.json \
   --sessions /path/to/sessions \
-  --edges-only \
+  --mode edges-only \
   --decay-during-replay \
   --decay-interval 10
 ```
@@ -534,7 +538,7 @@ Dimension mismatch usually means query embedding dimensions do not match the vec
 Fixes:
 - Run daemon in default auto mode (`--embed-model auto`), which follows state metadata safely.
 - Rebuild state if needed with the embedder you intend to keep.
-- Only force `--embed-model hash` or `--embed-model <model>` when you intentionally want that behavior and dimensions are known to match.
+- Only force `--embed-model hash`, `--embed-model local`, or `--embed-model openai:<model>` when you intentionally want that behavior and dimensions are known to match.
 
 ```bash
 openclawbrain init --workspace ~/.openclaw/workspace --output ~/.openclawbrain/main
@@ -549,7 +553,7 @@ Common causes:
 
 Fixes:
 
-- Use the canonical brain-on command (`openclawbrain serve --state ...`).
+- Use the canonical brain-on command (`openclawbrain serve start --state ...`).
 - Use OpenAI embeddings for production routing/scoring behavior; only use hash embeddings for offline/testing fallback.
 
 ### “Daemon starts but OpenClaw can’t talk to it”
@@ -630,7 +634,7 @@ openclawbrain(action="shutdown", confirm="shutdown")
 ```
 
 ### Requirements
-- OpenClawBrain daemon must be running (`openclawbrain serve --state ...`)
+- OpenClawBrain daemon must be running (`openclawbrain serve start --state ...`)
 - The `daemon.sock` file must be accessible from the OpenClaw process
 
 ### Media understanding synergy
@@ -662,7 +666,7 @@ To enable in your OpenClaw config:
                                          ▼
                          ┌──────────────────────────────────┐
                          │        OpenClawBrain daemon       │
-                         │ openclawbrain serve --state ...    │
+                         │ openclawbrain serve start --state ... │
                          │  (NDJSON over stdin/stdout)       │
                          └───────────────┬───────────────────┘
                                          │

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -16,7 +16,7 @@ Use packaged adapter CLIs for agent hooks (no `~/openclawbrain` clone required):
 Canonical run command:
 
 ```bash
-openclawbrain serve --state ~/.openclawbrain/main/state.json
+openclawbrain serve start --state ~/.openclawbrain/main/state.json
 ```
 
 What `serve` does:
@@ -46,7 +46,7 @@ Route-mode behavior:
 ## 3) Confirm it's ON
 
 ```bash
-openclawbrain status --state ~/.openclawbrain/main/state.json
+openclawbrain serve status --state ~/.openclawbrain/main/state.json
 ls -l ~/.openclawbrain/main/daemon.sock
 ```
 
@@ -63,7 +63,7 @@ Use when you need improvements now and can defer full replay/harvest.
 openclawbrain replay \
   --state ~/.openclawbrain/main/state.json \
   --sessions ~/.openclaw/agents/main/sessions \
-  --fast-learning \
+  --mode fast-learning \
   --stop-after-fast-learning \
   --resume \
   --checkpoint ~/.openclawbrain/main/replay_checkpoint.json
@@ -88,8 +88,8 @@ examples/ops/rebuild_then_cutover.sh main ~/.openclaw/workspace \
 This rebuilds into a fresh directory, verifies it, stops daemon briefly at cutover, swaps dirs atomically, then restarts.
 
 ### full-learning guidance + when to schedule it
-Use full-learning (`--full-learning`) off-peak (nightly/low traffic, and after large session growth or major workspace changes).  
-Single-writer rule still applies: either run full-learning on a NEW state before cutover, or stop daemon writes before replaying LIVE.
+Use full replay (`--mode full`) off-peak (nightly/low traffic, and after large session growth or major workspace changes).  
+Single-writer rule still applies: either run full replay on a NEW state before cutover, or stop daemon writes before replaying LIVE.
 
 ## 5) Checkpoints & resume
 Default checkpoint path is next to state: `~/.openclawbrain/main/replay_checkpoint.json`.
@@ -136,7 +136,7 @@ Flag meanings:
 - Replay phase: stderr shows `Loaded <N> interactions from session files`; with `--progress-every`, shows `[replay] <done>/<total> (<pct>%)`.
 - Startup banner includes selected `mode` and `checkpoint` path.
 - Replay completion: `Replayed <n>/<total> queries, <m> cross-file edges created`
-- Full-learning completion (`--full-learning`): final line includes harvest summary, e.g. `harvest: tasks=<k>, damped_edges=<x>`.
+- Full replay completion (`--mode full`): final line includes harvest summary, e.g. `harvest: tasks=<k>, damped_edges=<x>`.
 
 ## 7) Concurrency rules (single writer)
 Only one process should write a given `state.json` at a time.
@@ -210,12 +210,12 @@ Operational notes:
 
 | Symptom | Likely cause | Commands |
 |---|---|---|
-| `status` says `Daemon: not running` | service not started, crashed, or wrong state path | `openclawbrain serve --state ~/.openclawbrain/main/state.json` then `openclawbrain status --state ~/.openclawbrain/main/state.json` |
+| `status` says `Daemon: not running` | service not started, crashed, or wrong state path | `openclawbrain serve start --state ~/.openclawbrain/main/state.json` then `openclawbrain serve status --state ~/.openclawbrain/main/state.json` |
 | `daemon.sock` missing | service never started or wrong agent/state directory | `ls -la ~/.openclawbrain/main` and restart `openclawbrain serve` with the same `--state` |
 | embedder/dimension mismatch on daemon query | forced wrong `--embed-model` for this state | use `--embed-model auto` for local/hash states, or explicit OpenAI mode for OpenAI states: `--embed-model openai:text-embedding-3-small` |
 | Replay fails with lock/single-writer message | another process holds `state.json.lock` | stop the other writer, use `examples/ops/rebuild_then_cutover.sh ...`, or expert override with `--force` / `OPENCLAWBRAIN_STATE_LOCK_FORCE=1` |
 | Replay restarts from old work | checkpoint not used, wrong path, or intentionally ignored | run with `--resume --checkpoint ~/.openclawbrain/main/replay_checkpoint.json`; inspect with `openclawbrain replay --state ~/.openclawbrain/main/state.json --show-checkpoint --resume` |
-| `LLM required for fast-learning` | no OpenAI client/key configured for fast-learning mining | set `OPENAI_API_KEY` or run `--edges-only` replay path |
+| `LLM required for fast-learning` | no OpenAI client/key configured for fast-learning mining | set `OPENAI_API_KEY` or run `--mode edges-only` replay path |
 | CLI says invalid sessions path | wrong sessions directory/file path | `ls -la ~/.openclaw/agents/main/sessions` and pass existing dir/files to `--sessions` |
 
 ## 10) Prompt-context and route-mode eval (offline)

--- a/docs/operator-quickstart.md
+++ b/docs/operator-quickstart.md
@@ -58,6 +58,16 @@ python3 -m openclawbrain.socket_client \
   --params '{"query":"summarize deploy risks","top_k":4}'
 ```
 
+## Defaults that matter
+
+- `serve start` defaults to `--route-mode learned`.
+- `init` writes `route_model.npz` beside `state.json`; if missing/unloadable, query routing falls back to `edge+sim`.
+- Override route mode at service start with `--route-mode off|edge|edge+sim|learned`.
+- Query embeddings default to `--embed-model auto`:
+  - `local:*` state metadata -> local embeddings (fastembed)
+  - `hash-v1` state metadata -> hash embeddings
+  - OpenAI state metadata -> use `--embed-model openai:<model>` explicitly if you want OpenAI query embeddings
+
 ## Stop
 
 ```bash

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -4,7 +4,7 @@
 - Python 3.10+
 - `pip install openclawbrain`
 - `OPENAI_API_KEY` only if you explicitly use OpenAI embeddings/teacher labeling
-- A workspace directory with markdown files (your agent's knowledge base)
+- A workspace directory with markdown files (your agent's working knowledge/docs)
 
 ## Step 1: Build your first brain
 
@@ -26,18 +26,18 @@ Runtime route-mode default is `learned`. `init` writes a default identity-like `
 
 ## Initial learning: replay your sessions
 
-After init, replay your existing sessions to seed graph edges and extract learning signals. By default, `replay` runs the full learning pipeline (LLM mining + edge replay + harvest):
+After init, replay your existing sessions to seed graph edges and extract learning signals. By default, `replay` runs `--mode edges-only` (cheap/fast, no LLM mining, no harvest):
 
 ```bash
 openclawbrain replay --state ./brain/state.json --sessions ./sessions/
 ```
 
-This extracts durable correction/teaching nodes and runs maintenance in one command (`--full-learning`, alias: `--full-pipeline`).
+Use `--mode full` when you explicitly want the full pipeline (LLM mining + edge replay + harvest).
 
 For cheap edge-only replay (no LLM, no harvest):
 
 ```bash
-openclawbrain replay --state ./brain/state.json --sessions ./sessions/ --edges-only
+openclawbrain replay --state ./brain/state.json --sessions ./sessions/ --mode edges-only
 ```
 
 For fine-grained control over the LLM mining pass:
@@ -46,7 +46,7 @@ For fine-grained control over the LLM mining pass:
 openclawbrain replay \
   --state ./brain/state.json \
   --sessions ./sessions/ \
-  --fast-learning \
+  --mode fast-learning \
   --workers 4 \
   --window-radius 8 \
   --max-windows 6 \
@@ -61,7 +61,7 @@ openclawbrain replay \
 
 You can run this repeatedly; dedupe is by `(type, sha256(content), session_pointer)`, so repeated runs are idempotent.
 
-For ongoing operation after startup, use `--ignore-checkpoint` only when you intentionally want to replay older chunks that were already ingested.
+For ongoing operation after startup, use `--fresh` (`--no-checkpoint`) only when you intentionally want to replay older chunks that were already ingested.
 
 Replay progress defaults:
 - Fast-learning prints progress as it processes extraction windows.
@@ -82,7 +82,7 @@ openclawbrain replay --state ./brain/state.json --show-checkpoint --resume --jso
 
 Resume semantics:
 - `--resume` enables checkpoint offsets.
-- `--ignore-checkpoint` disables resume even when a checkpoint exists.
+- `--fresh` / `--no-checkpoint` disables resume even when a checkpoint exists (`--ignore-checkpoint` remains a legacy alias).
 - If a checkpoint only has legacy top-level `sessions` offsets, replay still resumes from them and prints a warning.
 
 ## Step 2: Wire up the fast loop (per-query)
@@ -128,7 +128,7 @@ openclawbrain harvest \
 
 The harvest path is intentionally sidecar: it consumes OpenClaw replay artifacts and updates graph structure from them, without changing OpenClaw core memory files.
 
-For production automation, run `harvest` after `replay --fast-learning` with a bounded schedule (daily/hourly depending on session volume).
+For production automation, run `harvest` after `replay --mode fast-learning` with a bounded schedule (daily/hourly depending on session volume).
 
 ## Decay during replay
 
@@ -137,7 +137,7 @@ The default full-learning mode automatically enables decay during the replay pas
 To enable decay during an edges-only replay, pass `--decay-during-replay`:
 
 ```bash
-openclawbrain replay --state ./brain/state.json --sessions ./sessions/ --edges-only --decay-during-replay --decay-interval 10
+openclawbrain replay --state ./brain/state.json --sessions ./sessions/ --mode edges-only --decay-during-replay --decay-interval 10
 ```
 
 `--decay-interval N` (default 10) controls how many learning steps occur between each decay pass.
@@ -268,7 +268,7 @@ Reference: `examples/ops/callbacks.py`
 Run the production service as a Unix socket wrapper around the NDJSON daemon:
 
 ```bash
-openclawbrain serve --state ~/.openclawbrain/main/state.json
+openclawbrain serve start --state ~/.openclawbrain/main/state.json
 ```
 
 `serve` runs the daemon worker with `--embed-model auto` and `--route-mode learned` by default. Embedding mode follows state metadata (`local:*` => local, `hash-v1` => hash, OpenAI states require explicit `--embed-model openai:<model>`).
@@ -306,6 +306,7 @@ Create `~/Library/LaunchAgents/com.openclawbrain.daemon.plist`:
     <string>/usr/bin/env</string>
     <string>openclawbrain</string>
     <string>serve</string>
+    <string>start</string>
     <string>--state</string>
     <string>/Users/YOU/.openclawbrain/main/state.json</string>
   </array>
@@ -341,7 +342,7 @@ After=network-online.target
 Type=simple
 User=YOUR_USER
 WorkingDirectory=/home/YOUR_USER
-ExecStart=/usr/bin/env openclawbrain serve --state /home/YOUR_USER/.openclawbrain/main/state.json
+ExecStart=/usr/bin/env openclawbrain serve start --state /home/YOUR_USER/.openclawbrain/main/state.json
 Restart=always
 RestartSec=1
 


### PR DESCRIPTION
## Summary
- Align operator-facing docs to current CLI lifecycle commands: `serve start|status|stop`.
- Update replay guidance to explicit mode/checkpoint semantics: `--mode {edges-only,fast-learning,full}`, `--resume`, `--fresh`, `--checkpoint`.
- Clarify defaults: route mode defaults to `learned` with `edge+sim` fallback when `route_model.npz` is unavailable.
- Clarify embedding defaults: `init` uses local embeddings first (`fastembed`) with hash fallback; OpenAI remains optional/explicit.
- Add README OOTB 5-minute operator path (`init -> serve start -> serve status -> query example -> serve stop`).
- Remove hardcoded/stale production size/performance claims from README.

## Validation
- Ran: `PYTHONPATH=. pytest -q`
- Result: `435 passed`
