### PR TITLE
embed: default to local bge-large + add reembed + remove hash option

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ python3 -m openclawbrain.openclaw_adapter.query_brain \
 
 **OpenClawBrain learns from your agent feedback, so wrong answers get suppressed instead of resurfacing.** It builds a memory graph over your workspace, remembers what worked, and routes future answers through learned paths.
 
-- Pure Python 3.10+ core (no vector DB). OOTB embeddings are local (`fastembed`, BGE-small), so OpenAI is not required.
-- Built-in local + hash embeddings for offline/default operation; OpenAI embeddings are optional.
+- Pure Python 3.10+ core (no vector DB). OOTB embeddings are local (`fastembed`, BGE-large), so OpenAI is not required.
+- Built-in local embeddings for offline/default operation; OpenAI embeddings are optional.
 - Builds a **`state.json`** brain from your workspace.
 - Queries follow learned routes instead of only similarity matches.
 - Positive feedback (`+1`) uses the default policy-gradient learner `apply_outcome_pg()` (conserving probability mass across traversed nodes), while negative (`-1`) creates inhibitory edges.
@@ -114,7 +114,7 @@ See also: [Setup Guide](docs/setup-guide.md) for a complete local configuration 
 ## 5-minute operator path (OOTB)
 
 ```bash
-# 1) init (default embedder auto -> local fastembed -> hash fallback)
+# 1) init (default embedder auto -> local fastembed bge-large)
 openclawbrain init --workspace ~/.openclaw/workspace --output ~/.openclawbrain/main
 
 # 2) start service
@@ -291,7 +291,7 @@ openclawbrain query "incident runbook for deploy failures" --state /tmp/brain/st
 | Negative feedback | Inhibitory edges suppress bad paths | None | None (additive only) | None |
 | New knowledge | `inject` node (no rebuild) | Re-embed corpus | Add to reflection prompt | Update tier config |
 | Integration | Standalone library, any agent | Vector DB required | Tied to agent loop | Tied to agent architecture |
-| Cold start | Hash embeddings, no API key | Needs embedding service | Needs prior episodes | Needs configured tiers |
+| Cold start | Local fastembed embeddings, no API key | Needs embedding service | Needs prior episodes | Needs configured tiers |
 | State | Single `state.json` file | External DB | Prompt history | Multi-tier storage |
 
 ## Optional OpenAI embeddings + LLM routing
@@ -300,7 +300,7 @@ If you want API-backed embeddings/teacher labeling, use:
 
 - **Embeddings:** `text-embedding-3-small` (1536-dim)
 - **LLM routing/scoring:** `gpt-5-mini`
-- **Offline/testing fallback:** `hash` embeddings (lower quality, no API key required).
+- **Offline/testing default:** local fastembed embeddings (no API key required).
 
 ```python
 from openai import OpenAI
@@ -379,9 +379,9 @@ openclawbrain daemon --state ~/.openclawbrain/main/state.json
 
 Embedding mode defaults to `--embed-model auto`:
 - For `local:*` state metadata, daemon queries use local embeddings.
-- For `hash-v1` state metadata, daemon queries use hash embeddings.
+- For legacy `hash-v1` state metadata, daemon queries use hash embeddings (avoid for new states).
 - For OpenAI-based states, `auto` does not call OpenAI; use `--embed-model openai:<model>` explicitly.
-- Use `--embed-model hash` or `--embed-model local` to force offline query embeddings.
+- Use `--embed-model local` to force offline query embeddings.
 
 Routing mode defaults to `--route-mode learned`. `init` writes a default identity-like `route_model.npz` beside `state.json`; if that file is missing or unloadable, daemon query routing gracefully falls back to `edge+sim`.
 
@@ -574,7 +574,7 @@ from openclawbrain import (
 ## State lifecycle
 
 - **Where it lives:** a single `state.json` file (portable, version-controllable)
-- **How big:** depends on workspace size and embedder (`hash` smaller, dense embeddings larger)
+- **How big:** depends on workspace size and embedder (dense embeddings are larger)
 - **When to rebuild:** after major workspace restructuring or embedder changes
 - **Embedder changes:** OpenClawBrain stores the embedder name + dimension in state metadata and hard-fails on mismatch — no silent corruption
 - **Maintenance:** use `openclawbrain maintain` (`decay` + `scale` + `split` + `merge` + `prune` + `connect`) to rebalance structure as the graph evolves
@@ -586,10 +586,22 @@ from openclawbrain import (
 
 ## Cost control
 
-- **Default OOTB:** `openclawbrain init` uses local BGE-small embeddings (`--embedder auto` -> local -> hash fallback) and writes vectors to `state.json`.
+- **Default OOTB:** `openclawbrain init` uses local BGE-large embeddings (`--embedder auto` -> local fastembed) and writes vectors to `state.json`.
 - **Optional OpenAI:** install `openclawbrain[openai]` and use `--embedder openai` (or OpenAI teacher labeling via `async-route-pg`) when you want API-backed labels/embeddings.
 - **Batch init:** `openclawbrain init` embeds all workspace files in one batch call. Subsequent queries reuse cached vectors.
-- **Explicit control:** use `--embedder local` / `--embedder hash` / `--embedder openai` to force a specific embedder. Use `--llm none` to skip LLM-assisted splitting.
+- **Explicit control:** use `--embedder local` / `--embedder openai` to force a specific embedder. Use `--embed-model BAAI/bge-small-en-v1.5` to choose a smaller local model, or pass a bespoke fastembed model string. Use `--llm none` to skip LLM-assisted splitting.
+
+Example: switching an existing state to a different local model
+
+```bash
+# Smaller local model
+openclawbrain reembed --state ~/.openclawbrain/main/state.json \
+  --embedder local --embed-model BAAI/bge-small-en-v1.5 --backup
+
+# Bespoke fastembed model
+openclawbrain reembed --state ~/.openclawbrain/main/state.json \
+  --embedder local --embed-model my-org/my-embedding-model --backup
+```
 
 ## Warm start from sessions
 

--- a/REPRODUCE.md
+++ b/REPRODUCE.md
@@ -11,6 +11,21 @@ pip install -e .
 python sims/run_all.py
 ```
 
+## Embedding Defaults
+
+OpenClawBrain defaults to local fastembed embeddings with `BAAI/bge-large-en-v1.5`.
+To switch to a smaller or bespoke fastembed model:
+
+```bash
+# Smaller local model
+openclawbrain reembed --state ~/.openclawbrain/main/state.json \
+  --embedder local --embed-model BAAI/bge-small-en-v1.5 --backup
+
+# Bespoke fastembed model
+openclawbrain reembed --state ~/.openclawbrain/main/state.json \
+  --embedder local --embed-model my-org/my-embedding-model --backup
+```
+
 ## Expected Output
 
 ```

--- a/docs/openclaw-integration.md
+++ b/docs/openclaw-integration.md
@@ -42,7 +42,7 @@ OpenClawBrain stores everything in a single portable file:
   - `local:*` states use local query embeddings (fastembed, offline by default).
   - `hash-v1` states use hash query embeddings (offline, no OpenAI call).
   - OpenAI states do not auto-call OpenAI; use `--embed-model openai:<model>` explicitly when needed.
-  - Force hash mode: `--embed-model hash`.
+  - Legacy hash-v1 states can force hash query embeddings with `--embed-model hash` (legacy only).
   - Force local mode: `--embed-model local`.
   - Force explicit OpenAI model: `--embed-model openai:text-embedding-3-small`.
 
@@ -143,7 +143,7 @@ BRAIN_DIR=~/.openclawbrain/main
 mkdir -p "$BRAIN_DIR"
 
 # Create/overwrite state.json inside the output directory
-# By default, init uses embedder auto -> local fastembed -> hash fallback.
+# By default, init uses embedder auto -> local fastembed.
 openclawbrain init --workspace "$WORKSPACE" --output "$BRAIN_DIR"
 
 # Quick health signal
@@ -279,7 +279,7 @@ Daemon embed-model default and overrides:
 - `local:*` state metadata => local query embeddings.
 - `hash-v1` state metadata => hash query embeddings (offline).
 - OpenAI state metadata => no OpenAI call in auto; use `--embed-model openai:<model>` explicitly.
-- Force modes with `--embed-model hash` or `--embed-model local`.
+- Force modes with `--embed-model local`. Legacy hash-v1 states can force hash query embeddings with `--embed-model hash` (legacy only).
 
 Example request and reply:
 
@@ -538,7 +538,7 @@ Dimension mismatch usually means query embedding dimensions do not match the vec
 Fixes:
 - Run daemon in default auto mode (`--embed-model auto`), which follows state metadata safely.
 - Rebuild state if needed with the embedder you intend to keep.
-- Only force `--embed-model hash`, `--embed-model local`, or `--embed-model openai:<model>` when you intentionally want that behavior and dimensions are known to match.
+- Only force `--embed-model local` or `--embed-model openai:<model>` when you intentionally want that behavior and dimensions are known to match. Legacy hash-v1 states can use `--embed-model hash` if required.
 
 ```bash
 openclawbrain init --workspace ~/.openclaw/workspace --output ~/.openclawbrain/main
@@ -549,12 +549,12 @@ openclawbrain init --workspace ~/.openclaw/workspace --output ~/.openclawbrain/m
 Common causes:
 
 - You aren’t using the daemon (so `state.json` reload happens every call).
-- You’re using hash embeddings and still want production-grade retrieval (or `embed_query_ms` is high from OpenAI calls).
+- You’re using legacy hash-v1 embeddings and still want production-grade retrieval (or `embed_query_ms` is high from OpenAI calls).
 
 Fixes:
 
 - Use the canonical brain-on command (`openclawbrain serve start --state ...`).
-- Use OpenAI embeddings for production routing/scoring behavior; only use hash embeddings for offline/testing fallback.
+- Use OpenAI or local embeddings for production routing/scoring behavior; hash embeddings are legacy-only for existing hash-v1 states.
 
 ### “Daemon starts but OpenClaw can’t talk to it”
 

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -28,9 +28,9 @@ What `serve` does:
 
 Daemon embed-model auto behavior:
 - `local:*` states -> local query embeddings.
-- `hash-v1` states -> hash query embeddings.
+- `hash-v1` states -> hash query embeddings (legacy only).
 - OpenAI states -> no OpenAI call in `auto`; require explicit `--embed-model openai:<model>`.
-- Force offline mode: `--embed-model hash` or `--embed-model local`.
+- Force offline mode: `--embed-model local`. Legacy hash-v1 states can force hash query embeddings with `--embed-model hash`.
 - Force explicit OpenAI model: `--embed-model openai:text-embedding-3-small`.
 
 Route-mode behavior:
@@ -196,7 +196,7 @@ echo '{"id":"op-q1","method":"query","params":{"query":"incident deploy rollback
 Force query embed-model when needed:
 
 ```bash
-openclawbrain daemon --state ~/.openclawbrain/main/state.json --embed-model hash
+openclawbrain daemon --state ~/.openclawbrain/main/state.json --embed-model hash  # legacy hash-v1 only
 openclawbrain daemon --state ~/.openclawbrain/main/state.json --embed-model local
 openclawbrain daemon --state ~/.openclawbrain/main/state.json --embed-model openai:text-embedding-3-small
 ```
@@ -212,7 +212,7 @@ Operational notes:
 |---|---|---|
 | `status` says `Daemon: not running` | service not started, crashed, or wrong state path | `openclawbrain serve start --state ~/.openclawbrain/main/state.json` then `openclawbrain serve status --state ~/.openclawbrain/main/state.json` |
 | `daemon.sock` missing | service never started or wrong agent/state directory | `ls -la ~/.openclawbrain/main` and restart `openclawbrain serve` with the same `--state` |
-| embedder/dimension mismatch on daemon query | forced wrong `--embed-model` for this state | use `--embed-model auto` for local/hash states, or explicit OpenAI mode for OpenAI states: `--embed-model openai:text-embedding-3-small` |
+| embedder/dimension mismatch on daemon query | forced wrong `--embed-model` for this state | use `--embed-model auto` for local/legacy hash states, or explicit OpenAI mode for OpenAI states: `--embed-model openai:text-embedding-3-small` |
 | Replay fails with lock/single-writer message | another process holds `state.json.lock` | stop the other writer, use `examples/ops/rebuild_then_cutover.sh ...`, or expert override with `--force` / `OPENCLAWBRAIN_STATE_LOCK_FORCE=1` |
 | Replay restarts from old work | checkpoint not used, wrong path, or intentionally ignored | run with `--resume --checkpoint ~/.openclawbrain/main/replay_checkpoint.json`; inspect with `openclawbrain replay --state ~/.openclawbrain/main/state.json --show-checkpoint --resume` |
 | `LLM required for fast-learning` | no OpenAI client/key configured for fast-learning mining | set `OPENAI_API_KEY` or run `--mode edges-only` replay path |

--- a/docs/operator-quickstart.md
+++ b/docs/operator-quickstart.md
@@ -65,7 +65,7 @@ python3 -m openclawbrain.socket_client \
 - Override route mode at service start with `--route-mode off|edge|edge+sim|learned`.
 - Query embeddings default to `--embed-model auto`:
   - `local:*` state metadata -> local embeddings (fastembed)
-  - `hash-v1` state metadata -> hash embeddings
+  - `hash-v1` state metadata -> hash embeddings (legacy only)
   - OpenAI state metadata -> use `--embed-model openai:<model>` explicitly if you want OpenAI query embeddings
 
 ## Stop

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -14,13 +14,13 @@ openclawbrain doctor --state ./brain/state.json
 openclawbrain info --state ./brain/state.json
 ```
 
-By default, `init` uses local embeddings (`--embedder auto` resolves `local -> hash`) and does not require OpenAI. Use `--embedder hash --llm none` for strict zero-network mode, or `--embedder openai` if you explicitly want OpenAI embeddings.
+By default, `init` uses local embeddings (`--embedder auto` resolves to local) and does not require OpenAI. Use `--embedder openai` if you explicitly want OpenAI embeddings.
 
 Daemon query embedder default is `--embed-model auto`:
 - `local:*` states use local query embeddings.
 - `hash-v1` states use hash query embeddings.
 - OpenAI states do not auto-call OpenAI; set `--embed-model openai:<model>` to use OpenAI explicitly.
-- Force offline mode with `--embed-model hash` or `--embed-model local`.
+- Force offline mode with `--embed-model local`. Legacy `hash-v1` states can force hash query embeddings with `--embed-model hash` (legacy only).
 
 Runtime route-mode default is `learned`. `init` writes a default identity-like `route_model.npz` beside `state.json`; if missing/unloadable, daemon falls back to `edge+sim`.
 
@@ -93,7 +93,7 @@ Reference implementation: `examples/ops/query_and_learn.py`
 ```python
 from examples.ops.callbacks import make_embed_fn, make_llm_fn
 
-embed_fn = make_embed_fn("openai")  # or "hash" for offline/testing mode
+embed_fn = make_embed_fn("openai")  # or "local" for offline mode
 llm_fn = make_llm_fn("gpt-5-mini")  # optional, for LLM-assisted merge
 ```
 
@@ -271,7 +271,7 @@ Run the production service as a Unix socket wrapper around the NDJSON daemon:
 openclawbrain serve start --state ~/.openclawbrain/main/state.json
 ```
 
-`serve` runs the daemon worker with `--embed-model auto` and `--route-mode learned` by default. Embedding mode follows state metadata (`local:*` => local, `hash-v1` => hash, OpenAI states require explicit `--embed-model openai:<model>`).
+`serve` runs the daemon worker with `--embed-model auto` and `--route-mode learned` by default. Embedding mode follows state metadata (`local:*` => local, legacy `hash-v1` => hash, OpenAI states require explicit `--embed-model openai:<model>`).
 
 Advanced/alternate module form (same service behavior):
 
@@ -382,7 +382,7 @@ openclawbrain daemon --state ~/.openclawbrain/main/state.json --embed-model auto
 Force mode examples:
 
 ```bash
-# Force offline hash query embeddings
+# Force offline hash query embeddings (legacy hash-v1 only)
 openclawbrain daemon --state ~/.openclawbrain/main/state.json --embed-model hash
 
 # Force offline local query embeddings

--- a/openclawbrain/cli.py
+++ b/openclawbrain/cli.py
@@ -50,7 +50,7 @@ from .split import split_workspace
 from .hasher import HashEmbedder
 from .traverse import TraversalConfig, TraversalResult, traverse
 from .sync import DEFAULT_AUTHORITY_MAP, sync_workspace
-from .local_embedder import DEFAULT_LOCAL_MODEL, DEFAULT_LOCAL_MODEL_TAG, LocalEmbedder
+from .local_embedder import LocalEmbedder, resolve_local_model
 from .route_model import RouteModel
 from .full_learning import (
     _checkpoint_phase_offsets,
@@ -71,6 +71,7 @@ from .labels import LabelRecord, from_self_learning_event, from_teacher_output, 
 from .trace import RouteTrace, route_trace_to_json
 from .state_lock import StateLockError, state_write_lock
 from .store import load_state, save_state, resolve_default_state_path
+from ._batch import batch_or_single_embed
 from .ops.async_route_pg import run_async_route_pg
 from .profile import BrainProfile, BrainProfileError
 from .train_route_model import train_route_model, write_summary_json
@@ -247,6 +248,7 @@ def _state_lock_context_for_command(args: argparse.Namespace):
         "self-correct": False,
         "replay": True,
         "harvest": False,
+        "reembed": True,
         "sync": True,
         "async-route-pg": False,
     }
@@ -270,6 +272,7 @@ def _build_parser() -> argparse.ArgumentParser:
     i.add_argument("--output", required=True)
     i.add_argument("--sessions")
     i.add_argument("--embedder", choices=["hash", "local", "openai", "auto"], default="auto")
+    i.add_argument("--embed-model", default=None)
     i.add_argument("--llm", choices=["none", "openai", "auto"], default="auto")
     # LLM-splitting controls (default: use LLM only for larger/complex files)
     i.add_argument("--llm-split-min-chars", type=int, default=20000)
@@ -334,6 +337,13 @@ def _build_parser() -> argparse.ArgumentParser:
     z.add_argument("--dry-run", action="store_true")
     z.add_argument("--force", action="store_true", help="Bypass state lock (expert use)")
     z.add_argument("--json", action="store_true")
+
+    reembed = sub.add_parser("reembed", help="Rebuild embeddings + index for an existing state.json")
+    reembed.add_argument("--state", required=True)
+    reembed.add_argument("--embedder", choices=["local"], default="local")
+    reembed.add_argument("--embed-model", default=None)
+    reembed.add_argument("--backup", action=argparse.BooleanOptionalAction, default=True)
+    reembed.add_argument("--json", action="store_true")
 
     d = sub.add_parser(
         "daemon",
@@ -991,7 +1001,12 @@ def _parse_tool_result_allowlist(raw: str | None) -> set[str]:
     return {name for name in names if name}
 
 
-def _state_meta(meta: dict[str, object] | None, fallback_name: str | None = None, fallback_dim: int | None = None) -> dict[str, object]:
+def _state_meta(
+    meta: dict[str, object] | None,
+    fallback_name: str | None = None,
+    fallback_dim: int | None = None,
+    fallback_model: str | None = None,
+) -> dict[str, object]:
     """ state meta."""
     base = dict(meta or {})
     embedder_name, embedder_dim = _state_embedder_meta(base)
@@ -999,6 +1014,10 @@ def _state_meta(meta: dict[str, object] | None, fallback_name: str | None = None
         base["embedder_name"] = embedder_name or fallback_name
     if fallback_dim is not None:
         base["embedder_dim"] = embedder_dim if embedder_dim is not None else fallback_dim
+    if fallback_model is not None:
+        embedder_model = _state_embedder_model(base)
+        if embedder_model is None:
+            base["embedder_model"] = fallback_model
     return base
 
 
@@ -1043,25 +1062,41 @@ def _state_embedder_meta(meta: dict[str, object]) -> tuple[str | None, int | Non
     return embedder_name, embedder_dim
 
 
+def _state_embedder_model(meta: dict[str, object]) -> str | None:
+    """Resolve stored embedder model name if present."""
+    embedder_model = meta.get("embedder_model")
+    if isinstance(embedder_model, str) and embedder_model.strip():
+        return embedder_model.strip()
+    return None
+
+
 def _resolve_embedder(
     args: argparse.Namespace, meta: dict[str, object]
-) -> tuple[callable[[str], list[float]], callable[[list[tuple[str, str]]], dict[str, list[float]]], str, int]:
+) -> tuple[
+    callable[[str], list[float]],
+    callable[[list[tuple[str, str]]], dict[str, list[float]]],
+    str,
+    int,
+    str | None,
+]:
     """ resolve embedder."""
     openai_name = "openai-text-embedding-3-small"
     embedder_name, _ = _state_embedder_meta(meta)
+    embed_model = getattr(args, "embed_model", None)
+
+    if args.embedder == "hash":
+        embedder = HashEmbedder()
+        return embedder.embed, embedder.embed_batch, embedder.name, embedder.dim, None
 
     if args.embedder == "auto":
-        try:
-            embedder = LocalEmbedder()
-            return embedder.embed, embedder.embed_batch, embedder.name, embedder.dim
-        except Exception:
-            print("warning: local embedder not available, falling back to hash embedder", file=sys.stderr)
-            embedder = HashEmbedder()
-            return embedder.embed, embedder.embed_batch, embedder.name, embedder.dim
+        local_model = resolve_local_model(meta, embed_model=embed_model)
+        embedder = LocalEmbedder(model_name=local_model)
+        return embedder.embed, embedder.embed_batch, embedder.name, embedder.dim, local_model
 
     if args.embedder == "local":
-        embedder = LocalEmbedder()
-        return embedder.embed, embedder.embed_batch, embedder.name, embedder.dim
+        local_model = resolve_local_model(meta, embed_model=embed_model)
+        embedder = LocalEmbedder(model_name=local_model)
+        return embedder.embed, embedder.embed_batch, embedder.name, embedder.dim, local_model
 
     use_openai = args.embedder == "openai" or (args.embedder is None and embedder_name == openai_name)
     use_local = args.embedder is None and isinstance(embedder_name, str) and embedder_name.startswith("local:")
@@ -1070,18 +1105,17 @@ def _resolve_embedder(
 
         embedder = OpenAIEmbedder()
     elif use_local:
-        local_model = DEFAULT_LOCAL_MODEL
-        if isinstance(embedder_name, str):
-            local_tag = embedder_name.split(":", 1)[1]
-            if "/" in local_tag:
-                local_model = local_tag
-            elif local_tag == DEFAULT_LOCAL_MODEL_TAG:
-                local_model = DEFAULT_LOCAL_MODEL
+        local_model = resolve_local_model(meta, embed_model=embed_model)
         embedder = LocalEmbedder(model_name=local_model)
     else:
-        embedder = HashEmbedder()
+        if embedder_name == HashEmbedder().name:
+            embedder = HashEmbedder()
+        else:
+            local_model = resolve_local_model(meta, embed_model=embed_model)
+            embedder = LocalEmbedder(model_name=local_model)
 
-    return embedder.embed, embedder.embed_batch, embedder.name, embedder.dim
+    resolved_model = local_model if isinstance(embedder, LocalEmbedder) else None
+    return embedder.embed, embedder.embed_batch, embedder.name, embedder.dim, resolved_model
 
 
 def _resolve_llm(args: argparse.Namespace) -> tuple[Callable[[str, str], str] | None, Callable[[list[dict]], list[dict]] | None]:
@@ -1273,7 +1307,7 @@ def cmd_init(args: argparse.Namespace) -> int:
             node.metadata["authority"] = authority
 
     print("Phase 2/4: Embedding texts...", file=sys.stderr)
-    embedder_fn, embed_batch_fn, embedder_name, embedder_dim = _resolve_embedder(args, prior_meta)
+    embedder_fn, embed_batch_fn, embedder_name, embedder_dim, embedder_model = _resolve_embedder(args, prior_meta)
     print(
         f"Embedding {len(texts)} texts ({embedder_name}, dim={embedder_dim})",
         file=sys.stderr,
@@ -1313,7 +1347,12 @@ def cmd_init(args: argparse.Namespace) -> int:
     print("Phase 4/5: Saving state...", file=sys.stderr)
     graph_path = output_dir / "graph.json"
     text_path = output_dir / "texts.json"
-    state_meta = _state_meta(prior_meta, fallback_name=embedder_name, fallback_dim=embedder_dim)
+    state_meta = _state_meta(
+        prior_meta,
+        fallback_name=embedder_name,
+        fallback_dim=embedder_dim,
+        fallback_model=embedder_model,
+    )
     if replay_stats.get("last_replayed_ts") is not None:
         state_meta["last_replayed_ts"] = replay_stats["last_replayed_ts"]
         source = replay_stats.get("last_replayed_ts_source")
@@ -1353,7 +1392,6 @@ def cmd_init(args: argparse.Namespace) -> int:
 def cmd_query(args: argparse.Namespace) -> int:
     """cmd query."""
     graph, index, meta = _resolve_graph_index(args, allow_default_state=True)
-    embed_fn, _, embedder_name, _ = _resolve_embedder(args, meta)
     if args.top <= 0:
         raise SystemExit("--top must be >= 1")
 
@@ -1363,6 +1401,7 @@ def cmd_query(args: argparse.Namespace) -> int:
         query_vec = _load_query_vector_from_stdin()
         seeds = index.search(query_vec, top_k=args.top)
     elif index is not None:
+        embed_fn, _, embedder_name, _, _ = _resolve_embedder(args, meta)
         if embedder_name == HashEmbedder().name:
             _ensure_hash_embedder_compat(meta)
         query_vec = embed_fn(args.text)
@@ -1517,7 +1556,7 @@ def cmd_compact(args: argparse.Namespace) -> int:
     _, _, meta = _resolve_graph_index(args, allow_default_state=True)
 
     embed_args = SimpleNamespace(embedder=None)
-    embed_fn, _, _, _ = _resolve_embedder(embed_args, meta)
+    embed_fn, _, _, _, _ = _resolve_embedder(embed_args, meta)
     if args.llm == "openai":
         from .openai_llm import openai_llm_fn
 
@@ -1550,6 +1589,62 @@ def cmd_compact(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_reembed(args: argparse.Namespace) -> int:
+    """Rebuild embeddings for every node and rewrite index + embedder metadata."""
+    state_path = _resolve_state_path(args.state, allow_default=False)
+    if state_path is None:
+        raise SystemExit("--state is required for reembed")
+
+    graph, _index, meta = load_state(state_path)
+    embed_fn, embed_batch_fn, embedder_name, embedder_dim, embedder_model = _resolve_embedder(args, meta)
+
+    if embedder_name == HashEmbedder().name:
+        raise SystemExit("hash embedder is not permitted for reembed; use --embedder local")
+
+    texts = [(node.id, node.content) for node in graph.nodes()]
+    vectors = batch_or_single_embed(texts, embed_fn=embed_fn, embed_batch_fn=embed_batch_fn)
+    if len(vectors) != graph.node_count():
+        raise SystemExit(
+            f"reembed failed: expected {graph.node_count()} embeddings, got {len(vectors)}"
+        )
+
+    index = VectorIndex()
+    for node_id, vector in vectors.items():
+        index.upsert(node_id, vector)
+
+    state_meta = dict(meta)
+    state_meta["embedder_name"] = embedder_name
+    state_meta["embedder_dim"] = embedder_dim
+    if embedder_model is not None:
+        state_meta["embedder_model"] = embedder_model
+    _persist_state(
+        graph=graph,
+        index=index,
+        meta=state_meta,
+        state_path=state_path,
+        backup=bool(args.backup),
+    )
+
+    payload = {
+        "state": state_path,
+        "nodes": graph.node_count(),
+        "embedder_name": state_meta.get("embedder_name"),
+        "embedder_dim": state_meta.get("embedder_dim"),
+        "embedder_model": state_meta.get("embedder_model"),
+        "backup": bool(args.backup),
+    }
+    if args.json:
+        print(json.dumps(payload, indent=2))
+    else:
+        print(
+            "reembed ok: "
+            f"nodes={payload['nodes']} "
+            f"embedder={payload['embedder_name']} "
+            f"dim={payload['embedder_dim']}"
+        )
+    return 0
+
+
 def cmd_inject(args: argparse.Namespace) -> int:
     """cmd inject."""
     graph, index, meta = _resolve_graph_index(args, allow_default_state=True)
@@ -1558,7 +1653,7 @@ def cmd_inject(args: argparse.Namespace) -> int:
         raise SystemExit("--state is required for inject")
     if index is None:
         index = VectorIndex()
-    embed_fn, _, embedder_name, _ = _resolve_embedder(args, meta)
+    embed_fn, _, embedder_name, _, _ = _resolve_embedder(args, meta)
 
     if args.vector_stdin:
         vector = _load_query_vector_from_stdin()
@@ -1625,7 +1720,7 @@ def cmd_self_correct(args: argparse.Namespace) -> int:
         raise SystemExit("--state is required for self-correct")
     if index is None:
         index = VectorIndex()
-    embed_fn, _, embedder_name, _ = _resolve_embedder(args, meta)
+    embed_fn, _, embedder_name, _, _ = _resolve_embedder(args, meta)
     if embedder_name == HashEmbedder().name:
         _ensure_hash_embedder_compat(meta)
 
@@ -2562,7 +2657,7 @@ def cmd_sync(args: argparse.Namespace) -> int:
     authority_map = _parse_authority_map(getattr(args, "authority_map", None))
     graph, index, meta = _resolve_graph_index(args, allow_default_state=True)
 
-    embed_fn, embed_batch_fn, _, _ = _resolve_embedder(args, meta)
+    embed_fn, embed_batch_fn, _, _, _ = _resolve_embedder(args, meta)
 
     if args.dry_run:
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -2638,7 +2733,7 @@ def cmd_maintain(args: argparse.Namespace) -> int:
         raise SystemExit("--state is required for maintain")
     requested_tasks = [task.strip() for task in args.tasks.split(",") if task.strip()]
     _, _, meta = _resolve_graph_index(args, allow_default_state=True)
-    embed_fn, _, _, _ = _resolve_embedder(args, meta)
+    embed_fn, _, _, _, _ = _resolve_embedder(args, meta)
     llm_fn, _ = _resolve_llm(args)
     report = run_maintenance(
         state_path=state_path,
@@ -2993,6 +3088,7 @@ def main(argv: list[str] | None = None) -> int:
         "anchor": cmd_anchor,
         "connect": cmd_connect,
         "compact": cmd_compact,
+        "reembed": cmd_reembed,
         "daemon": cmd_daemon,
         "serve": cmd_serve,
         "inject": cmd_inject,

--- a/openclawbrain/cli.py
+++ b/openclawbrain/cli.py
@@ -271,7 +271,7 @@ def _build_parser() -> argparse.ArgumentParser:
     i.add_argument("--workspace", required=True)
     i.add_argument("--output", required=True)
     i.add_argument("--sessions")
-    i.add_argument("--embedder", choices=["hash", "local", "openai", "auto"], default="auto")
+    i.add_argument("--embedder", choices=["local", "openai", "auto"], default="auto")
     i.add_argument("--embed-model", default=None)
     i.add_argument("--llm", choices=["none", "openai", "auto"], default="auto")
     # LLM-splitting controls (default: use LLM only for larger/complex files)
@@ -286,7 +286,7 @@ def _build_parser() -> argparse.ArgumentParser:
     q.add_argument("--index")
     q.add_argument("--top", type=int, default=10)
     q.add_argument("--query-vector-stdin", action="store_true")
-    q.add_argument("--embedder", choices=["hash", "local", "openai"], default=None)
+    q.add_argument("--embedder", choices=["local", "openai"], default=None)
     q.add_argument("--max-context-chars", type=int, default=None)
     q.add_argument("--json", action="store_true")
 
@@ -324,7 +324,7 @@ def _build_parser() -> argparse.ArgumentParser:
     p.add_argument("--max-merges", type=int, default=5)
     p.add_argument("--prune-below", type=float, default=0.01)
     p.add_argument("--llm", choices=["none", "openai"], default="none")
-    p.add_argument("--embedder", choices=["hash", "local", "openai"], default=None)
+    p.add_argument("--embedder", choices=["local", "openai"], default=None)
     p.add_argument("--force", action="store_true", help="Bypass state lock (expert use)")
     p.add_argument("--json", action="store_true")
 
@@ -409,7 +409,7 @@ def _build_parser() -> argparse.ArgumentParser:
     x.add_argument("--summary")
     x.add_argument("--connect-top-k", type=int, default=3)
     x.add_argument("--connect-min-sim", type=float, default=None)
-    x.add_argument("--embedder", choices=["hash", "local", "openai"], default=None)
+    x.add_argument("--embedder", choices=["local", "openai"], default=None)
     x.add_argument("--vector-stdin", action="store_true")
     x.add_argument("--json", action="store_true")
 
@@ -602,7 +602,7 @@ def _build_parser() -> argparse.ArgumentParser:
     sync = sub.add_parser("sync")
     sync.add_argument("--state")
     sync.add_argument("--workspace", required=True)
-    sync.add_argument("--embedder", choices=["openai", "hash", "local"], default=None)
+    sync.add_argument("--embedder", choices=["openai", "local"], default=None)
     sync.add_argument(
         "--authority-map",
         help="JSON object mapping file name -> authority level",
@@ -1085,8 +1085,7 @@ def _resolve_embedder(
     embed_model = getattr(args, "embed_model", None)
 
     if args.embedder == "hash":
-        embedder = HashEmbedder()
-        return embedder.embed, embedder.embed_batch, embedder.name, embedder.dim, None
+        raise SystemExit("hash embedder is not selectable via CLI; use local/openai or migrate legacy state")
 
     if args.embedder == "auto":
         local_model = resolve_local_model(meta, embed_model=embed_model)

--- a/openclawbrain/daemon.py
+++ b/openclawbrain/daemon.py
@@ -20,7 +20,7 @@ from .graph import Graph, Node
 from .hasher import HashEmbedder
 from .index import VectorIndex
 from .learn import apply_outcome, apply_outcome_pg
-from .local_embedder import DEFAULT_LOCAL_MODEL, LocalEmbedder
+from .local_embedder import DEFAULT_LOCAL_MODEL, LocalEmbedder, resolve_local_model
 from .maintain import run_maintenance
 from .inject import _apply_inhibitory_edges, inject_correction, inject_node
 from .policy import DecisionMetrics, RoutingPolicy, make_runtime_route_fn
@@ -86,14 +86,14 @@ def _resolve_embed_fn(embed_model: str, meta: dict[str, object]) -> Callable[[st
 
     if model_lower in {"auto", ""}:
         if embedder_name_str.startswith("local:"):
-            return _make_local_embed_fn(DEFAULT_LOCAL_MODEL)
+            return _make_local_embed_fn(resolve_local_model(meta))
         if embedder_name_str == "hash-v1":
             return None
         return None
     if model_lower == "hash":
         return None
     if model_lower == "local":
-        return _make_local_embed_fn(DEFAULT_LOCAL_MODEL)
+        return _make_local_embed_fn(resolve_local_model(meta))
     if model_lower.startswith("local:"):
         local_model = model.split(":", 1)[1].strip()
         return _make_local_embed_fn(local_model or DEFAULT_LOCAL_MODEL)

--- a/openclawbrain/full_learning.py
+++ b/openclawbrain/full_learning.py
@@ -25,6 +25,7 @@ except Exception:
     OpenAIEmbedder = None
 
 from .hasher import HashEmbedder
+from .local_embedder import LocalEmbedder, resolve_local_model
 
 try:
     from .openai_llm import openai_llm_fn
@@ -733,6 +734,10 @@ def _state_embedder_info(
     if OpenAIEmbedder is not None and embedder_name == OpenAIEmbedder.name:
         embedder = OpenAIEmbedder()
         return embedder.embed_batch, 0.30
+    if embedder_name.startswith("local:"):
+        local_model = resolve_local_model(meta)
+        embedder = LocalEmbedder(model_name=local_model)
+        return embedder.embed_batch, 0.30
     embedder = HashEmbedder()
     return embedder.embed_batch, 0.0
 
@@ -1020,6 +1025,8 @@ def run_harvest(
     embedder_name = meta.get("embedder_name")
     if OpenAIEmbedder is not None and embedder_name == OpenAIEmbedder.name:
         embed_fn = OpenAIEmbedder().embed
+    elif isinstance(embedder_name, str) and embedder_name.startswith("local:"):
+        embed_fn = LocalEmbedder(model_name=resolve_local_model(meta)).embed
     else:
         embed_fn = HashEmbedder().embed
 

--- a/openclawbrain/local_embedder.py
+++ b/openclawbrain/local_embedder.py
@@ -3,13 +3,40 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import os
 
 import numpy as np
 
-DEFAULT_LOCAL_MODEL = "BAAI/bge-small-en-v1.5"
-DEFAULT_LOCAL_MODEL_TAG = "bge-small-en-v1.5"
+DEFAULT_LOCAL_MODEL = "BAAI/bge-large-en-v1.5"
+DEFAULT_LOCAL_MODEL_TAG = "bge-large-en-v1.5"
+
+_LOCAL_MODEL_TAG_MAP = {
+    "bge-large-en-v1.5": "BAAI/bge-large-en-v1.5",
+    "bge-small-en-v1.5": "BAAI/bge-small-en-v1.5",
+}
 
 _MODEL_CACHE: dict[str, object] = {}
+
+
+def _stub_dim_for_model(model_name: str) -> int:
+    lower = model_name.lower()
+    if "small" in lower:
+        return 384
+    if "large" in lower:
+        return 1024
+    return 768
+
+
+class _StubTextEmbedding:
+    def __init__(self, model_name: str) -> None:
+        from .hasher import HashEmbedder
+
+        self.model_name = model_name
+        self._embedder = HashEmbedder(dim=_stub_dim_for_model(model_name))
+
+    def embed(self, texts: list[str]):
+        for text in texts:
+            yield self._embedder.embed(text)
 
 
 def _normalize(vec: object) -> list[float]:
@@ -22,6 +49,49 @@ def _normalize(vec: object) -> list[float]:
     return [float(v) for v in arr.tolist()]
 
 
+def local_tag_from_model(model_name: str | None) -> str:
+    """Derive the local tag name used in metadata from a model name."""
+    if not model_name:
+        return DEFAULT_LOCAL_MODEL_TAG
+    return model_name.rsplit("/", 1)[-1]
+
+
+def local_embedder_name(model_name: str | None) -> str:
+    """Create the stable embedder_name string for local embeddings."""
+    return f"local:{local_tag_from_model(model_name)}"
+
+
+def resolve_local_model(
+    meta: dict[str, object] | None = None,
+    *,
+    embed_model: str | None = None,
+    default_model: str = DEFAULT_LOCAL_MODEL,
+) -> str:
+    """Resolve the full local model name from metadata and overrides."""
+    if embed_model:
+        cleaned = str(embed_model).strip()
+        if cleaned:
+            return cleaned
+
+    if meta:
+        embedder_model = meta.get("embedder_model")
+        if isinstance(embedder_model, str) and embedder_model.strip():
+            return embedder_model.strip()
+        embedder_name = meta.get("embedder_name") or meta.get("embedder")
+        if isinstance(embedder_name, str) and embedder_name.startswith("local:"):
+            local_tag = embedder_name.split(":", 1)[1].strip()
+            if not local_tag:
+                return default_model
+            if "/" in local_tag:
+                return local_tag
+            mapped = _LOCAL_MODEL_TAG_MAP.get(local_tag)
+            if mapped:
+                return mapped
+            return local_tag
+
+    return default_model
+
+
 @dataclass
 class LocalEmbedder:
     """Fast local embedder powered by `fastembed`."""
@@ -31,8 +101,7 @@ class LocalEmbedder:
 
     @property
     def name(self) -> str:
-        model_tag = self.model_name.rsplit("/", 1)[-1]
-        return f"local:{model_tag}"
+        return local_embedder_name(self.model_name)
 
     @property
     def dim(self) -> int:
@@ -47,6 +116,10 @@ class LocalEmbedder:
         try:
             from fastembed import TextEmbedding
         except ImportError as exc:
+            if os.environ.get("OPENCLAWBRAIN_FASTEMBED_STUB"):
+                model = _StubTextEmbedding(self.model_name)
+                _MODEL_CACHE[self.model_name] = model
+                return model
             raise ImportError("fastembed is required for local embeddings") from exc
         model = TextEmbedding(model_name=self.model_name)
         _MODEL_CACHE[self.model_name] = model

--- a/openclawbrain/openclaw_adapter/capture_feedback.py
+++ b/openclawbrain/openclaw_adapter/capture_feedback.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Any
 
 from openclawbrain import HashEmbedder, apply_outcome_pg, inject_correction, inject_node, load_state, save_state
+from openclawbrain.local_embedder import LocalEmbedder, resolve_local_model
 from openclawbrain.socket_client import OCBClient
 
 FIRE_LOG = "fired_log.jsonl"
@@ -131,6 +132,10 @@ def _resolve_embed_fn(meta: dict[str, object]) -> Callable[[str], list[float]]:
     embedder_name = meta.get("embedder_name")
     if embedder_name == "hash-v1":
         return HashEmbedder().embed
+
+    if isinstance(embedder_name, str) and embedder_name.startswith("local:"):
+        embedder = LocalEmbedder(model_name=resolve_local_model(meta))
+        return embedder.embed
 
     if embedder_name in {"text-embedding-3-small", "openai-text-embedding-3-small"}:
         from openai import OpenAI

--- a/openclawbrain/openclaw_adapter/learn_correction.py
+++ b/openclawbrain/openclaw_adapter/learn_correction.py
@@ -12,6 +12,7 @@ from typing import Any
 import time
 
 from openclawbrain import HashEmbedder, apply_outcome, inject_correction, load_state, save_state
+from openclawbrain.local_embedder import LocalEmbedder, resolve_local_model
 from openclawbrain.socket_client import OCBClient
 
 
@@ -70,6 +71,10 @@ def _resolve_embed_fn(meta: dict[str, object]) -> Callable[[str], list[float]]:
     embedder_name = meta.get("embedder_name")
     if embedder_name == "hash-v1":
         return HashEmbedder().embed
+
+    if isinstance(embedder_name, str) and embedder_name.startswith("local:"):
+        embedder = LocalEmbedder(model_name=resolve_local_model(meta))
+        return embedder.embed
 
     if embedder_name in {"text-embedding-3-small", "openai-text-embedding-3-small"}:
         from openai import OpenAI

--- a/openclawbrain/openclaw_adapter/query_brain.py
+++ b/openclawbrain/openclaw_adapter/query_brain.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any, Callable
 
 from openclawbrain import HashEmbedder, TraversalConfig, load_state, traverse
+from openclawbrain.local_embedder import LocalEmbedder, resolve_local_model
 from openclawbrain.prompt_context import build_prompt_context_ranked_with_stats
 from openclawbrain.socket_client import OCBClient
 
@@ -215,6 +216,9 @@ def _embed_fn_from_state(meta: dict[str, object]) -> tuple[Callable[[str], list[
     embedder_name = str(meta.get("embedder_name", "hash-v1"))
     hash_dim = meta.get("embedder_dim")
 
+    if embedder_name.startswith("local:"):
+        embedder = LocalEmbedder(model_name=resolve_local_model(meta))
+        return embedder.embed, embedder.name
     if embedder_name == "hash-v1" and hash_dim == HashEmbedder().dim:
         return HashEmbedder().embed, embedder_name
     if embedder_name == "hash-v1":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,9 +8,12 @@ from pathlib import Path
 import pytest
 
 from openclawbrain.cli import main
+from openclawbrain.graph import Graph, Node
 from openclawbrain.hasher import default_embed
 from openclawbrain.journal import read_journal
+from openclawbrain.index import VectorIndex
 from openclawbrain.state_lock import lock_path_for_state
+from openclawbrain.store import save_state
 
 
 def _write_graph_payload(path: Path) -> None:
@@ -34,6 +37,27 @@ def _write_index(path: Path, payload: dict[str, list[float]] | None = None) -> N
     if payload is None:
         payload = {"a": [1.0, 0.0], "b": [0.0, 1.0]}
     path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _install_fake_local_embedder(monkeypatch):
+    class FakeLocalEmbedder:
+        def __init__(self, model_name: str | None = None) -> None:
+            self.model_name = model_name or "BAAI/bge-large-en-v1.5"
+            self.name = f"local:{self.model_name.rsplit('/', 1)[-1]}"
+            self.dim = 2
+
+        def embed(self, text: str) -> list[float]:
+            lowered = text.lower()
+            if "alpha" in lowered or "deploy" in lowered:
+                return [1.0, 0.0]
+            return [0.0, 1.0]
+
+        def embed_batch(self, texts: list[tuple[str, str]]) -> dict[str, list[float]]:
+            return {node_id: self.embed(content) for node_id, content in texts}
+
+    import openclawbrain.cli as cli_module
+    monkeypatch.setattr(cli_module, "LocalEmbedder", FakeLocalEmbedder)
+    return FakeLocalEmbedder
 
 
 def _write_state(
@@ -145,16 +169,17 @@ def test_init_sets_authority_metadata_for_mapped_files(tmp_path, monkeypatch) ->
     assert "canonical" in authorities_for("USER.md")
 
 
-def test_query_command_returns_json_with_fired_nodes(tmp_path, capsys) -> None:
+def test_query_command_returns_json_with_fired_nodes(tmp_path, capsys, monkeypatch) -> None:
     """test query command returns json with fired nodes."""
+    _install_fake_local_embedder(monkeypatch)
     graph_path = tmp_path / "graph.json"
     index_path = tmp_path / "index.json"
     _write_graph_payload(graph_path)
     _write_index(
         index_path,
         {
-            "a": default_embed("alpha"),
-            "b": default_embed("beta"),
+            "a": [1.0, 0.0],
+            "b": [0.0, 1.0],
         },
     )
 
@@ -168,6 +193,8 @@ def test_query_command_returns_json_with_fired_nodes(tmp_path, capsys) -> None:
             str(index_path),
             "--top",
             "2",
+            "--embedder",
+            "local",
             "--json",
         ]
     )
@@ -183,16 +210,17 @@ def test_query_command_returns_json_with_fired_nodes(tmp_path, capsys) -> None:
     }
 
 
-def test_query_auto_embeds(tmp_path, capsys) -> None:
+def test_query_auto_embeds(tmp_path, capsys, monkeypatch) -> None:
     """test query auto embeds."""
+    _install_fake_local_embedder(monkeypatch)
     graph_path = tmp_path / "graph.json"
     index_path = tmp_path / "index.json"
     _write_graph_payload(graph_path)
     _write_index(
         index_path,
         {
-            "a": default_embed("alpha"),
-            "b": default_embed("completely different text"),
+            "a": [1.0, 0.0],
+            "b": [0.0, 1.0],
         },
     )
 
@@ -206,6 +234,8 @@ def test_query_auto_embeds(tmp_path, capsys) -> None:
             str(index_path),
             "--top",
             "2",
+            "--embedder",
+            "local",
             "--json",
         ]
     )
@@ -525,8 +555,9 @@ def test_cli_replay_with_fast_learning_writes_learning_events_and_injects_nodes(
     assert len(second_learning_nodes) == len(learning_nodes)
 
 
-def test_query_command_text_output_includes_node_ids(tmp_path, capsys) -> None:
+def test_query_command_text_output_includes_node_ids(tmp_path, capsys, monkeypatch) -> None:
     """test query text output includes node ids."""
+    _install_fake_local_embedder(monkeypatch)
     graph_path = tmp_path / "graph.json"
     index_path = tmp_path / "index.json"
     graph_payload = {
@@ -557,7 +588,7 @@ def test_query_command_text_output_includes_node_ids(tmp_path, capsys) -> None:
         }
     }
     graph_path.write_text(json.dumps(graph_payload), encoding="utf-8")
-    _write_index(index_path, {"deploy.md::0": default_embed("deploy"), "deploy.md::1": default_embed("hotfix")})
+    _write_index(index_path, {"deploy.md::0": [1.0, 0.0], "deploy.md::1": [0.0, 1.0]})
 
     code = main(
         [
@@ -569,6 +600,8 @@ def test_query_command_text_output_includes_node_ids(tmp_path, capsys) -> None:
             str(index_path),
             "--top",
             "2",
+            "--embedder",
+            "local",
         ]
     )
     assert code == 0
@@ -1720,8 +1753,11 @@ def test_cli_init_auto_embedder_prefers_local(tmp_path, monkeypatch) -> None:
     """init with auto embedder uses local embedder metadata when available."""
 
     class FakeLocalEmbedder:
-        name = "local:bge-small-en-v1.5"
+        name = "local:bge-large-en-v1.5"
         dim = 3
+
+        def __init__(self, model_name: str | None = None) -> None:
+            self.model_name = model_name or "BAAI/bge-large-en-v1.5"
 
         def embed(self, _text: str) -> list[float]:
             return [1.0, 0.0, 0.0]
@@ -1742,6 +1778,61 @@ def test_cli_init_auto_embedder_prefers_local(tmp_path, monkeypatch) -> None:
     assert code == 0
 
     state_data = json.loads((output / "state.json").read_text(encoding="utf-8"))
-    assert state_data["meta"]["embedder_name"] == "local:bge-small-en-v1.5"
+    assert state_data["meta"]["embedder_name"] == "local:bge-large-en-v1.5"
     assert state_data["meta"]["embedder_dim"] == 3
+    assert state_data["meta"]["embedder_model"] == "BAAI/bge-large-en-v1.5"
     assert (output / "route_model.npz").exists()
+
+
+def test_reembed_rewrites_embedder_meta_and_index_dims(tmp_path, monkeypatch) -> None:
+    """reembed should recompute vectors and update embedder metadata."""
+    class FakeLocalEmbedder:
+        def __init__(self, model_name: str | None = None) -> None:
+            self.model_name = model_name or "BAAI/bge-large-en-v1.5"
+            self.name = f"local:{self.model_name.rsplit('/', 1)[-1]}"
+            self.dim = 3
+
+        def embed(self, text: str) -> list[float]:
+            return [1.0, 0.0, 0.0] if "alpha" in text.lower() else [0.0, 1.0, 0.0]
+
+        def embed_batch(self, texts: list[tuple[str, str]]) -> dict[str, list[float]]:
+            return {node_id: self.embed(content) for node_id, content in texts}
+
+    import openclawbrain.cli as cli_module
+    monkeypatch.setattr(cli_module, "LocalEmbedder", FakeLocalEmbedder)
+
+    graph = Graph()
+    graph.add_node(Node(id="a", content="alpha", summary="", metadata={}))
+    graph.add_node(Node(id="b", content="beta", summary="", metadata={}))
+    index = VectorIndex()
+    index.upsert("a", [0.0, 1.0])
+    index.upsert("b", [1.0, 0.0])
+    state_path = tmp_path / "state.json"
+    save_state(
+        graph=graph,
+        index=index,
+        path=str(state_path),
+        meta={"embedder_name": "openai-text-embedding-3-small", "embedder_dim": 2},
+    )
+
+    code = main(
+        [
+            "reembed",
+            "--state",
+            str(state_path),
+            "--embedder",
+            "local",
+            "--embed-model",
+            "BAAI/bge-large-en-v1.5",
+            "--json",
+        ]
+    )
+    assert code == 0
+
+    payload = json.loads(state_path.read_text(encoding="utf-8"))
+    assert payload["meta"]["embedder_name"] == "local:bge-large-en-v1.5"
+    assert payload["meta"]["embedder_dim"] == 3
+    assert payload["meta"]["embedder_model"] == "BAAI/bge-large-en-v1.5"
+    index_payload = payload["index"]
+    assert len(index_payload["a"]) == 3
+    assert len(index_payload["b"]) == 3

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -87,14 +87,15 @@ def _write_state(
     path.write_text(json.dumps({"graph": graph_payload, "index": index_payload, "meta": meta}), encoding="utf-8")
 
 
-def test_init_command_creates_workspace_graph(tmp_path) -> None:
+def test_init_command_creates_workspace_graph(tmp_path, monkeypatch) -> None:
     """test init command creates workspace graph."""
     workspace = tmp_path / "ws"
     workspace.mkdir()
     (workspace / "a.md").write_text("## A\nHello", encoding="utf-8")
     output = tmp_path
 
-    code = main(["init", "--workspace", str(workspace), "--output", str(output), "--embedder", "hash", "--llm", "none"])
+    monkeypatch.setenv("OPENCLAWBRAIN_FASTEMBED_STUB", "1")
+    code = main(["init", "--workspace", str(workspace), "--output", str(output), "--embedder", "local", "--llm", "none"])
     assert code == 0
 
     graph_path = output / "graph.json"
@@ -106,21 +107,22 @@ def test_init_command_creates_workspace_graph(tmp_path) -> None:
     graph_data = json.loads(graph_path.read_text(encoding="utf-8"))
     graph_payload = graph_data["graph"] if "graph" in graph_data else graph_data
     assert len(graph_payload["nodes"]) == 1
-    assert graph_data.get("meta", {}).get("embedder_name") == "hash-v1"
+    assert graph_data.get("meta", {}).get("embedder_name") == "local:bge-large-en-v1.5"
     state_data = json.loads((tmp_path / "state.json").read_text(encoding="utf-8"))
-    assert state_data["meta"]["embedder_name"] == "hash-v1"
+    assert state_data["meta"]["embedder_name"] == "local:bge-large-en-v1.5"
     texts_data = json.loads(texts_path.read_text(encoding="utf-8"))
     assert len(texts_data) == 1
 
 
-def test_init_command_with_empty_workspace(tmp_path) -> None:
+def test_init_command_with_empty_workspace(tmp_path, monkeypatch) -> None:
     """test init command with empty workspace."""
     workspace = tmp_path / "empty"
     workspace.mkdir()
     output = tmp_path / "out"
     output.mkdir()
 
-    code = main(["init", "--workspace", str(workspace), "--output", str(output), "--embedder", "hash", "--llm", "none"])
+    monkeypatch.setenv("OPENCLAWBRAIN_FASTEMBED_STUB", "1")
+    code = main(["init", "--workspace", str(workspace), "--output", str(output), "--embedder", "local", "--llm", "none"])
     assert code == 0
     graph_file = json.loads((output / "graph.json").read_text(encoding="utf-8"))
     graph_data = graph_file["graph"] if "graph" in graph_file else graph_file
@@ -151,7 +153,8 @@ def test_init_sets_authority_metadata_for_mapped_files(tmp_path, monkeypatch) ->
     output = tmp_path / "out"
     output.mkdir()
 
-    code = main(["init", "--workspace", str(workspace), "--output", str(output), "--embedder", "hash", "--llm", "none"])
+    monkeypatch.setenv("OPENCLAWBRAIN_FASTEMBED_STUB", "1")
+    code = main(["init", "--workspace", str(workspace), "--output", str(output), "--embedder", "local", "--llm", "none"])
     assert code == 0
 
     state_data = json.loads((output / "state.json").read_text(encoding="utf-8"))
@@ -610,18 +613,16 @@ def test_query_command_text_output_includes_node_ids(tmp_path, capsys, monkeypat
     assert "deploy.md::1" in out
 
 
-def test_cli_dimension_mismatch_error(tmp_path) -> None:
-    """test cli dimension mismatch error."""
+def test_cli_rejects_hash_embedder_flag(tmp_path, capsys) -> None:
+    """CLI rejects hash embedder selection."""
     state_path = tmp_path / "state.json"
-    _write_state(
-        state_path,
-        index_payload={"a": [1.0, 0.0] * 768, "b": [0.0, 1.0] * 768},
-        meta={"embedder_name": "openai-text-embedding-3-small", "embedder_dim": 1536},
-    )
+    _write_state(state_path)
 
-    with pytest.raises(SystemExit, match=r"Index was built with openai-text-embedding-3-small \(dim=1536\). CLI hash embedder uses dim=1024. Dimension mismatch. Use --query-vector-stdin with matching embedder."):
+    with pytest.raises(SystemExit):
         main(["query", "alpha", "--state", str(state_path), "--embedder", "hash", "--top", "2", "--json"])
-        main(["query", "alpha", "--state", str(state_path), "--top", "2", "--json"])
+
+    err = capsys.readouterr().err
+    assert "invalid choice" in err
 
 
 def test_query_command_error_on_missing_graph(tmp_path) -> None:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -18,6 +18,7 @@ from openclawbrain.traverse import TraversalConfig, traverse
 
 def test_full_cycle_init_query_learn_query(tmp_path, capsys, monkeypatch) -> None:
     """test full cycle init query learn query."""
+    monkeypatch.setenv("OPENCLAWBRAIN_FASTEMBED_STUB", "1")
     workspace = tmp_path / "docs"
     workspace.mkdir()
     (workspace / "note.md").write_text(
@@ -34,8 +35,6 @@ def test_full_cycle_init_query_learn_query(tmp_path, capsys, monkeypatch) -> Non
             str(workspace),
             "--output",
             str(output_dir),
-            "--embedder",
-            "hash",
             "--llm",
             "none",
         ]
@@ -158,6 +157,7 @@ def test_decay_and_learning_interaction() -> None:
 
 def test_large_workspace_pipeline_end_to_end(tmp_path, capsys, monkeypatch) -> None:
     """test large workspace pipeline end to end."""
+    monkeypatch.setenv("OPENCLAWBRAIN_FASTEMBED_STUB", "1")
     workspace = tmp_path / "docs"
     workspace.mkdir()
 
@@ -176,8 +176,6 @@ def test_large_workspace_pipeline_end_to_end(tmp_path, capsys, monkeypatch) -> N
             str(workspace),
             "--output",
             str(output_dir),
-            "--embedder",
-            "hash",
             "--llm",
             "none",
         ]

--- a/tests/test_openai_embeddings.py
+++ b/tests/test_openai_embeddings.py
@@ -261,25 +261,23 @@ def test_resolve_embedder_chooses_by_arg_and_meta(monkeypatch) -> None:
     """test resolve embedder."""
     _install_fake_openai(monkeypatch, lambda text: [1.0] * 1536)
 
-    hash_fn, hash_batch_fn, hash_name, hash_dim = _resolve_embedder(argparse.Namespace(embedder="hash"), {})
+    hash_fn, hash_batch_fn, hash_name, hash_dim, hash_model = _resolve_embedder(argparse.Namespace(embedder="hash"), {})
     assert hash_name == "hash-v1"
     assert hash_dim == 1024
+    assert hash_model is None
     assert isinstance(hash_fn("alpha"), list)
     assert isinstance(hash_batch_fn([("a", "alpha")]), dict)
 
-    default_fn, _, default_name, _ = _resolve_embedder(argparse.Namespace(embedder=None), {})
-    assert default_name == "hash-v1"
-    assert isinstance(default_fn("alpha"), list)
-
-    openai_fn, openai_batch_fn, openai_name, openai_dim = _resolve_embedder(
+    openai_fn, openai_batch_fn, openai_name, openai_dim, openai_model = _resolve_embedder(
         argparse.Namespace(embedder="openai"), {}
     )
     assert openai_name == "openai-text-embedding-3-small"
     assert openai_dim == 1536
+    assert openai_model is None
     assert openai_fn("query") == [1.0] * 1536
     assert openai_batch_fn([("a", "query")]) == {"a": [1.0] * 1536}
 
-    auto_fn, _, auto_name, _ = _resolve_embedder(
+    auto_fn, _, auto_name, _, _ = _resolve_embedder(
         argparse.Namespace(embedder=None),
         {"embedder_name": "openai-text-embedding-3-small", "embedder_dim": 1536},
     )
@@ -287,8 +285,11 @@ def test_resolve_embedder_chooses_by_arg_and_meta(monkeypatch) -> None:
     assert auto_fn("query") == [1.0] * 1536
 
     class FakeLocalEmbedder:
-        name = "local:bge-small-en-v1.5"
+        name = "local:bge-large-en-v1.5"
         dim = 3
+
+        def __init__(self, model_name: str | None = None) -> None:
+            self.model_name = model_name or "BAAI/bge-large-en-v1.5"
 
         def embed(self, _text: str) -> list[float]:
             return [0.1, 0.2, 0.3]
@@ -298,9 +299,15 @@ def test_resolve_embedder_chooses_by_arg_and_meta(monkeypatch) -> None:
 
     import openclawbrain.cli as cli_module
     monkeypatch.setattr(cli_module, "LocalEmbedder", FakeLocalEmbedder)
-    local_fn, local_batch_fn, local_name, local_dim = _resolve_embedder(argparse.Namespace(embedder="auto"), {})
-    assert local_name == "local:bge-small-en-v1.5"
+    default_fn, _, default_name, _, default_model = _resolve_embedder(argparse.Namespace(embedder=None), {})
+    assert default_name == "local:bge-large-en-v1.5"
+    assert default_model == "BAAI/bge-large-en-v1.5"
+    assert isinstance(default_fn("alpha"), list)
+
+    local_fn, local_batch_fn, local_name, local_dim, local_model = _resolve_embedder(argparse.Namespace(embedder="auto"), {})
+    assert local_name == "local:bge-large-en-v1.5"
     assert local_dim == 3
+    assert local_model == "BAAI/bge-large-en-v1.5"
     assert local_fn("query") == [0.1, 0.2, 0.3]
     assert local_batch_fn([("n1", "query")]) == {"n1": [0.1, 0.2, 0.3]}
 

--- a/tests/test_openai_embeddings.py
+++ b/tests/test_openai_embeddings.py
@@ -261,7 +261,10 @@ def test_resolve_embedder_chooses_by_arg_and_meta(monkeypatch) -> None:
     """test resolve embedder."""
     _install_fake_openai(monkeypatch, lambda text: [1.0] * 1536)
 
-    hash_fn, hash_batch_fn, hash_name, hash_dim, hash_model = _resolve_embedder(argparse.Namespace(embedder="hash"), {})
+    hash_fn, hash_batch_fn, hash_name, hash_dim, hash_model = _resolve_embedder(
+        argparse.Namespace(embedder=None),
+        {"embedder_name": "hash-v1", "embedder_dim": 1024},
+    )
     assert hash_name == "hash-v1"
     assert hash_dim == 1024
     assert hash_model is None

--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -19,6 +19,7 @@ def _write_workspace(path: Path) -> None:
 def _build_state(workspace: Path) -> Path:
     env = os.environ.copy()
     env.pop("OPENAI_API_KEY", None)
+    env["OPENCLAWBRAIN_FASTEMBED_STUB"] = "1"
     output = workspace.parent / "state"
     output.mkdir(parents=True, exist_ok=True)
 
@@ -39,6 +40,7 @@ def _build_state(workspace: Path) -> Path:
 def _start_server(state_path: Path, socket_path: Path) -> subprocess.Popen:
     env = os.environ.copy()
     env.pop("OPENAI_API_KEY", None)
+    env["OPENCLAWBRAIN_FASTEMBED_STUB"] = "1"
     return subprocess.Popen(
         [
             sys.executable,

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -175,8 +175,6 @@ def test_sync_dry_run_doesnt_modify(tmp_path: Path) -> None:
             str(state_path),
             "--workspace",
             str(workspace),
-            "--embedder",
-            "hash",
             "--dry-run",
             "--json",
         ]


### PR DESCRIPTION
 - Default local embedder is now fastembed BAAI/bge-large-en-v1.5.
- Adds a new CLI command: `openclawbrain reembed` to rebuild an existing state index with local embeddings (no OpenAI embeddings).
- Removes hash embedder as a selectable CLI option (backward-compat reading existing hash-v1 states remains).

After merge (example):

  openclawbrain reembed --state ~/.openclawbrain/main/state.json --embedder local --embed-model BAAI/bge-large-en-v1.5

Repeat for pelican/bountiful/family state paths.