### PR TITLE
feat(eval): add industry baseline suite (vector top-k, rerank, pointer-chase)

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,6 +516,24 @@ python examples/eval/simulate_two_cluster_routing.py \
   --output-dir /tmp/ocb_two_cluster
 ```
 
+Run the industry baseline suite (JSON + CSV + report in scratch):
+
+```bash
+python examples/eval/run_baselines.py \
+  --state /path/to/state.json \
+  --output-dir scratch/industry-baselines/latest
+```
+
+Baseline matrix (industry standard):
+
+| Mode | Description | Optional deps |
+| --- | --- | --- |
+| `vector_topk` | Vector similarity top-k only | none |
+| `vector_topk_rerank` | Vector top-k reranked by BM25 | `openclawbrain[reranker]` |
+| `pointer_chase` | Deterministic pointer-chasing simulator | none |
+| `learned` | OpenClawBrain learned routing | route model |
+| `edge_sim_legacy` | Legacy edge+sim routing | none |
+
 See [docs/evaluation-plan.md](docs/evaluation-plan.md) for baselines, metrics, ablation matrix, and dataset guidance.
 
 Quick run (from project root):

--- a/docs/evaluation-plan.md
+++ b/docs/evaluation-plan.md
@@ -10,7 +10,9 @@ OpenClawBrain reduces multi-hop pointer chasing, which should reduce turns, toke
 
 Evaluate the following retrieval modes with the same state and query set:
 
-- `vector_only`: top-k vector seeds only; no traversal.
+- `vector_topk` (`vector_only` in `run_eval.py`): top-k vector seeds only; no traversal.
+- `vector_topk_rerank`: vector top-k with BM25 reranking (optional `openclawbrain[reranker]`).
+- `pointer_chase`: deterministic pointer-chasing simulator (LLM/tool loop) for turn/token/latency/cost comparison.
 - `graph_prior_only`: learned router path with `router_conf=0.0` (forces graph-prior behavior from edge weight/relevance confidence mix).
 - `qtsim_only`: learned router path with `router_conf=1.0` and `relevance_conf=1.0` (forces QTsim score dominance).
 - `learned`: default confidence-mixed learned routing.
@@ -44,6 +46,16 @@ For each dataset split or benchmark shard, run all five modes:
 4. `qtsim_only`
 5. `learned`
 
+## Industry baseline matrix
+
+Report alongside the learned modes:
+
+1. `vector_topk`
+2. `vector_topk_rerank` (BM25; optional extra)
+3. `pointer_chase` (deterministic simulated LLM/tool loop)
+4. `learned`
+5. `edge_sim_legacy`
+
 Interpretation:
 
 - `learned` should outperform `vector_only` on multi-hop and history queries.
@@ -76,6 +88,8 @@ Recommended process for paper-grade ground truth:
 
 - Eval and ablations:
   - `python examples/eval/run_eval.py --state /path/to/state.json --output /tmp/ocb_eval.json`
+- Industry baseline suite (JSON + CSV + report in scratch):
+  - `python examples/eval/run_baselines.py --state /path/to/state.json --output-dir scratch/industry-baselines/latest`
 - Primary synthetic proof-of-learning:
   - `python examples/eval/simulate_expert_regions.py --output-dir /tmp/ocb_expert_regions`
   - This is the paper-grade synthetic benchmark: K-expert Gaussian regions, soft teacher labels, heldout baselines (`random`, `oracle`, `graph_prior_only`, `qtsim_only`, `learned_mixed`), and oracle-gap closure curves.

--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,0 +1,1 @@
+"""Examples package for OpenClawBrain."""

--- a/examples/eval/__init__.py
+++ b/examples/eval/__init__.py
@@ -1,0 +1,1 @@
+"""Evaluation example scripts."""

--- a/examples/eval/run_baselines.py
+++ b/examples/eval/run_baselines.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Industry-standard baseline suite runner for OpenClawBrain."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from openclawbrain.eval.runner import run_baseline_suite
+
+VALID_MODES = {
+    "vector_topk",
+    "vector_only",
+    "vector_topk_rerank",
+    "pointer_chase",
+    "learned",
+    "edge_sim_legacy",
+}
+MODE_ALIASES = {"vector_only": "vector_topk"}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run industry-standard baseline suite for OpenClawBrain.")
+    parser.add_argument("--state", required=True, help="Path to state.json")
+    parser.add_argument(
+        "--queries",
+        default=str(Path(__file__).resolve().parent / "queries.jsonl"),
+        help="Path to query JSONL dataset",
+    )
+    parser.add_argument(
+        "--modes",
+        default="vector_topk,vector_topk_rerank,pointer_chase,learned",
+        help="Comma-separated modes",
+    )
+    parser.add_argument("--route-model", help="Optional path to route_model.npz")
+    parser.add_argument("--embed-model", default="auto", help="auto|hash|local|local:<model>")
+    parser.add_argument("--top-k", type=int, default=4)
+    parser.add_argument("--max-fired-nodes", type=int, default=30)
+    parser.add_argument("--max-prompt-context-chars", type=int, default=30000)
+    parser.add_argument(
+        "--output-dir",
+        default=str(Path("scratch") / "industry-baselines" / "latest"),
+        help="Directory for summary.json/summary.csv/report.md",
+    )
+    parser.add_argument("--print-per-query", action="store_true", help="Include per-query rows in output JSON")
+    args = parser.parse_args()
+
+    if args.top_k <= 0:
+        raise SystemExit("--top-k must be > 0")
+    if args.max_fired_nodes <= 0:
+        raise SystemExit("--max-fired-nodes must be > 0")
+    if args.max_prompt_context_chars <= 0:
+        raise SystemExit("--max-prompt-context-chars must be > 0")
+
+    selected_modes = [part.strip() for part in args.modes.split(",") if part.strip()]
+    if not selected_modes:
+        raise SystemExit("--modes must include at least one mode")
+    unknown = [mode for mode in selected_modes if mode not in VALID_MODES]
+    if unknown:
+        raise SystemExit(f"unknown mode(s): {unknown}; valid: {sorted(VALID_MODES)}")
+
+    normalized_modes: list[str] = []
+    for mode in selected_modes:
+        resolved = MODE_ALIASES.get(mode, mode)
+        if resolved not in normalized_modes:
+            normalized_modes.append(resolved)
+
+    summary = run_baseline_suite(
+        state_path=Path(args.state).expanduser(),
+        queries_path=Path(args.queries).expanduser(),
+        modes=normalized_modes,
+        embed_model=args.embed_model,
+        route_model_path=Path(args.route_model).expanduser() if args.route_model else None,
+        top_k=args.top_k,
+        max_fired_nodes=args.max_fired_nodes,
+        max_prompt_context_chars=args.max_prompt_context_chars,
+        output_dir=Path(args.output_dir).expanduser(),
+        include_per_query=args.print_per_query,
+    )
+    print(json.dumps(summary, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/openclawbrain/eval/__init__.py
+++ b/openclawbrain/eval/__init__.py
@@ -1,0 +1,21 @@
+"""Evaluation helpers and baselines for OpenClawBrain."""
+
+from .baselines import (
+    PointerChaseConfig,
+    PointerChaseSimulator,
+    run_pointer_chase,
+    run_vector_topk,
+    run_vector_topk_rerank,
+    try_load_bm25_reranker,
+)
+from .runner import run_baseline_suite
+
+__all__ = [
+    "PointerChaseConfig",
+    "PointerChaseSimulator",
+    "run_pointer_chase",
+    "run_vector_topk",
+    "run_vector_topk_rerank",
+    "try_load_bm25_reranker",
+    "run_baseline_suite",
+]

--- a/openclawbrain/eval/baselines.py
+++ b/openclawbrain/eval/baselines.py
@@ -1,0 +1,319 @@
+"""Industry-standard evaluation baselines for OpenClawBrain."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+import re
+import time
+from typing import Any, Callable, Protocol
+
+from openclawbrain.graph import Graph
+from openclawbrain.prompt_context import build_prompt_context_ranked_with_stats
+
+_TOKEN_RE = re.compile(r"[A-Za-z0-9']+")
+
+
+class Reranker(Protocol):
+    """Minimal reranker interface."""
+
+    name: str
+
+    def rerank(self, query: str, candidates: list[tuple[str, str, float]]) -> list[tuple[str, float]]:
+        """Return [(node_id, score)] sorted by descending score."""
+
+
+class _BM25Reranker:
+    """BM25 reranker using rank_bm25."""
+
+    name = "bm25"
+
+    def __init__(self) -> None:
+        from rank_bm25 import BM25Okapi
+
+        self._bm25_cls = BM25Okapi
+
+    def rerank(self, query: str, candidates: list[tuple[str, str, float]]) -> list[tuple[str, float]]:
+        if not candidates:
+            return []
+        tokenized_docs = [_tokenize_text(content) for _node_id, content, _score in candidates]
+        bm25 = self._bm25_cls(tokenized_docs)
+        query_tokens = _tokenize_text(query)
+        scores = bm25.get_scores(query_tokens)
+        reranked = [(node_id, float(score)) for (node_id, _content, _score), score in zip(candidates, scores)]
+        reranked.sort(key=lambda item: item[1], reverse=True)
+        return reranked
+
+
+def try_load_bm25_reranker() -> tuple[Reranker | None, str | None]:
+    """Return (reranker, reason_if_missing)."""
+    try:
+        reranker = _BM25Reranker()
+    except ImportError:
+        return None, "rank_bm25 not installed; install openclawbrain[reranker]"
+    return reranker, None
+
+
+def _tokenize_text(text: str) -> list[str]:
+    return [match.group(0).lower() for match in _TOKEN_RE.finditer(text or "")]
+
+
+def _approx_tokens(text: str) -> int:
+    if not text:
+        return 0
+    return max(1, int(len(text) / 4))
+
+
+def _normalize_scores(scores: list[float]) -> list[float]:
+    if not scores:
+        return []
+    low = min(scores)
+    high = max(scores)
+    if math.isclose(low, high):
+        return [1.0 for _ in scores]
+    return [(score - low) / (high - low) for score in scores]
+
+
+def run_vector_topk(
+    *,
+    graph: Graph,
+    index: Any,
+    embed_fn: Callable[[str], list[float]],
+    query_text: str,
+    top_k: int,
+    max_prompt_context_chars: int,
+    prompt_context_include_node_ids: bool,
+) -> dict[str, object]:
+    q_vec = embed_fn(query_text)
+    seeds = index.search(q_vec, top_k=top_k)
+    fired_nodes = [node_id for node_id, _score in seeds]
+    fired_scores = {node_id: float(score) for node_id, score in seeds}
+    prompt_context, prompt_stats = build_prompt_context_ranked_with_stats(
+        graph=graph,
+        node_ids=fired_nodes,
+        node_scores=fired_scores,
+        max_chars=max_prompt_context_chars,
+        include_node_ids=prompt_context_include_node_ids,
+    )
+    return {
+        "fired_nodes": fired_nodes,
+        "prompt_context": prompt_context,
+        **prompt_stats,
+        "route_router_conf_mean": 0.0,
+        "route_relevance_conf_mean": 0.0,
+        "route_policy_disagreement_mean": 0.0,
+        "route_decision_count": 0,
+    }
+
+
+def run_vector_topk_rerank(
+    *,
+    graph: Graph,
+    index: Any,
+    embed_fn: Callable[[str], list[float]],
+    query_text: str,
+    top_k: int,
+    max_prompt_context_chars: int,
+    prompt_context_include_node_ids: bool,
+    reranker: Reranker | None,
+) -> dict[str, object]:
+    if reranker is None:
+        return {"skipped": True, "skipped_reason": "reranker unavailable"}
+
+    q_vec = embed_fn(query_text)
+    seeds = index.search(q_vec, top_k=top_k)
+    candidates: list[tuple[str, str, float]] = []
+    for node_id, score in seeds:
+        node = graph.get_node(node_id)
+        if node is None:
+            continue
+        candidates.append((node_id, node.content or "", float(score)))
+
+    reranked = reranker.rerank(query_text, candidates)
+    fired_nodes = [node_id for node_id, _score in reranked]
+    scores = _normalize_scores([score for _node_id, score in reranked])
+    fired_scores = {node_id: score for node_id, score in zip(fired_nodes, scores)}
+    prompt_context, prompt_stats = build_prompt_context_ranked_with_stats(
+        graph=graph,
+        node_ids=fired_nodes,
+        node_scores=fired_scores,
+        max_chars=max_prompt_context_chars,
+        include_node_ids=prompt_context_include_node_ids,
+    )
+    return {
+        "fired_nodes": fired_nodes,
+        "prompt_context": prompt_context,
+        **prompt_stats,
+        "route_router_conf_mean": 0.0,
+        "route_relevance_conf_mean": 0.0,
+        "route_policy_disagreement_mean": 0.0,
+        "route_decision_count": 0,
+        "reranker_name": reranker.name,
+    }
+
+
+@dataclass(frozen=True)
+class PointerChaseConfig:
+    top_k: int = 4
+    max_turns: int = 6
+    max_tool_calls: int = 8
+    max_candidates: int = 6
+    edge_weight_factor: float = 0.55
+    similarity_factor: float = 0.45
+    min_next_score: float = 0.05
+    tool_latency_ms: float = 30.0
+    llm_latency_ms: float = 200.0
+    completion_tokens_per_turn: int = 24
+    cost_per_1k_tokens: float = 0.0
+    candidate_snippet_chars: int = 180
+    max_prompt_context_chars: int = 20000
+    prompt_context_include_node_ids: bool = True
+
+
+class PointerChaseSimulator:
+    """Deterministic pointer-chasing simulator for baseline comparisons."""
+
+    def __init__(
+        self,
+        *,
+        graph: Graph,
+        index: Any,
+        embed_fn: Callable[[str], list[float]],
+        config: PointerChaseConfig | None = None,
+    ) -> None:
+        self._graph = graph
+        self._index = index
+        self._embed_fn = embed_fn
+        self._config = config or PointerChaseConfig()
+
+    def run(self, query_text: str) -> dict[str, object]:
+        cfg = self._config
+        start = time.perf_counter()
+        query_vec = self._embed_fn(query_text)
+        seeds = self._index.search(query_vec, top_k=cfg.top_k)
+        tool_calls = 1 if seeds else 0
+        tool_latency = cfg.tool_latency_ms if seeds else 0.0
+        if not seeds:
+            return {
+                "fired_nodes": [],
+                "prompt_context": "",
+                "prompt_context_len": 0,
+                "pointer_turns": 0,
+                "pointer_tool_calls": tool_calls,
+                "pointer_prompt_tokens": 0,
+                "pointer_completion_tokens": 0,
+                "pointer_total_tokens": 0,
+                "pointer_cost": 0.0,
+                "pointer_latency_ms": 0.0,
+            }
+
+        current_node_id, current_score = seeds[0]
+        visited = [current_node_id]
+        visited_scores = {current_node_id: float(current_score)}
+        llm_turns = 0
+        prompt_tokens = 0
+        completion_tokens = 0
+
+        for _turn in range(cfg.max_turns):
+            if tool_calls >= cfg.max_tool_calls:
+                break
+            outgoing = self._graph.outgoing(current_node_id)
+            tool_calls += 1
+            tool_latency += cfg.tool_latency_ms
+            if not outgoing:
+                break
+
+            candidates = []
+            for node, edge in outgoing[: cfg.max_candidates]:
+                sim = _safe_cosine(query_vec, self._embed_fn(node.content or ""))
+                combined = (cfg.edge_weight_factor * float(edge.weight)) + (
+                    cfg.similarity_factor * sim
+                )
+                candidates.append((node.id, node.content or "", float(edge.weight), sim, combined))
+
+            if not candidates:
+                break
+
+            candidates.sort(key=lambda item: item[4], reverse=True)
+            next_id, _content, _edge_weight, _sim, score = candidates[0]
+            llm_turns += 1
+
+            prompt_tokens += _approx_tokens(
+                _render_pointer_prompt(query_text, current_node_id, candidates, cfg.candidate_snippet_chars)
+            )
+            completion_tokens += cfg.completion_tokens_per_turn
+
+            if score < cfg.min_next_score:
+                break
+            if next_id in visited:
+                break
+
+            visited.append(next_id)
+            visited_scores[next_id] = score
+            current_node_id = next_id
+
+        prompt_context, prompt_stats = build_prompt_context_ranked_with_stats(
+            graph=self._graph,
+            node_ids=visited,
+            node_scores=visited_scores,
+            max_chars=cfg.max_prompt_context_chars,
+            include_node_ids=cfg.prompt_context_include_node_ids,
+        )
+        total_tokens = prompt_tokens + completion_tokens
+        cost = (total_tokens / 1000.0) * cfg.cost_per_1k_tokens
+        elapsed_ms = (time.perf_counter() - start) * 1000.0
+        simulated_latency = tool_latency + (llm_turns * cfg.llm_latency_ms)
+
+        return {
+            "fired_nodes": visited,
+            "prompt_context": prompt_context,
+            **prompt_stats,
+            "pointer_turns": llm_turns,
+            "pointer_tool_calls": tool_calls,
+            "pointer_prompt_tokens": prompt_tokens,
+            "pointer_completion_tokens": completion_tokens,
+            "pointer_total_tokens": total_tokens,
+            "pointer_cost": cost,
+            "pointer_latency_ms": simulated_latency,
+            "latency_ms": elapsed_ms,
+        }
+
+
+def run_pointer_chase(
+    *,
+    graph: Graph,
+    index: Any,
+    embed_fn: Callable[[str], list[float]],
+    query_text: str,
+    config: PointerChaseConfig | None = None,
+) -> dict[str, object]:
+    simulator = PointerChaseSimulator(graph=graph, index=index, embed_fn=embed_fn, config=config)
+    return simulator.run(query_text)
+
+
+def _safe_cosine(a: list[float], b: list[float]) -> float:
+    if not a or not b or len(a) != len(b):
+        return 0.0
+    dot = 0.0
+    norm_a = 0.0
+    norm_b = 0.0
+    for x, y in zip(a, b):
+        dot += x * y
+        norm_a += x * x
+        norm_b += y * y
+    if norm_a == 0.0 or norm_b == 0.0:
+        return 0.0
+    return dot / (math.sqrt(norm_a) * math.sqrt(norm_b))
+
+
+def _render_pointer_prompt(
+    query_text: str,
+    current_node_id: str,
+    candidates: list[tuple[str, str, float, float, float]],
+    snippet_chars: int,
+) -> str:
+    lines = [f"Query: {query_text}", f"Current node: {current_node_id}", "Candidates:"]
+    for node_id, content, edge_weight, sim, score in candidates:
+        snippet = (content or "").replace("\n", " ")[:snippet_chars]
+        lines.append(f"- {node_id} w={edge_weight:.3f} sim={sim:.3f} score={score:.3f} :: {snippet}")
+    return "\n".join(lines)

--- a/openclawbrain/eval/runner.py
+++ b/openclawbrain/eval/runner.py
@@ -1,0 +1,422 @@
+"""Baseline evaluation runner for OpenClawBrain."""
+
+from __future__ import annotations
+
+import csv
+import json
+import statistics
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from openclawbrain.daemon import _handle_query
+from openclawbrain.eval.baselines import (
+    PointerChaseConfig,
+    run_pointer_chase,
+    run_vector_topk,
+    run_vector_topk_rerank,
+    try_load_bm25_reranker,
+)
+from openclawbrain.hasher import HashEmbedder
+from openclawbrain.local_embedder import DEFAULT_LOCAL_MODEL, LocalEmbedder
+from openclawbrain.route_model import RouteModel
+from openclawbrain.store import load_state
+
+VALID_CATEGORIES = {"decision-history", "project-boundary", "pointer", "ops"}
+
+
+class _NullEventStore:
+    def append(self, event: dict[str, object]) -> None:  # noqa: D401
+        """Discard events so eval does not mutate journal files."""
+        _ = event
+
+
+@dataclass(frozen=True)
+class EvalQuery:
+    id: str
+    query: str
+    category: str
+    expected_keywords: tuple[str, ...] = ()
+
+
+def _percentile(values: list[float], pct: float) -> float:
+    if not values:
+        return 0.0
+    if pct <= 0:
+        return float(min(values))
+    if pct >= 100:
+        return float(max(values))
+    ordered = sorted(float(v) for v in values)
+    rank = (len(ordered) - 1) * (pct / 100.0)
+    low = int(rank)
+    high = min(low + 1, len(ordered) - 1)
+    weight = rank - low
+    return float(ordered[low] * (1.0 - weight) + ordered[high] * weight)
+
+
+def _load_queries(path: Path) -> list[EvalQuery]:
+    if not path.exists():
+        raise SystemExit(f"queries file not found: {path}")
+    loaded: list[EvalQuery] = []
+    for line_no, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        raw = line.strip()
+        if not raw:
+            continue
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise SystemExit(f"invalid JSON on line {line_no}: {exc}") from exc
+        if not isinstance(payload, dict):
+            raise SystemExit(f"line {line_no}: expected JSON object")
+        query_id = payload.get("id")
+        query_text = payload.get("query")
+        category = payload.get("category")
+        if not isinstance(query_id, str) or not query_id.strip():
+            raise SystemExit(f"line {line_no}: id must be a non-empty string")
+        if not isinstance(query_text, str) or not query_text.strip():
+            raise SystemExit(f"line {line_no}: query must be a non-empty string")
+        if not isinstance(category, str) or category not in VALID_CATEGORIES:
+            raise SystemExit(
+                f"line {line_no}: category must be one of {sorted(VALID_CATEGORIES)}"
+            )
+        expected_keywords = payload.get("expected_keywords", [])
+        if expected_keywords is None:
+            expected_keywords = []
+        if not isinstance(expected_keywords, list) or any(
+            not isinstance(item, str) or not item.strip() for item in expected_keywords
+        ):
+            raise SystemExit(f"line {line_no}: expected_keywords must be a list of non-empty strings")
+        loaded.append(
+            EvalQuery(
+                id=query_id.strip(),
+                query=query_text.strip(),
+                category=category,
+                expected_keywords=tuple(item.strip() for item in expected_keywords),
+            )
+        )
+    if not loaded:
+        raise SystemExit("queries file has no valid rows")
+    seen_ids: set[str] = set()
+    for item in loaded:
+        if item.id in seen_ids:
+            raise SystemExit(f"duplicate query id: {item.id}")
+        seen_ids.add(item.id)
+    return loaded
+
+
+def _resolve_embed(meta: dict[str, object], embed_model: str) -> Any:
+    model = embed_model.strip().lower()
+    if model == "hash":
+        return HashEmbedder().embed
+    if model == "local":
+        return LocalEmbedder(DEFAULT_LOCAL_MODEL).embed
+    if model.startswith("local:"):
+        return LocalEmbedder(embed_model.split(":", 1)[1].strip() or DEFAULT_LOCAL_MODEL).embed
+
+    embedder_name = str(meta.get("embedder_name", "hash-v1")).strip().lower()
+    if embedder_name.startswith("local:"):
+        return LocalEmbedder(DEFAULT_LOCAL_MODEL).embed
+    return HashEmbedder().embed
+
+
+def _keyword_hit_ratio(prompt_context: str, expected_keywords: tuple[str, ...]) -> float | None:
+    if not expected_keywords:
+        return None
+    text = prompt_context.lower()
+    hits = sum(1 for key in expected_keywords if key.lower() in text)
+    return hits / max(1, len(expected_keywords))
+
+
+def _mean(values: list[float]) -> float:
+    return float(sum(values) / len(values)) if values else 0.0
+
+
+def _median(values: list[float]) -> float:
+    return float(statistics.median(values)) if values else 0.0
+
+
+def _distribution(values: list[float]) -> dict[str, int]:
+    bins = [0.0, 0.2, 0.4, 0.6, 0.8, 1.0000001]
+    labels = ["[0.0,0.2)", "[0.2,0.4)", "[0.4,0.6)", "[0.6,0.8)", "[0.8,1.0]"]
+    counts = {label: 0 for label in labels}
+    for raw in values:
+        value = max(0.0, min(1.0, float(raw)))
+        for idx in range(len(bins) - 1):
+            if bins[idx] <= value < bins[idx + 1]:
+                counts[labels[idx]] += 1
+                break
+    return counts
+
+
+def _summarize_mode(rows: list[dict[str, object]]) -> dict[str, object]:
+    latencies = [float(row["latency_ms"]) for row in rows if row.get("latency_ms") is not None]
+    context_lens = [float(row["prompt_context_len"]) for row in rows]
+    fired_counts = [float(row["fired_count"]) for row in rows]
+    router_conf = [float(row.get("route_router_conf_mean", 0.0)) for row in rows]
+    relevance_conf = [float(row.get("route_relevance_conf_mean", 0.0)) for row in rows]
+    policy_disagreement = [float(row.get("route_policy_disagreement_mean", 0.0)) for row in rows]
+
+    keyword_scores = [float(row["keyword_hit_ratio"]) for row in rows if row.get("keyword_hit_ratio") is not None]
+
+    pointer_turns = [float(row["pointer_turns"]) for row in rows if row.get("pointer_turns") is not None]
+    pointer_tool_calls = [float(row["pointer_tool_calls"]) for row in rows if row.get("pointer_tool_calls") is not None]
+    pointer_tokens = [float(row["pointer_total_tokens"]) for row in rows if row.get("pointer_total_tokens") is not None]
+    pointer_cost = [float(row["pointer_cost"]) for row in rows if row.get("pointer_cost") is not None]
+    pointer_latency = [float(row["pointer_latency_ms"]) for row in rows if row.get("pointer_latency_ms") is not None]
+
+    summary = {
+        "query_count": len(rows),
+        "latency": {
+            "p50_ms": _percentile(latencies, 50),
+            "p95_ms": _percentile(latencies, 95),
+            "mean_ms": _mean(latencies),
+        },
+        "context": {
+            "prompt_context_len_mean": _mean(context_lens),
+            "prompt_context_len_median": _median(context_lens),
+            "fired_count_mean": _mean(fired_counts),
+            "fired_count_median": _median(fired_counts),
+        },
+        "routing_diagnostics": {
+            "route_router_conf_mean": _mean(router_conf),
+            "route_relevance_conf_mean": _mean(relevance_conf),
+            "route_policy_disagreement_mean": _mean(policy_disagreement),
+        },
+        "qtsim_proxies": {
+            "route_router_conf_distribution": _distribution(router_conf),
+            "fraction_router_conf_gt_0_7": (
+                sum(1 for value in router_conf if value > 0.7) / len(router_conf) if router_conf else 0.0
+            ),
+        },
+        "keyword_hit_ratio_mean": _mean(keyword_scores) if keyword_scores else None,
+    }
+
+    if pointer_turns:
+        summary["pointer_chase"] = {
+            "turns_mean": _mean(pointer_turns),
+            "tool_calls_mean": _mean(pointer_tool_calls),
+            "total_tokens_mean": _mean(pointer_tokens),
+            "cost_mean": _mean(pointer_cost),
+            "latency_mean_ms": _mean(pointer_latency),
+        }
+    return summary
+
+
+def _render_report(summary: dict[str, object], modes: list[str]) -> str:
+    lines = [
+        "# Baseline Evaluation Report",
+        "",
+        "## Summary",
+        "",
+        "| mode | status | queries | p50 latency (ms) | p95 latency (ms) | ctx mean | fired mean |",
+        "| --- | --- | --- | --- | --- | --- | --- |",
+    ]
+    mode_status = summary.get("mode_status", {}) if isinstance(summary.get("mode_status"), dict) else {}
+    mode_summaries = summary.get("mode_summaries", {}) if isinstance(summary.get("mode_summaries"), dict) else {}
+    for mode in modes:
+        status = mode_status.get(mode, {}).get("status", "ok") if isinstance(mode_status.get(mode), dict) else "ok"
+        mode_summary = mode_summaries.get(mode, {}) if isinstance(mode_summaries.get(mode), dict) else {}
+        latency = mode_summary.get("latency", {}) if isinstance(mode_summary.get("latency"), dict) else {}
+        context = mode_summary.get("context", {}) if isinstance(mode_summary.get("context"), dict) else {}
+        lines.append(
+            f"| {mode} | {status} | {mode_summary.get('query_count', 0)} | {latency.get('p50_ms', 0):.2f} | {latency.get('p95_ms', 0):.2f} | {context.get('prompt_context_len_mean', 0):.2f} | {context.get('fired_count_mean', 0):.2f} |"
+        )
+
+    lines.append("")
+    lines.append("## Pointer-Chase Diagnostics")
+    lines.append("")
+    lines.append("| mode | turns mean | tool calls mean | total tokens mean | cost mean | latency mean (ms) |")
+    lines.append("| --- | --- | --- | --- | --- | --- |")
+    for mode in modes:
+        mode_summary = mode_summaries.get(mode, {}) if isinstance(mode_summaries.get(mode), dict) else {}
+        pointer = mode_summary.get("pointer_chase", {}) if isinstance(mode_summary.get("pointer_chase"), dict) else {}
+        if pointer:
+            lines.append(
+                f"| {mode} | {pointer.get('turns_mean', 0):.2f} | {pointer.get('tool_calls_mean', 0):.2f} | {pointer.get('total_tokens_mean', 0):.2f} | {pointer.get('cost_mean', 0):.4f} | {pointer.get('latency_mean_ms', 0):.2f} |"
+            )
+        else:
+            lines.append(f"| {mode} | - | - | - | - | - |")
+
+    return "\n".join(lines)
+
+
+def run_baseline_suite(
+    *,
+    state_path: Path,
+    queries_path: Path,
+    modes: list[str],
+    embed_model: str,
+    route_model_path: Path | None,
+    top_k: int,
+    max_fired_nodes: int,
+    max_prompt_context_chars: int,
+    output_dir: Path,
+    include_per_query: bool,
+) -> dict[str, object]:
+    graph, index, meta = load_state(str(state_path))
+    embed_fn = _resolve_embed(meta, embed_model)
+    queries = _load_queries(queries_path)
+
+    route_model = None
+    if any(mode == "learned" for mode in modes):
+        model_path = route_model_path or (state_path.parent / "route_model.npz")
+        if model_path.exists():
+            route_model = RouteModel.load_npz(model_path)
+        else:
+            raise SystemExit(
+                "selected modes require a learned route model but none was found; set --route-model or create route_model.npz"
+            )
+
+    target_projections = route_model.precompute_target_projections(index) if route_model is not None else {}
+    reranker, reranker_reason = try_load_bm25_reranker()
+
+    per_mode_rows: dict[str, list[dict[str, object]]] = {mode: [] for mode in modes}
+    mode_status: dict[str, dict[str, object]] = {mode: {"status": "ok"} for mode in modes}
+    null_store = _NullEventStore()
+
+    for mode in modes:
+        if mode == "vector_topk_rerank" and reranker is None:
+            mode_status[mode] = {"status": "skipped", "reason": reranker_reason}
+            continue
+
+        for item in queries:
+            start = time.perf_counter()
+            if mode == "vector_topk":
+                payload = run_vector_topk(
+                    graph=graph,
+                    index=index,
+                    embed_fn=embed_fn,
+                    query_text=item.query,
+                    top_k=top_k,
+                    max_prompt_context_chars=max_prompt_context_chars,
+                    prompt_context_include_node_ids=True,
+                )
+            elif mode == "vector_topk_rerank":
+                payload = run_vector_topk_rerank(
+                    graph=graph,
+                    index=index,
+                    embed_fn=embed_fn,
+                    query_text=item.query,
+                    top_k=top_k,
+                    max_prompt_context_chars=max_prompt_context_chars,
+                    prompt_context_include_node_ids=True,
+                    reranker=reranker,
+                )
+            elif mode == "pointer_chase":
+                cfg = PointerChaseConfig(
+                    top_k=top_k,
+                    max_prompt_context_chars=max_prompt_context_chars,
+                )
+                payload = run_pointer_chase(
+                    graph=graph,
+                    index=index,
+                    embed_fn=embed_fn,
+                    query_text=item.query,
+                    config=cfg,
+                )
+            elif mode in {"learned", "edge_sim_legacy"}:
+                params = {
+                    "query": item.query,
+                    "top_k": top_k,
+                    "max_prompt_context_chars": max_prompt_context_chars,
+                    "max_context_chars": max_prompt_context_chars,
+                    "max_fired_nodes": max_fired_nodes,
+                    "prompt_context_include_node_ids": True,
+                }
+                if mode == "edge_sim_legacy":
+                    params["route_mode"] = "edge+sim"
+                else:
+                    params["route_mode"] = "learned"
+                payload = _handle_query(
+                    graph=graph,
+                    index=index,
+                    meta=meta,
+                    embed_fn=embed_fn,
+                    params=params,
+                    event_store=null_store,
+                    learned_model=route_model,
+                    target_projections=target_projections,
+                )
+            else:
+                raise SystemExit(f"unknown mode: {mode}")
+
+            elapsed_ms = (time.perf_counter() - start) * 1000.0
+            fired_nodes = payload.get("fired_nodes", [])
+            prompt_context = str(payload.get("prompt_context", ""))
+            row = {
+                "query_id": item.id,
+                "category": item.category,
+                "mode": mode,
+                "latency_ms": round(elapsed_ms, 6),
+                "prompt_context_len": int(payload.get("prompt_context_len", len(prompt_context))),
+                "fired_count": len(fired_nodes) if isinstance(fired_nodes, list) else 0,
+                "route_router_conf_mean": float(payload.get("route_router_conf_mean", 0.0)),
+                "route_relevance_conf_mean": float(payload.get("route_relevance_conf_mean", 0.0)),
+                "route_policy_disagreement_mean": float(payload.get("route_policy_disagreement_mean", 0.0)),
+                "keyword_hit_ratio": _keyword_hit_ratio(prompt_context, item.expected_keywords),
+                "pointer_turns": payload.get("pointer_turns"),
+                "pointer_tool_calls": payload.get("pointer_tool_calls"),
+                "pointer_total_tokens": payload.get("pointer_total_tokens"),
+                "pointer_cost": payload.get("pointer_cost"),
+                "pointer_latency_ms": payload.get("pointer_latency_ms"),
+                "reranker_name": payload.get("reranker_name"),
+            }
+            per_mode_rows[mode].append(row)
+
+    summary = {
+        "state": str(state_path),
+        "queries_path": str(queries_path),
+        "modes": modes,
+        "mode_status": mode_status,
+        "query_count": len(queries),
+        "mode_summaries": {
+            mode: _summarize_mode(rows) for mode, rows in per_mode_rows.items() if rows
+        },
+    }
+    if include_per_query:
+        summary["per_query"] = per_mode_rows
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    summary_path = output_dir / "summary.json"
+    summary_path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    csv_path = output_dir / "summary.csv"
+    _write_csv(csv_path, modes, per_mode_rows)
+
+    report_path = output_dir / "report.md"
+    report_path.write_text(_render_report(summary, modes) + "\n", encoding="utf-8")
+
+    summary["output"] = {
+        "summary_json": str(summary_path),
+        "summary_csv": str(csv_path),
+        "report_md": str(report_path),
+    }
+    return summary
+
+
+def _write_csv(path: Path, modes: list[str], rows: dict[str, list[dict[str, object]]]) -> None:
+    fieldnames = [
+        "query_id",
+        "category",
+        "mode",
+        "latency_ms",
+        "prompt_context_len",
+        "fired_count",
+        "keyword_hit_ratio",
+        "route_router_conf_mean",
+        "route_relevance_conf_mean",
+        "route_policy_disagreement_mean",
+        "pointer_turns",
+        "pointer_tool_calls",
+        "pointer_total_tokens",
+        "pointer_cost",
+        "pointer_latency_ms",
+        "reranker_name",
+    ]
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        for mode in modes:
+            for row in rows.get(mode, []):
+                writer.writerow({name: row.get(name) for name in fieldnames})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
 openai = ["openai>=1.0"]
 embeddings = ["sentence-transformers>=2.0"]
 benchmark = ["rank_bm25>=0.2"]
+reranker = ["rank_bm25>=0.2"]
 
 [project.scripts]
 openclawbrain = "openclawbrain.cli:main"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_baseline_runner.py
+++ b/tests/test_baseline_runner.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import socket
+from pathlib import Path
+
+from openclawbrain.graph import Edge, Graph, Node
+from openclawbrain.hasher import HashEmbedder
+from openclawbrain.index import VectorIndex
+from openclawbrain.store import save_state
+
+from openclawbrain.eval.runner import run_baseline_suite
+
+
+def _write_state(tmp_path: Path) -> Path:
+    graph = Graph()
+    graph.add_node(Node("n1", "Alpha specs and build steps."))
+    graph.add_node(Node("n2", "Beta workflow guide and release notes."))
+    graph.add_node(Node("n3", "Gamma pointer to beta; follow the link."))
+    graph.add_edge(Edge("n3", "n2", weight=0.7, kind="pointer"))
+    graph.add_edge(Edge("n1", "n3", weight=0.4, kind="pointer"))
+
+    index = VectorIndex()
+    embedder = HashEmbedder()
+    for node in graph.nodes():
+        index.upsert(node.id, embedder.embed(node.content))
+
+    state_path = tmp_path / "state.json"
+    save_state(graph=graph, index=index, path=str(state_path))
+    return state_path
+
+
+def _write_queries(tmp_path: Path) -> Path:
+    path = tmp_path / "queries.jsonl"
+    path.write_text(
+        "\n".join(
+            [
+                '{"id":"q1","query":"alpha build steps","category":"ops"}',
+                '{"id":"q2","query":"beta release notes","category":"pointer"}',
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_baseline_suite_runs_offline(tmp_path: Path, monkeypatch) -> None:
+    state_path = _write_state(tmp_path)
+    queries_path = _write_queries(tmp_path)
+    output_dir = tmp_path / "out"
+
+    def _block_socket(*_args, **_kwargs):
+        raise RuntimeError("network disabled")
+
+    monkeypatch.setattr(socket, "socket", _block_socket)
+
+    summary = run_baseline_suite(
+        state_path=state_path,
+        queries_path=queries_path,
+        modes=["vector_topk", "vector_topk_rerank", "pointer_chase", "edge_sim_legacy"],
+        embed_model="hash",
+        route_model_path=None,
+        top_k=2,
+        max_fired_nodes=5,
+        max_prompt_context_chars=2000,
+        output_dir=output_dir,
+        include_per_query=False,
+    )
+
+    assert output_dir.joinpath("summary.json").exists()
+    assert output_dir.joinpath("summary.csv").exists()
+    assert output_dir.joinpath("report.md").exists()
+    mode_status = summary.get("mode_status", {})
+    assert mode_status["vector_topk"]["status"] == "ok"
+    assert mode_status["pointer_chase"]["status"] == "ok"
+    assert mode_status["edge_sim_legacy"]["status"] == "ok"
+    assert mode_status["vector_topk_rerank"]["status"] in {"ok", "skipped"}

--- a/tests/test_expert_regions_sim.py
+++ b/tests/test_expert_regions_sim.py
@@ -34,6 +34,13 @@ def test_learned_closes_at_least_40_percent_of_oracle_gap(tmp_path: Path) -> Non
     assert gap_closed >= 0.40
 
 
+def test_learned_reward_beats_random_by_margin(tmp_path: Path) -> None:
+    summary = _run_small(tmp_path / "reward_gap", seed=24)
+    learned_reward = float(summary["final_learned_reward"])
+    random_reward = float(summary["random_reward"])
+    assert learned_reward - random_reward > 0.10
+
+
 def test_expert_regions_simulation_is_deterministic(tmp_path: Path) -> None:
     out_a = tmp_path / "run_a"
     out_b = tmp_path / "run_b"


### PR DESCRIPTION
Adds examples/eval/run_baselines.py + pointer_chase simulator + docs updates.

Repro:
- python examples/eval/run_baselines.py --state <state.json> --output-dir scratch/industry-baselines/latest

Also updates docs/evaluation-plan.md and README baseline matrix.