### PR TITLE
ops/docs: default complete brain-building pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 
 - Operator quickstart (start here): [docs/operator-quickstart.md](docs/operator-quickstart.md)
 - Operator guide (deep dive): [docs/operator-guide.md](docs/operator-guide.md)
+- Default brain-building experience (macOS): [docs/default-experience.md](docs/default-experience.md)
 - Shadow routing architecture: [docs/shadow-routing-upg-architecture.md](docs/shadow-routing-upg-architecture.md)
 - Evaluation plan: [docs/evaluation-plan.md](docs/evaluation-plan.md)
 - QTsim math appendix: [docs/ultimate-policy-gradient-routing-math.md](docs/ultimate-policy-gradient-routing-math.md)

--- a/docs/default-experience.md
+++ b/docs/default-experience.md
@@ -1,0 +1,57 @@
+# Default Brain-Building Experience (macOS)
+
+This is the **default, complete brain-building pipeline** for OpenClawBrain. It is designed to be reproducible, one-command, and **local-embedding-first** for OpenClaw operators.
+
+## Goals
+
+- Local embeddings everywhere (BGE-large via `fastembed`), **no OpenAI embeddings**.
+- Re-embed existing states before learning so all vectors are consistent.
+- Full replay pipeline (`--mode full`) with tool results included.
+- Structural maintenance tasks run every cycle.
+- Async route-teacher labeling + route model training.
+
+## Cost & spend notes
+
+This pipeline intentionally does **LLM work** in replay and labeling:
+
+- **Replay `--mode full`** runs fast-learning transcript mining + edge replay + harvest. The fast-learning phase calls an LLM to extract learning events, so it will incur LLM usage.
+- **Async teacher labeling** (`async-route-pg --teacher openai --teacher-model gpt-5-mini`) uses the OpenAI API to label route decisions and generate training traces.
+
+The script **never uses OpenAI embeddings**. All embedding work is forced to local BGE-large (`BAAI/bge-large-en-v1.5`). If you do not want any OpenAI usage at all, set `--teacher none` and use a non-LLM replay mode; otherwise supply `OPENAI_API_KEY`.
+
+## One-command orchestration
+
+The operator script below is the default macOS path for a complete brain build across all agents in `~/.openclaw/openclaw.json`.
+
+- Script: `examples/ops/default_experience.sh`
+- It is idempotent and logs per agent under `~/.openclawbrain/<agent>/scratch/`.
+
+### What it does (per agent)
+
+1. **Re-embed** the state with local BGE-large embeddings.
+2. **Replay** full pipeline with tool results included.
+3. **Maintain** structural tasks: `health,decay,scale,split,merge,prune,connect`.
+4. **Async route teacher labeling** (OpenAI teacher, `gpt-5-mini`) for the last 168 hours.
+5. **Train route model** from the generated traces.
+
+### Run it
+
+```bash
+examples/ops/default_experience.sh
+```
+
+### Environment
+
+If present, the script sources:
+
+```
+~/.openclaw/credentials/env/openclawbrain.env
+```
+
+This is the place to set `OPENAI_API_KEY` (required for replay `--mode full` and async teacher labeling). The script does not print secrets.
+
+## Notes
+
+- The script expects existing agent state files at `~/.openclawbrain/<agent>/state.json`.
+- The script does **not** start or stop `launchd` services; it only builds artifacts.
+- If you need a clean rebuild + cutover workflow, use `examples/ops/rebuild_then_cutover.sh` after this completes.

--- a/examples/ops/default_experience.sh
+++ b/examples/ops/default_experience.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+VENV_DIR="$HOME/.openclaw/venvs/openclawbrain"
+CONFIG="$HOME/.openclaw/openclaw.json"
+ENV_FILE="$HOME/.openclaw/credentials/env/openclawbrain.env"
+ROOT="$HOME/.openclawbrain"
+EMBED_MODEL="BAAI/bge-large-en-v1.5"
+TEACHER_MODEL="gpt-5-mini"
+SINCE_HOURS="168"
+
+usage() {
+  cat <<'USAGE'
+Usage: default_experience.sh
+
+Runs the complete default brain-building pipeline for every agent listed in
+~/.openclaw/openclaw.json.
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ -f "$ENV_FILE" ]]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+  set +a
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "error: python3 not found" >&2
+  exit 1
+fi
+
+if [[ ! -f "$CONFIG" ]]; then
+  echo "error: missing config: $CONFIG" >&2
+  exit 1
+fi
+
+mkdir -p "$ROOT"
+
+if [[ ! -d "$VENV_DIR" ]]; then
+  python3 -m venv "$VENV_DIR"
+fi
+
+PY_BIN="$VENV_DIR/bin/python"
+PIP_BIN="$VENV_DIR/bin/pip"
+OCB_BIN="$VENV_DIR/bin/openclawbrain"
+
+"$PY_BIN" -m pip install --upgrade pip wheel
+"$PY_BIN" -m pip install -e "$REPO_ROOT[openai]"
+
+if [[ ! -x "$OCB_BIN" ]]; then
+  echo "error: openclawbrain CLI not found in venv: $OCB_BIN" >&2
+  exit 1
+fi
+
+AGENT_ROWS="$($PY_BIN - <<'PY'
+import json
+import os
+import sys
+
+config = os.path.expanduser("~/.openclaw/openclaw.json")
+with open(config, "r", encoding="utf-8") as f:
+    data = json.load(f)
+
+agents = data.get("agents", {}).get("list", [])
+if not isinstance(agents, list):
+    sys.exit(0)
+
+for agent in agents:
+    if not isinstance(agent, dict):
+        continue
+    agent_id = agent.get("id")
+    workspace = agent.get("workspace")
+    if not agent_id or not workspace:
+        continue
+    print(f"{agent_id}\t{workspace}")
+PY
+)"
+
+if [[ -z "$AGENT_ROWS" ]]; then
+  echo "error: no agents found in $CONFIG" >&2
+  exit 1
+fi
+
+backup_if_exists() {
+  local path="$1"
+  local ts="$2"
+  if [[ -e "$path" ]]; then
+    local backup="${path}.bak.${ts}"
+    cp -p "$path" "$backup"
+  fi
+}
+
+FAILED=0
+
+while IFS=$'\t' read -r AGENT_ID WORKSPACE_DIR; do
+  if [[ -z "$AGENT_ID" || -z "$WORKSPACE_DIR" ]]; then
+    continue
+  fi
+
+  TS="$(date '+%Y%m%d-%H%M%S')"
+  AGENT_DIR="$ROOT/$AGENT_ID"
+  STATE="$AGENT_DIR/state.json"
+  SCRATCH="$AGENT_DIR/scratch"
+  SESSIONS="$HOME/.openclaw/agents/$AGENT_ID/sessions"
+  TRACE_OUT="$SCRATCH/route_traces.jsonl"
+  ROUTE_MODEL_OUT="$AGENT_DIR/route_model.npz"
+  STATE_BACKUP="$SCRATCH/state.pre-default-experience.${TS}.json"
+  LOG="$SCRATCH/default-experience.${TS}.log"
+
+  mkdir -p "$SCRATCH"
+
+  (
+    exec > >(tee -a "$LOG") 2>&1
+    echo "== OpenClawBrain default experience =="
+    echo "agent: $AGENT_ID"
+    echo "workspace: $WORKSPACE_DIR"
+    echo "state: $STATE"
+    echo "sessions: $SESSIONS"
+    echo "timestamp: $(date -Is)"
+
+    if [[ ! -f "$STATE" ]]; then
+      echo "error: missing state file: $STATE" >&2
+      exit 2
+    fi
+    if [[ ! -e "$SESSIONS" ]]; then
+      echo "error: missing sessions path: $SESSIONS" >&2
+      exit 2
+    fi
+
+    backup_if_exists "$TRACE_OUT" "$TS"
+    backup_if_exists "$ROUTE_MODEL_OUT" "$TS"
+    cp -p "$STATE" "$STATE_BACKUP"
+
+    echo
+    echo "== 1) Re-embed (local BGE-large) =="
+    "$OCB_BIN" reembed \
+      --state "$STATE" \
+      --embedder local \
+      --embed-model "$EMBED_MODEL"
+
+    echo
+    echo "== 2) Replay (full, include tool results) =="
+    "$OCB_BIN" replay \
+      --state "$STATE" \
+      --sessions "$SESSIONS" \
+      --mode full \
+      --include-tool-results
+
+    echo
+    echo "== 3) Maintain (structural tasks) =="
+    "$OCB_BIN" maintain \
+      --state "$STATE" \
+      --tasks health,decay,scale,split,merge,prune,connect \
+      --llm none \
+      --embedder local
+
+    echo
+    echo "== 4) Async route teacher labeling =="
+    "$OCB_BIN" async-route-pg \
+      --state "$STATE" \
+      --teacher openai \
+      --teacher-model "$TEACHER_MODEL" \
+      --since-hours "$SINCE_HOURS" \
+      --traces-out "$TRACE_OUT"
+
+    echo
+    echo "== 5) Train route model =="
+    "$OCB_BIN" train-route-model \
+      --state "$STATE" \
+      --traces-in "$TRACE_OUT" \
+      --out "$ROUTE_MODEL_OUT"
+
+    echo
+    echo "Done. Log: $LOG"
+  ) || FAILED=1
+
+done <<< "$AGENT_ROWS"
+
+exit "$FAILED"


### PR DESCRIPTION
Adds docs/default-experience.md and examples/ops/default_experience.sh describing the complete default pipeline (reembed local bge-large, replay full+harvest, maintain, async-route-pg + train-route-model).

This is the canonical end-to-end operator path for the default experience.