### PR TITLE
replay: tool/action provenance edges + default FULL + provenance wiring

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ See `examples/openai_embedder/` for a complete example.
 | `compact` | Compact old daily notes into graph nodes |
 | `sync` | Incremental re-embed after file changes |
 | `inject` | Add CORRECTION/TEACHING/DIRECTIVE nodes |
-| `replay` | Replay session queries (`--mode edges-only` default, plus `--mode fast-learning` or `--mode full`; use `--resume`/`--fresh`/`--checkpoint` to control checkpoint behavior) |
+| `replay` | Replay session queries (`--mode full` default, plus `--mode edges-only` or `--mode fast-learning`; use `--resume`/`--fresh`/`--checkpoint` to control checkpoint behavior) |
 | `harvest` | Apply slow-learning pass from `learning_events.jsonl` to current graph |
 | `async-route-pg` | Background teacher-shadow routing labels from recent query journal + PG edge updates |
 | `health` | Show graph health metrics |

--- a/docs/default-experience.md
+++ b/docs/default-experience.md
@@ -66,3 +66,23 @@ Each agent run writes auditable artifacts under `~/.openclawbrain/<agent>/scratc
 - The script expects existing agent state files at `~/.openclawbrain/<agent>/state.json`.
 - The script does **not** start or stop `launchd` services; it only builds artifacts.
 - If you need a clean rebuild + cutover workflow, use `examples/ops/rebuild_then_cutover.sh` after this completes.
+
+## Tool provenance edges
+
+Replay now builds first-class tool action/evidence nodes by default. This helps the brain learn tool usage quickly while keeping evidence out of prompt context unless explicitly requested.
+
+- Tool actions are always connected to the fired nodes that caused them.
+- Tool evidence is stored only for allowlisted tools and is redacted/truncated to avoid secrets or graph bloat.
+- Tool evidence nodes (`tool_evidence::...`) are excluded from traversal context by default.
+
+To view tool evidence during query/traverse:
+
+```bash
+openclawbrain query --provenance "your query"
+```
+
+To disable tool edge creation during replay:
+
+```bash
+openclawbrain replay --no-tool-edges --mode edges-only --sessions <path>
+```

--- a/docs/default-experience.md
+++ b/docs/default-experience.md
@@ -74,6 +74,7 @@ Replay now builds first-class tool action/evidence nodes by default. This helps 
 - Tool actions are always connected to the fired nodes that caused them.
 - Tool evidence is stored only for allowlisted tools and is redacted/truncated to avoid secrets or graph bloat.
 - Tool evidence nodes (`tool_evidence::...`) are excluded from traversal context by default.
+- Learning nodes with `session_pointer` (or session + line range metadata) automatically link to matching tool evidence nodes.
 
 To view tool evidence during query/traverse:
 

--- a/docs/openclaw-integration.md
+++ b/docs/openclaw-integration.md
@@ -415,7 +415,7 @@ OpenClawBrain ships an OpenClaw adapter that logs fired IDs per chat.
 
 That’s the ergonomic way to do “same-turn correction” inside OpenClaw.
 
-For full-history rebuilds, replay your sessions. Default mode is `edges-only`; use `--mode full` for full-learning + replay + harvest:
+For full-history rebuilds, replay your sessions. Default mode is `full`; use `--mode edges-only` for cheap edge-only replay:
 
 ```bash
 openclawbrain replay \

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -72,7 +72,7 @@ openclawbrain replay \
 Then keep serving from the daemon state.
 
 Replay mode quick guidance:
-- `--mode edges-only` (default when omitted): cheapest/fastest, no LLM mining, no harvest.
+- `--mode full` (default when omitted): fast-learning + replay + harvest.
 - `--mode fast-learning`: LLM transcript mining + injection only; usually the slowest and most expensive stage.
 - `--mode full`: fast-learning + edge replay + harvest; highest end-to-end runtime/cost.
 - Legacy flags still work and map to mode: `--edges-only`, `--fast-learning` (`--extract-learning-events`), `--full-learning` (`--full-pipeline`).
@@ -120,7 +120,7 @@ jq . ~/.openclawbrain/main/replay_checkpoint.json
 ```
 
 Flag meanings:
-- `--mode {edges-only,fast-learning,full}`: explicit replay mode. If omitted, replay defaults to `edges-only` and prints a startup note.
+- `--mode {edges-only,fast-learning,full}`: explicit replay mode. If omitted, replay defaults to `full` and prints a startup note.
 - `--checkpoint <path>`: checkpoint file location.
 - `--resume`: continue from saved per-session line offsets.
 - `--fresh` / `--no-checkpoint`: start from scratch even if checkpoint exists.

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -26,7 +26,7 @@ Runtime route-mode default is `learned`. `init` writes a default identity-like `
 
 ## Initial learning: replay your sessions
 
-After init, replay your existing sessions to seed graph edges and extract learning signals. By default, `replay` runs `--mode edges-only` (cheap/fast, no LLM mining, no harvest):
+After init, replay your existing sessions to seed graph edges and extract learning signals. By default, `replay` runs `--mode full` (fast-learning + replay + harvest):
 
 ```bash
 openclawbrain replay --state ./brain/state.json --sessions ./sessions/
@@ -37,7 +37,7 @@ Use `--mode full` when you explicitly want the full pipeline (LLM mining + edge 
 For cheap edge-only replay (no LLM, no harvest):
 
 ```bash
-openclawbrain replay --state ./brain/state.json --sessions ./sessions/ --mode edges-only
+openclawbrain replay --state ./brain/state.json --sessions ./sessions/ --mode full
 ```
 
 For fine-grained control over the LLM mining pass:

--- a/openclawbrain/cli.py
+++ b/openclawbrain/cli.py
@@ -288,6 +288,7 @@ def _build_parser() -> argparse.ArgumentParser:
     q.add_argument("--query-vector-stdin", action="store_true")
     q.add_argument("--embedder", choices=["local", "openai"], default=None)
     q.add_argument("--max-context-chars", type=int, default=None)
+    q.add_argument("--provenance", action=argparse.BooleanOptionalAction, default=False)
     q.add_argument("--json", action="store_true")
 
     l = sub.add_parser("learn")
@@ -489,6 +490,12 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     r.add_argument("--ignore-checkpoint", action="store_true", help=argparse.SUPPRESS)
     r.add_argument("--include-tool-results", action=argparse.BooleanOptionalAction, default=True)
+    r.add_argument(
+        "--tool-edges",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Create tool action/evidence edges during replay (default: on).",
+    )
     r.add_argument(
         "--tool-result-allowlist",
         default=",".join(sorted(DEFAULT_TOOL_RESULT_ALLOWLIST)),
@@ -1411,7 +1418,11 @@ def cmd_query(args: argparse.Namespace) -> int:
     result = traverse(
         graph=graph,
         seeds=seeds,
-        config=TraversalConfig(max_hops=15, max_context_chars=args.max_context_chars),
+        config=TraversalConfig(
+            max_hops=15,
+            max_context_chars=args.max_context_chars,
+            include_provenance=bool(args.provenance),
+        ),
         query_text=args.text,
     )
     log_query(
@@ -2196,6 +2207,7 @@ def cmd_replay(args: argparse.Namespace) -> int:
             auto_decay=auto_decay,
             decay_interval=decay_interval,
             on_merge=_on_merge,
+            tool_edges=bool(args.tool_edges),
         )
         stats["queries_replayed"] = int(parallel_stats.get("queries_replayed", 0))
         stats["edges_reinforced"] = int(parallel_stats.get("edges_reinforced", 0))
@@ -2222,6 +2234,7 @@ def cmd_replay(args: argparse.Namespace) -> int:
                 verbose=False,
                 auto_decay=auto_decay,
                 decay_interval=decay_interval,
+                tool_edges=bool(args.tool_edges),
             )
             merge_batches += 1
             processed_interactions += len(batch)

--- a/openclawbrain/cli.py
+++ b/openclawbrain/cli.py
@@ -81,9 +81,9 @@ DEFAULT_STATE_PROFILE = "main"
 REPLAY_MODES = ("edges-only", "fast-learning", "full")
 REPLAY_HELP_EPILOG = (
     "Replay modes and rough cost profile:\n"
-    "  edges-only    Fastest/cheapest. No LLM calls, no harvest. Good default for frequent warm-up.\n"
+    "  edges-only    Fastest/cheapest. No LLM calls, no harvest.\n"
     "  fast-learning LLM-bound transcript mining + injection only. Usually the slowest and highest-cost phase.\n"
-    "  full          Fast-learning + edge replay + harvest. Highest end-to-end time and API spend.\n\n"
+    "  full          Fast-learning + edge replay + harvest. Highest end-to-end time and API spend. Default.\n\n"
     "Checkpoint semantics:\n"
     "  --resume uses saved per-session offsets.\n"
     "  --fresh / --no-checkpoint starts from scratch even if a checkpoint exists.\n"
@@ -142,7 +142,7 @@ def _resolve_replay_mode(args: argparse.Namespace) -> tuple[str, bool]:
         return explicit_mode, False
     if legacy_mode is not None:
         return legacy_mode, False
-    return "edges-only", True
+    return "full", True
 
 
 def _load_profile(profile_path: str | None) -> BrainProfile | None:
@@ -443,8 +443,8 @@ def _build_parser() -> argparse.ArgumentParser:
         choices=REPLAY_MODES,
         default=None,
         help=(
-            "Replay mode: edges-only (cheap/default), fast-learning (LLM mining only), "
-            "or full (fast-learning + replay + harvest)."
+            "Replay mode: edges-only (cheap), fast-learning (LLM mining only), "
+            "or full (fast-learning + replay + harvest; default)."
         ),
     )
     r.add_argument(
@@ -1984,7 +1984,7 @@ def cmd_replay(args: argparse.Namespace) -> int:
     timed_progress_interval_seconds = 30
     if mode_defaulted and not quiet:
         print(
-            "Replay mode note: no mode specified; defaulting to --mode edges-only (never defaults to full).",
+            "Replay mode note: no mode specified; defaulting to --mode full.",
             file=sys.stderr,
         )
 

--- a/openclawbrain/daemon.py
+++ b/openclawbrain/daemon.py
@@ -422,7 +422,12 @@ def _handle_query(
     result = traverse(
         graph=graph,
         seeds=seeds,
-        config=TraversalConfig(max_hops=15, max_context_chars=max_context_chars, max_fired_nodes=max_fired_nodes),
+        config=TraversalConfig(
+            max_hops=15,
+            max_context_chars=max_context_chars,
+            max_fired_nodes=max_fired_nodes,
+            include_provenance=query.include_provenance,
+        ),
         query_text=query_text,
         route_fn=route_fn,
     )

--- a/openclawbrain/full_learning.py
+++ b/openclawbrain/full_learning.py
@@ -17,8 +17,8 @@ from pathlib import Path
 from typing import Any
 
 from ._util import _extract_json
-from .graph import Edge
 from .inject import inject_batch
+from .provenance import attach_tool_evidence_provenance
 from .maintain import run_maintenance
 try:
     from .openai_embeddings import OpenAIEmbedder
@@ -758,82 +758,6 @@ def _state_embedder_info(
     return embedder.embed_batch, 0.0
 
 
-def _parse_session_pointer(pointer: str) -> tuple[str, int, int] | None:
-    """Parse session_pointer into (session, start_line, end_line)."""
-    if not pointer or ":" not in pointer:
-        return None
-    session_part, range_part = pointer.rsplit(":", 1)
-    if "-" not in range_part:
-        return None
-    start_raw, end_raw = range_part.split("-", 1)
-    try:
-        start = int(start_raw)
-        end = int(end_raw)
-    except ValueError:
-        return None
-    if start > end:
-        start, end = end, start
-    return session_part, start, end
-
-
-def _connect_learning_to_tool_evidence(
-    graph: object,
-    events: list[dict],
-) -> dict[str, int]:
-    """Connect learning nodes to tool evidence nodes by session/line ranges."""
-    if not hasattr(graph, "nodes") or not hasattr(graph, "get_node"):
-        return {"edges_added": 0}
-
-    session_index: dict[str, list[tuple[int, str]]] = {}
-    for node in graph.nodes():  # type: ignore[union-attr]
-        if not node.id.startswith("tool_evidence::"):
-            continue
-        metadata = node.metadata if isinstance(node.metadata, dict) else {}
-        line_no = metadata.get("line_no")
-        if not isinstance(line_no, (int, float)):
-            continue
-        line_val = int(line_no)
-        for key in ("session", "session_path"):
-            session = metadata.get(key)
-            if isinstance(session, str) and session:
-                session_index.setdefault(session, []).append((line_val, node.id))
-
-    if not session_index:
-        return {"edges_added": 0}
-
-    edges_added = 0
-    for event in events:
-        node_id = event.get("node_id")
-        pointer = event.get("session_pointer")
-        if not isinstance(node_id, str) or not isinstance(pointer, str):
-            continue
-        parsed = _parse_session_pointer(pointer)
-        if parsed is None:
-            continue
-        session, start_line, end_line = parsed
-        evidence_nodes = session_index.get(session, [])
-        if not evidence_nodes:
-            continue
-        for line_no, evidence_id in evidence_nodes:
-            if line_no < start_line or line_no > end_line:
-                continue
-            existing = graph._edges.get(node_id, {}).get(evidence_id)  # type: ignore[attr-defined]
-            if existing is not None:
-                continue
-            graph.add_edge(  # type: ignore[attr-defined]
-                Edge(
-                    source=node_id,
-                    target=evidence_id,
-                    weight=0.20,
-                    kind="provenance",
-                    metadata={"source": "fast_learning"},
-                )
-            )
-            edges_added += 1
-
-    return {"edges_added": edges_added}
-
-
 def run_fast_learning(
     state_path: str,
     session_paths: str | list[str] | list[Path] | Path,
@@ -1042,7 +966,7 @@ def run_fast_learning(
             connect_top_k=3,
             connect_min_sim=connect_min_sim,
         )
-        provenance_edges = _connect_learning_to_tool_evidence(graph, deduped)
+        provenance_edges = attach_tool_evidence_provenance(graph, deduped)
         if provenance_edges.get("edges_added"):
             injected["edges_added"] = int(injected.get("edges_added", 0)) + int(provenance_edges["edges_added"])
         _persist_state(graph=graph, index=index, meta=meta, state_path=state_path, backup=backup)

--- a/openclawbrain/full_learning.py
+++ b/openclawbrain/full_learning.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Any
 
 from ._util import _extract_json
+from .graph import Edge
 from .inject import inject_batch
 from .maintain import run_maintenance
 try:
@@ -34,7 +35,9 @@ except Exception:
 from .replay import (
     DEFAULT_TOOL_RESULT_ALLOWLIST,
     DEFAULT_TOOL_RESULT_MAX_CHARS,
+    _extract_tool_calls,
     _extract_tool_result,
+    _extract_tool_result_record,
     _is_media_stub_query,
     _normalize_tool_result_allowlist,
     replay_queries,
@@ -648,6 +651,7 @@ def load_interactions_for_replay(
 
     for path in files:
         path_name = str(path)
+        session_name = path.name
         start_line = int((since_lines or {}).get(path_name, 0))
         last_line = start_line
         last_user_idx: int | None = None
@@ -671,9 +675,13 @@ def load_interactions_for_replay(
                         "query": query,
                         "response": None,
                         "tool_calls": [],
+                        "tool_results": [],
                         "ts": record_ts,
                         "source": path_name,
+                        "session": session_name,
                         "line_no": line_no,
+                        "line_no_start": line_no,
+                        "line_no_end": line_no,
                     }
                 )
                 last_user_idx = len(interactions) - 1
@@ -681,6 +689,16 @@ def load_interactions_for_replay(
                 continue
 
             if role in {"toolresult", "tool_result"}:
+                if last_user_idx is not None:
+                    record = _extract_tool_result_record(message)
+                    if record is not None:
+                        record["line_no"] = line_no
+                        record["session"] = session_name
+                        record["source"] = path_name
+                        interactions[last_user_idx].setdefault("tool_results", [])
+                        if isinstance(interactions[last_user_idx]["tool_results"], list):
+                            interactions[last_user_idx]["tool_results"].append(record)
+                    interactions[last_user_idx]["line_no_end"] = line_no
                 if (
                     include_tool_results
                     and last_user_idx is not None
@@ -714,12 +732,10 @@ def load_interactions_for_replay(
 
             response = _resolve_text(message.get("content"))
             interactions[last_user_idx]["response"] = response
-            tool_calls = []
-            raw_calls = message.get("tool_calls")
-            if isinstance(raw_calls, list):
-                tool_calls = [call for call in raw_calls if isinstance(call, dict)]
+            tool_calls = _extract_tool_calls(message, is_assistant=True)
             interactions[last_user_idx]["tool_calls"] = tool_calls
             interactions[last_user_idx]["ts"] = record_ts
+            interactions[last_user_idx]["line_no_end"] = line_no
             last_user_idx = None
 
         offsets[path_name] = last_line
@@ -740,6 +756,82 @@ def _state_embedder_info(
         return embedder.embed_batch, 0.30
     embedder = HashEmbedder()
     return embedder.embed_batch, 0.0
+
+
+def _parse_session_pointer(pointer: str) -> tuple[str, int, int] | None:
+    """Parse session_pointer into (session, start_line, end_line)."""
+    if not pointer or ":" not in pointer:
+        return None
+    session_part, range_part = pointer.rsplit(":", 1)
+    if "-" not in range_part:
+        return None
+    start_raw, end_raw = range_part.split("-", 1)
+    try:
+        start = int(start_raw)
+        end = int(end_raw)
+    except ValueError:
+        return None
+    if start > end:
+        start, end = end, start
+    return session_part, start, end
+
+
+def _connect_learning_to_tool_evidence(
+    graph: object,
+    events: list[dict],
+) -> dict[str, int]:
+    """Connect learning nodes to tool evidence nodes by session/line ranges."""
+    if not hasattr(graph, "nodes") or not hasattr(graph, "get_node"):
+        return {"edges_added": 0}
+
+    session_index: dict[str, list[tuple[int, str]]] = {}
+    for node in graph.nodes():  # type: ignore[union-attr]
+        if not node.id.startswith("tool_evidence::"):
+            continue
+        metadata = node.metadata if isinstance(node.metadata, dict) else {}
+        line_no = metadata.get("line_no")
+        if not isinstance(line_no, (int, float)):
+            continue
+        line_val = int(line_no)
+        for key in ("session", "session_path"):
+            session = metadata.get(key)
+            if isinstance(session, str) and session:
+                session_index.setdefault(session, []).append((line_val, node.id))
+
+    if not session_index:
+        return {"edges_added": 0}
+
+    edges_added = 0
+    for event in events:
+        node_id = event.get("node_id")
+        pointer = event.get("session_pointer")
+        if not isinstance(node_id, str) or not isinstance(pointer, str):
+            continue
+        parsed = _parse_session_pointer(pointer)
+        if parsed is None:
+            continue
+        session, start_line, end_line = parsed
+        evidence_nodes = session_index.get(session, [])
+        if not evidence_nodes:
+            continue
+        for line_no, evidence_id in evidence_nodes:
+            if line_no < start_line or line_no > end_line:
+                continue
+            existing = graph._edges.get(node_id, {}).get(evidence_id)  # type: ignore[attr-defined]
+            if existing is not None:
+                continue
+            graph.add_edge(  # type: ignore[attr-defined]
+                Edge(
+                    source=node_id,
+                    target=evidence_id,
+                    weight=0.20,
+                    kind="provenance",
+                    metadata={"source": "fast_learning"},
+                )
+            )
+            edges_added += 1
+
+    return {"edges_added": edges_added}
 
 
 def run_fast_learning(
@@ -950,6 +1042,9 @@ def run_fast_learning(
             connect_top_k=3,
             connect_min_sim=connect_min_sim,
         )
+        provenance_edges = _connect_learning_to_tool_evidence(graph, deduped)
+        if provenance_edges.get("edges_added"):
+            injected["edges_added"] = int(injected.get("edges_added", 0)) + int(provenance_edges["edges_added"])
         _persist_state(graph=graph, index=index, meta=meta, state_path=state_path, backup=backup)
 
     if checkpoint_path:

--- a/openclawbrain/inject.py
+++ b/openclawbrain/inject.py
@@ -7,6 +7,7 @@ from collections.abc import Callable
 from ._util import _first_line
 from .graph import Edge, Graph, Node
 from .index import VectorIndex
+from .provenance import attach_tool_evidence_provenance
 
 
 def _resolve_vector(
@@ -192,9 +193,16 @@ def inject_node(
         connect_min_sim=connect_min_sim,
     )
 
+    provenance_edges = {"edges_added": 0}
+    if isinstance(metadata, dict):
+        provenance_edges = attach_tool_evidence_provenance(
+            graph,
+            [{"node_id": node_id, "metadata": metadata}],
+        )
+
     return {
         "node_id": node_id,
-        "edges_added": len(connected_to) * 2,
+        "edges_added": len(connected_to) * 2 + int(provenance_edges.get("edges_added", 0)),
         "connected_to": connected_to,
     }
 
@@ -313,6 +321,7 @@ def inject_batch(
     edges_added = 0
     inhibitory = 0
     skipped = 0
+    provenance_items: list[dict[str, object]] = []
 
     for item in nodes:
         if not isinstance(item, dict):
@@ -373,6 +382,12 @@ def inject_batch(
 
         injected += 1
         edges_added += int(result.get("edges_added", 0))
+        if isinstance(node_metadata, dict):
+            provenance_items.append({"node_id": node_id, "metadata": node_metadata})
+
+    if provenance_items:
+        provenance_edges = attach_tool_evidence_provenance(graph, provenance_items)
+        edges_added += int(provenance_edges.get("edges_added", 0))
 
     return {
         "injected": injected,

--- a/openclawbrain/openclaw_adapter/query_brain.py
+++ b/openclawbrain/openclaw_adapter/query_brain.py
@@ -81,6 +81,7 @@ def _load_query_via_socket(
     exclude_files: list[str],
     exclude_file_prefixes: list[str],
     prompt_context_include_node_ids: bool,
+    include_provenance: bool,
 ) -> dict[str, object] | None:
     if socket_path is None:
         return None
@@ -94,6 +95,7 @@ def _load_query_via_socket(
             "route_alpha_sim": route_alpha_sim,
             "route_use_relevance": route_use_relevance,
             "max_prompt_context_chars": max_prompt_context_chars,
+            "include_provenance": include_provenance,
         }
         if chat_id is not None:
             params["chat_id"] = chat_id
@@ -329,6 +331,7 @@ def main(argv: list[str] | None = None) -> None:
         default=None,
         help="Include '- node: <id>' lines in prompt_context",
     )
+    parser.add_argument("--provenance", action=argparse.BooleanOptionalAction, default=False)
     parser.add_argument(
         "--no-include-node-ids",
         dest="include_node_ids",
@@ -388,6 +391,7 @@ def main(argv: list[str] | None = None) -> None:
                 exclude_files,
                 [],
                 include_node_ids,
+                bool(args.provenance),
             )
             if result is not None:
                 fired_nodes = [str(node_id) for node_id in result.get("fired_nodes", [])]
@@ -449,7 +453,12 @@ def main(argv: list[str] | None = None) -> None:
         )
 
     seeds = index.search(query_vector, top_k=args.top)
-    result = traverse(graph=graph, seeds=seeds, query_text=query_text, config=TraversalConfig(max_context_chars=20000))
+    result = traverse(
+        graph=graph,
+        seeds=seeds,
+        query_text=query_text,
+        config=TraversalConfig(max_context_chars=20000, include_provenance=bool(args.provenance)),
+    )
 
     excluded_node_ids: set[str] = set()
     excluded_files: set[str] = set()

--- a/openclawbrain/protocol.py
+++ b/openclawbrain/protocol.py
@@ -122,6 +122,7 @@ class QueryParams:
     prompt_context_include_node_ids: bool = True
     exclude_files: tuple[str, ...] = ()
     exclude_file_prefixes: tuple[str, ...] = ()
+    include_provenance: bool = False
     chat_id: str | None = None
 
     @classmethod
@@ -173,6 +174,7 @@ class QueryParams:
             exclude_file_prefixes=tuple(
                 parse_str_list(params.get("exclude_file_prefixes"), "exclude_file_prefixes", required=False)
             ),
+            include_provenance=parse_bool(params.get("include_provenance"), "include_provenance", default=False),
             chat_id=parse_chat_id(params.get("chat_id"), "chat_id", required=False),
         )
 
@@ -194,6 +196,7 @@ class QueryParams:
             "prompt_context_include_node_ids": self.prompt_context_include_node_ids,
             "exclude_files": list(self.exclude_files),
             "exclude_file_prefixes": list(self.exclude_file_prefixes),
+            "include_provenance": self.include_provenance,
             "chat_id": self.chat_id,
         }
 

--- a/openclawbrain/provenance.py
+++ b/openclawbrain/provenance.py
@@ -1,0 +1,347 @@
+"""Tool/action provenance helpers for OpenClawBrain replay."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+from .graph import Edge, Graph, Node
+
+
+TOOL_ACTION_PREFIX = "tool_action::"
+TOOL_EVIDENCE_PREFIX = "tool_evidence::"
+
+TIER1_STORE_EVIDENCE = frozenset(
+    {
+        "web_search",
+        "web_fetch",
+        "read",
+        "image",
+        "pdf",
+        "openai-whisper",
+        "openai-whisper-api",
+        "summarize",
+    }
+)
+
+TIER2_ACTION_ONLY = frozenset(
+    {
+        "exec",
+        "process",
+        "write",
+        "edit",
+        "browser",
+        "canvas",
+        "nodes",
+        "message",
+        "tts",
+    }
+)
+
+TIER3_SKIP = frozenset({"subagents"})
+
+SENSITIVE_KEY_FRAGMENTS = frozenset(
+    {
+        "api_key",
+        "apikey",
+        "access_key",
+        "access_token",
+        "refresh_token",
+        "secret",
+        "password",
+        "passwd",
+        "authorization",
+        "bearer",
+        "cookie",
+        "set-cookie",
+        "client_secret",
+        "private_key",
+        "session",
+        "token",
+    }
+)
+
+REDACTION_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"(?i)bearer\s+[A-Za-z0-9._\-]{8,}"),
+    re.compile(r"sk-[A-Za-z0-9]{20,}"),
+    re.compile(r"AIza[0-9A-Za-z\-_]{20,}"),
+    re.compile(r"(?is)-----BEGIN [A-Z ]+PRIVATE KEY-----.*?-----END [A-Z ]+PRIVATE KEY-----"),
+    re.compile(r"(?i)(secret|token|password)\s*[:=]\s*[^\s\"']{6,}"),
+)
+
+
+@dataclass(frozen=True)
+class ToolProvenanceConfig:
+    """Configuration for tool-action and evidence nodes."""
+
+    store_evidence_tools: frozenset[str] = field(default_factory=lambda: TIER1_STORE_EVIDENCE)
+    action_only_tools: frozenset[str] = field(default_factory=lambda: TIER2_ACTION_ONLY)
+    skip_tools: frozenset[str] = field(default_factory=lambda: TIER3_SKIP)
+    max_evidence_chars: int = 4000
+    max_argument_chars: int = 800
+
+
+def _normalize_tool_name(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip().lower()
+    return cleaned or None
+
+
+def _safe_tool_slug(tool_name: str | None) -> str:
+    if not tool_name:
+        return "tool"
+    cleaned = re.sub(r"[^a-z0-9_.-]+", "-", tool_name.lower()).strip("-")
+    return cleaned or "tool"
+
+
+def _hash_call_id(call_id: str) -> str:
+    return hashlib.sha256(call_id.encode("utf-8")).hexdigest()[:12]
+
+
+def _redact_string(value: str) -> str:
+    redacted = value
+    for pattern in REDACTION_PATTERNS:
+        redacted = pattern.sub("[REDACTED]", redacted)
+    return redacted
+
+
+def _should_redact_key(key: str) -> bool:
+    lowered = key.lower()
+    return any(fragment in lowered for fragment in SENSITIVE_KEY_FRAGMENTS)
+
+
+def _redact_value(value: Any) -> Any:
+    if isinstance(value, dict):
+        redacted: dict[str, Any] = {}
+        for key, item in value.items():
+            if isinstance(key, str) and _should_redact_key(key):
+                redacted[key] = "[REDACTED]"
+            else:
+                redacted[key] = _redact_value(item)
+        return redacted
+    if isinstance(value, list):
+        return [_redact_value(item) for item in value]
+    if isinstance(value, tuple):
+        return [_redact_value(item) for item in value]
+    if isinstance(value, str):
+        return _redact_string(value)
+    return value
+
+
+def _maybe_parse_json(value: str) -> Any | None:
+    stripped = value.strip()
+    if not stripped:
+        return None
+    if stripped[0] not in "[{":
+        return None
+    try:
+        return json.loads(stripped)
+    except json.JSONDecodeError:
+        return None
+
+
+def _stringify(value: Any, *, max_chars: int) -> str:
+    if isinstance(value, str):
+        text = _redact_string(value)
+    else:
+        redacted = _redact_value(value)
+        text = json.dumps(redacted, ensure_ascii=True, sort_keys=True, separators=(",", ":"))
+    if max_chars <= 0:
+        return ""
+    if len(text) > max_chars:
+        return text[:max_chars]
+    return text
+
+
+def _extract_arguments(raw: object) -> Any:
+    if raw is None:
+        return None
+    if isinstance(raw, str):
+        parsed = _maybe_parse_json(raw)
+        return parsed if parsed is not None else raw
+    return raw
+
+
+def _ensure_node(graph: Graph, node_id: str, *, content: str, summary: str, metadata: dict[str, Any]) -> bool:
+    if graph.get_node(node_id) is not None:
+        return False
+    graph.add_node(Node(id=node_id, content=content, summary=summary, metadata=dict(metadata)))
+    return True
+
+
+def _ensure_edge(
+    graph: Graph,
+    source: str,
+    target: str,
+    *,
+    weight: float,
+    kind: str,
+    metadata: dict[str, Any] | None = None,
+) -> bool:
+    existing = graph._edges.get(source, {}).get(target)
+    if existing is not None:
+        return False
+    graph.add_edge(
+        Edge(
+            source=source,
+            target=target,
+            weight=weight,
+            kind=kind,
+            metadata=dict(metadata or {}),
+        )
+    )
+    return True
+
+
+def build_tool_provenance(
+    *,
+    graph: Graph,
+    fired_nodes: list[str],
+    tool_calls: list[dict[str, object]],
+    tool_results: list[dict[str, object]] | None = None,
+    session: str | None = None,
+    session_path: str | None = None,
+    line_no_start: int | None = None,
+    line_no_end: int | None = None,
+    config: ToolProvenanceConfig | None = None,
+) -> dict[str, int]:
+    """Create tool_action/tool_evidence nodes and edges for tool calls."""
+    if not tool_calls:
+        return {"actions": 0, "evidence": 0, "edges": 0}
+
+    cfg = config or ToolProvenanceConfig()
+    results_by_id: dict[str, dict[str, object]] = {}
+    if tool_results:
+        for result in tool_results:
+            if not isinstance(result, dict):
+                continue
+            call_id = result.get("tool_call_id") or result.get("toolCallId") or result.get("tool_call_id")
+            if isinstance(call_id, str) and call_id:
+                results_by_id[call_id] = result
+
+    created_actions = 0
+    created_evidence = 0
+    created_edges = 0
+
+    for call in tool_calls:
+        if not isinstance(call, dict):
+            continue
+        call_id = call.get("id") or call.get("toolCallId") or call.get("tool_call_id")
+        call_id = call_id if isinstance(call_id, str) and call_id.strip() else None
+        tool_name = _normalize_tool_name(call.get("name") or call.get("toolName") or call.get("tool_name"))
+        tool_slug = _safe_tool_slug(tool_name)
+
+        if tool_name in cfg.skip_tools:
+            continue
+
+        if call_id is None:
+            fallback_basis = f"{tool_slug}:{session_path or session or ''}:{line_no_start or ''}:{call.get('arguments')}"
+            call_id = f"fallback:{_hash_call_id(fallback_basis)}"
+
+        action_hash = _hash_call_id(call_id)
+        action_node_id = f"{TOOL_ACTION_PREFIX}{tool_slug}::{action_hash}"
+
+        raw_args = _extract_arguments(call.get("arguments"))
+        args_text = ""
+        if raw_args is not None:
+            args_text = _stringify(raw_args, max_chars=cfg.max_argument_chars)
+
+        action_content = f"Tool action: {tool_slug}"
+        if args_text:
+            action_content = f"{action_content}\nArgs: {args_text}"
+
+        action_metadata: dict[str, Any] = {
+            "type": "tool_action",
+            "tool_name": tool_name,
+            "tool_call_id": call_id,
+            "session": session,
+            "session_path": session_path,
+            "line_no_start": line_no_start,
+            "line_no_end": line_no_end,
+        }
+        if raw_args is not None:
+            action_metadata["arguments"] = _redact_value(raw_args)
+
+        if _ensure_node(
+            graph,
+            action_node_id,
+            content=action_content,
+            summary=f"Tool action: {tool_slug}",
+            metadata=action_metadata,
+        ):
+            created_actions += 1
+
+        for fired_node in fired_nodes:
+            if _ensure_edge(
+                graph,
+                fired_node,
+                action_node_id,
+                weight=0.20,
+                kind="tool_action",
+                metadata={"source": "replay"},
+            ):
+                created_edges += 1
+
+        if tool_name in cfg.action_only_tools:
+            continue
+
+        if tool_name not in cfg.store_evidence_tools:
+            continue
+
+        result = results_by_id.get(call_id) or call.get("result")
+        if isinstance(result, dict):
+            evidence_text = result.get("content") or result.get("text") or result.get("result")
+            result_line = result.get("line_no")
+        else:
+            evidence_text = result
+            result_line = None
+
+        if evidence_text is None:
+            continue
+
+        evidence_payload = _extract_arguments(evidence_text)
+        if evidence_payload is None:
+            continue
+        evidence_text_out = _stringify(evidence_payload, max_chars=cfg.max_evidence_chars)
+        if not evidence_text_out:
+            continue
+
+        evidence_node_id = f"{TOOL_EVIDENCE_PREFIX}{tool_slug}::{action_hash}"
+        evidence_content = f"Tool evidence: {tool_slug}\n{evidence_text_out}"
+        evidence_metadata: dict[str, Any] = {
+            "type": "tool_evidence",
+            "tool_name": tool_name,
+            "tool_call_id": call_id,
+            "session": session,
+            "session_path": session_path,
+            "line_no": int(result_line) if isinstance(result_line, (int, float)) else line_no_end,
+        }
+
+        if _ensure_node(
+            graph,
+            evidence_node_id,
+            content=evidence_content,
+            summary=f"Tool evidence: {tool_slug}",
+            metadata=evidence_metadata,
+        ):
+            created_evidence += 1
+
+        if _ensure_edge(
+            graph,
+            action_node_id,
+            evidence_node_id,
+            weight=0.30,
+            kind="action",
+            metadata={"source": "replay"},
+        ):
+            created_edges += 1
+
+    return {
+        "actions": created_actions,
+        "evidence": created_evidence,
+        "edges": created_edges,
+    }

--- a/openclawbrain/provenance.py
+++ b/openclawbrain/provenance.py
@@ -197,6 +197,138 @@ def _ensure_edge(
     return True
 
 
+def _parse_session_pointer(pointer: str) -> tuple[str, int, int] | None:
+    """Parse session_pointer into (session, start_line, end_line)."""
+    if not pointer or ":" not in pointer:
+        return None
+    session_part, range_part = pointer.rsplit(":", 1)
+    if "-" not in range_part:
+        return None
+    start_raw, end_raw = range_part.split("-", 1)
+    try:
+        start = int(start_raw)
+        end = int(end_raw)
+    except ValueError:
+        return None
+    if start > end:
+        start, end = end, start
+    return session_part, start, end
+
+
+def _resolve_session_range(
+    metadata: dict[str, Any],
+    *,
+    pointer: str | None = None,
+) -> tuple[str, int, int] | None:
+    if pointer is None:
+        raw_pointer = metadata.get("session_pointer")
+        pointer = raw_pointer if isinstance(raw_pointer, str) else None
+    if pointer:
+        parsed = _parse_session_pointer(pointer)
+        if parsed is not None:
+            return parsed
+
+    session = metadata.get("session")
+    if not isinstance(session, str) or not session:
+        session = metadata.get("session_path")
+    if not isinstance(session, str) or not session:
+        return None
+
+    line_no_start = metadata.get("line_no_start")
+    line_no_end = metadata.get("line_no_end")
+    line_no = metadata.get("line_no")
+    if not isinstance(line_no_start, (int, float)):
+        line_no_start = line_no
+    if not isinstance(line_no_end, (int, float)):
+        line_no_end = line_no
+    if not isinstance(line_no_start, (int, float)) or not isinstance(line_no_end, (int, float)):
+        return None
+    start = int(line_no_start)
+    end = int(line_no_end)
+    if start > end:
+        start, end = end, start
+    return session, start, end
+
+
+def attach_tool_evidence_provenance(
+    graph: Graph,
+    node_ids_or_events: list[object],
+    *,
+    weight: float = 0.20,
+    kind: str = "provenance",
+) -> dict[str, int]:
+    """Attach tool evidence provenance edges for nodes with session pointers or line ranges."""
+    if not hasattr(graph, "nodes") or not hasattr(graph, "get_node"):
+        return {"edges_added": 0}
+
+    session_index: dict[str, list[tuple[int, str]]] = {}
+    for node in graph.nodes():
+        if not node.id.startswith(TOOL_EVIDENCE_PREFIX):
+            continue
+        metadata = node.metadata if isinstance(node.metadata, dict) else {}
+        line_no = metadata.get("line_no")
+        if not isinstance(line_no, (int, float)):
+            continue
+        line_val = int(line_no)
+        for key in ("session", "session_path"):
+            session = metadata.get(key)
+            if isinstance(session, str) and session:
+                session_index.setdefault(session, []).append((line_val, node.id))
+
+    if not session_index:
+        return {"edges_added": 0}
+
+    edges_added = 0
+    for item in node_ids_or_events:
+        node_id: str | None = None
+        metadata: dict[str, Any] = {}
+        pointer: str | None = None
+
+        if isinstance(item, str):
+            node_id = item
+            node = graph.get_node(node_id)
+            metadata = node.metadata if (node is not None and isinstance(node.metadata, dict)) else {}
+        elif isinstance(item, dict):
+            node_id = item.get("node_id") if isinstance(item.get("node_id"), str) else None
+            if node_id is None and isinstance(item.get("id"), str):
+                node_id = item.get("id")
+            raw_pointer = item.get("session_pointer")
+            pointer = raw_pointer if isinstance(raw_pointer, str) else None
+            raw_metadata = item.get("metadata")
+            metadata = raw_metadata if isinstance(raw_metadata, dict) else {}
+            if not metadata and node_id:
+                node = graph.get_node(node_id)
+                metadata = node.metadata if (node is not None and isinstance(node.metadata, dict)) else {}
+        else:
+            continue
+
+        if not node_id or graph.get_node(node_id) is None:
+            continue
+
+        parsed = _resolve_session_range(metadata, pointer=pointer)
+        if parsed is None:
+            continue
+        session, start_line, end_line = parsed
+
+        evidence_nodes = session_index.get(session, [])
+        if not evidence_nodes:
+            continue
+        for line_no, evidence_id in evidence_nodes:
+            if line_no < start_line or line_no > end_line:
+                continue
+            if _ensure_edge(
+                graph,
+                node_id,
+                evidence_id,
+                weight=weight,
+                kind=kind,
+                metadata={"source": "provenance"},
+            ):
+                edges_added += 1
+
+    return {"edges_added": edges_added}
+
+
 def build_tool_provenance(
     *,
     graph: Graph,

--- a/openclawbrain/replay.py
+++ b/openclawbrain/replay.py
@@ -12,6 +12,7 @@ from .decay import apply_decay
 from .graph import Graph
 from .learn import LearningConfig, apply_outcome
 from .traverse import TraversalConfig, traverse
+from .provenance import ToolProvenanceConfig, build_tool_provenance
 from ._util import _tokenize
 
 DEFAULT_TOOL_RESULT_ALLOWLIST = frozenset(
@@ -109,6 +110,24 @@ def _extract_tool_result(message: dict) -> tuple[str | None, str | None]:
     return normalized_name, text
 
 
+def _extract_tool_result_record(message: dict) -> dict[str, object] | None:
+    """Extract tool result record with call id + content when available."""
+    if not isinstance(message, dict):
+        return None
+    tool_call_id = message.get("toolCallId") or message.get("tool_call_id")
+    if not isinstance(tool_call_id, str) or not tool_call_id.strip():
+        tool_call_id = None
+    tool_name, text = _extract_tool_result(message)
+    record: dict[str, object] = {}
+    if tool_call_id is not None:
+        record["tool_call_id"] = tool_call_id
+    if tool_name is not None:
+        record["tool_name"] = tool_name
+    if text is not None:
+        record["content"] = text
+    return record or None
+
+
 def _extract_openclaw_query(payload: dict) -> str | None:
     """ extract openclaw query."""
     message = _extract_message_payload(payload)
@@ -156,6 +175,9 @@ def _extract_tool_call(payload: dict) -> dict[str, object] | None:
     call: dict[str, object] = {}
     if isinstance(payload.get("id"), str):
         call["id"] = payload["id"]
+    tool_call_id = payload.get("toolCallId") or payload.get("tool_call_id")
+    if isinstance(tool_call_id, str) and tool_call_id.strip():
+        call["id"] = tool_call_id
     if isinstance(name, str) and name.strip():
         call["name"] = name
     if arguments is not None:
@@ -182,7 +204,7 @@ def _extract_tool_calls(payload: dict, *, is_assistant: bool) -> list[dict[str, 
     content = payload.get("content")
     if isinstance(content, list):
         for item in content:
-            if not isinstance(item, dict) or item.get("type") != "tool_call":
+            if not isinstance(item, dict) or item.get("type") not in {"tool_call", "toolCall"}:
                 continue
             call = _extract_tool_call(item)
             if call is not None:
@@ -257,7 +279,7 @@ def extract_interactions(
     """Extract user/assistant interactions from a session log.
 
     Output entries use:
-    {"query": <user message>, "response": <assistant message>, "tool_calls": [...], "ts": <float|None>}
+    {"query": <user message>, "response": <assistant message>, "tool_calls": [...], "tool_results": [...], "ts": <float|None>}
     """
     path = Path(session_path).expanduser()
     if not path.exists():
@@ -276,7 +298,9 @@ def extract_interactions(
         print(f"warning: skipping unreadable session file: {path} ({exc})", file=sys.stderr)
         return []
 
-    for raw in fh:
+    session_name = path.name
+
+    for line_no, raw in enumerate(fh, start=1):
         raw = raw.strip()
         if not raw:
             continue
@@ -284,7 +308,20 @@ def extract_interactions(
         try:
             payload = json.loads(raw)
         except json.JSONDecodeError:
-            interactions.append({"query": raw, "response": None, "tool_calls": [], "ts": None})
+            interactions.append(
+                {
+                    "query": raw,
+                    "response": None,
+                    "tool_calls": [],
+                    "tool_results": [],
+                    "ts": None,
+                    "source": str(path),
+                    "session": session_name,
+                    "line_no": line_no,
+                    "line_no_start": line_no,
+                    "line_no_end": line_no,
+                }
+            )
             continue
 
         if not isinstance(payload, dict):
@@ -306,13 +343,36 @@ def extract_interactions(
             if since_ts is not None and record_ts is not None and record_ts <= since_ts:
                 last_user_index = None
                 continue
-            interactions.append({"query": query, "response": None, "tool_calls": [], "ts": record_ts})
+            interactions.append(
+                {
+                    "query": query,
+                    "response": None,
+                    "tool_calls": [],
+                    "tool_results": [],
+                    "ts": record_ts,
+                    "source": str(path),
+                    "session": session_name,
+                    "line_no": line_no,
+                    "line_no_start": line_no,
+                    "line_no_end": line_no,
+                }
+            )
             last_user_index = len(interactions) - 1
             appended_tool_chars[last_user_index] = 0
             continue
 
         normalized_role = role.strip().lower()
         if normalized_role in {"toolresult", "tool_result"}:
+            if last_user_index is not None:
+                record = _extract_tool_result_record(message)
+                if record is not None:
+                    record["line_no"] = line_no
+                    record["session"] = session_name
+                    record["source"] = str(path)
+                    interactions[last_user_index].setdefault("tool_results", [])
+                    if isinstance(interactions[last_user_index]["tool_results"], list):
+                        interactions[last_user_index]["tool_results"].append(record)
+                interactions[last_user_index]["line_no_end"] = line_no
             if (
                 include_tool_results
                 and last_user_index is not None
@@ -347,7 +407,13 @@ def extract_interactions(
             "query": None,
             "response": response,
             "tool_calls": tool_calls,
+            "tool_results": [],
             "ts": record_ts,
+            "source": str(path),
+            "session": session_name,
+            "line_no": line_no,
+            "line_no_start": line_no,
+            "line_no_end": line_no,
         }
 
         if last_user_index is not None:
@@ -356,11 +422,15 @@ def extract_interactions(
             ):
                 interactions[last_user_index]["response"] = response
                 interactions[last_user_index]["tool_calls"] = tool_calls
+                interactions[last_user_index]["line_no_end"] = line_no
+                if "tool_results" not in interactions[last_user_index]:
+                    interactions[last_user_index]["tool_results"] = []
                 if record_ts is not None:
                     interactions[last_user_index]["ts"] = record_ts
             else:
                 interactions[last_user_index]["response"] = None
                 interactions[last_user_index]["tool_calls"] = []
+                interactions[last_user_index]["tool_results"] = []
             continue
 
         if since_ts is not None and record_ts is not None and record_ts <= since_ts:
@@ -512,7 +582,9 @@ def _cross_file_edges(graph: Graph) -> set[tuple[str, str]]:
     return edges
 
 
-def _interaction_query_outcome(entry: dict[str, object]) -> tuple[str, float | None, str | None, list[dict[str, object]]]:
+def _interaction_query_outcome(
+    entry: dict[str, object],
+) -> tuple[str, float | None, str | None, list[dict[str, object]], list[dict[str, object]], dict[str, object]]:
     """ interaction query outcome."""
     raw_query = entry.get("query")
     query: str | None = None
@@ -531,38 +603,52 @@ def _interaction_query_outcome(entry: dict[str, object]) -> tuple[str, float | N
     raw_tool_calls = entry.get("tool_calls")
     tool_calls = [tool for tool in raw_tool_calls if isinstance(tool, dict)] if isinstance(raw_tool_calls, list) else []
 
-    return query, query_ts, response_text, tool_calls
+    raw_tool_results = entry.get("tool_results")
+    tool_results = (
+        [tool for tool in raw_tool_results if isinstance(tool, dict)] if isinstance(raw_tool_results, list) else []
+    )
+    meta = {
+        "source": entry.get("source"),
+        "session": entry.get("session"),
+        "line_no": entry.get("line_no"),
+        "line_no_start": entry.get("line_no_start"),
+        "line_no_end": entry.get("line_no_end"),
+    }
+
+    return query, query_ts, response_text, tool_calls, tool_results, meta
 
 
 def _normalize_replay_queries(
     queries: list[str | tuple[str, float | None] | dict[str, object]],
     *,
     since_ts: float | None = None,
-) -> list[tuple[str, float | None, str | None, list[dict[str, object]]]]:
+) -> list[tuple[str, float | None, str | None, list[dict[str, object]], list[dict[str, object]], dict[str, object]]]:
     """Normalize replay inputs into (query, ts, response, tool_calls)."""
-    normalized_queries: list[tuple[str, float | None, str | None, list[dict[str, object]]]] = []
+    normalized_queries: list[
+        tuple[str, float | None, str | None, list[dict[str, object]], list[dict[str, object]], dict[str, object]]
+    ] = []
     for entry in queries:
         if isinstance(entry, tuple) and len(entry) == 2 and isinstance(entry[0], str):
             query, query_ts = entry
             if not query.strip():
                 continue
-            normalized_queries.append((query, query_ts, None, []))
+            normalized_queries.append((query, query_ts, None, [], [], {}))
             continue
         if isinstance(entry, dict):
-            query, query_ts, response_text, tool_calls = _interaction_query_outcome(entry)
+            query, query_ts, response_text, tool_calls, tool_results, meta = _interaction_query_outcome(entry)
             if query is None or not query.strip():
                 continue
-            normalized_queries.append((query, query_ts, response_text, tool_calls))
+            normalized_queries.append((query, query_ts, response_text, tool_calls, tool_results, meta))
             continue
 
         query = str(entry)
         if query.strip():
-            normalized_queries.append((query, None, None, []))
+            normalized_queries.append((query, None, None, [], [], {}))
 
     if since_ts is not None:
         normalized_queries = [
-            (query, query_ts, response, tools)
-            for query, query_ts, response, tools in normalized_queries
+            (query, query_ts, response, tools, results, meta)
+            for query, query_ts, response, tools, results, meta in normalized_queries
             if query_ts is None or query_ts > since_ts
         ]
     return normalized_queries
@@ -579,6 +665,9 @@ def replay_queries(
     since_ts: float | None = None,
     auto_decay: bool = False,
     decay_interval: int = 10,
+    *,
+    tool_edges: bool = True,
+    tool_provenance_config: ToolProvenanceConfig | None = None,
 ) -> dict:
     """Replay historical queries to warm up graph edges.
 
@@ -615,7 +704,9 @@ def replay_queries(
     total_queries = len(normalized_queries)
     latest_ts = None
 
-    for idx, (query, query_ts, query_response, _) in enumerate(normalized_queries, start=1):
+    for idx, (query, query_ts, query_response, tool_calls, tool_results, meta) in enumerate(
+        normalized_queries, start=1
+    ):
         stats["queries_replayed"] += 1
 
         if idx > 0 and idx % 100 == 0:
@@ -624,6 +715,19 @@ def replay_queries(
         seeds = seed_fn(graph, query)
         result = traverse(graph=graph, seeds=seeds, config=cfg)
         if not result.fired:
+            if tool_edges and tool_calls:
+                fired_fallback = [str(seeds[0][0])] if seeds else []
+                build_tool_provenance(
+                    graph=graph,
+                    fired_nodes=fired_fallback,
+                    tool_calls=tool_calls,
+                    tool_results=tool_results,
+                    session=meta.get("session") if isinstance(meta, dict) else None,
+                    session_path=meta.get("source") if isinstance(meta, dict) else None,
+                    line_no_start=meta.get("line_no_start") if isinstance(meta, dict) else None,
+                    line_no_end=meta.get("line_no_end") if isinstance(meta, dict) else None,
+                    config=tool_provenance_config,
+                )
             if verbose:
                 print(
                     f"Replayed {stats['queries_replayed']}/{total_queries} queries, "
@@ -640,6 +744,19 @@ def replay_queries(
         query_outcome = _auto_score_query_outcome(query_outcome, query_response, result.fired, graph)
 
         fired_nodes = [result.steps[0].from_node, *[step.to_node for step in result.steps]] if result.steps else result.fired
+
+        if tool_edges and tool_calls:
+            build_tool_provenance(
+                graph=graph,
+                fired_nodes=fired_nodes,
+                tool_calls=tool_calls,
+                tool_results=tool_results,
+                session=meta.get("session") if isinstance(meta, dict) else None,
+                session_path=meta.get("source") if isinstance(meta, dict) else None,
+                line_no_start=meta.get("line_no_start") if isinstance(meta, dict) else None,
+                line_no_end=meta.get("line_no_end") if isinstance(meta, dict) else None,
+                config=tool_provenance_config,
+            )
         apply_outcome(
             graph=graph,
             fired_nodes=fired_nodes,
@@ -692,6 +809,8 @@ def replay_queries_parallel(
     auto_decay: bool = False,
     decay_interval: int = 10,
     on_merge: Callable[[dict[str, object]], None] | None = None,
+    tool_edges: bool = True,
+    tool_provenance_config: ToolProvenanceConfig | None = None,
 ) -> dict:
     """Approximate true-parallel replay with deterministic shard merges."""
     worker_count = max(1, workers)
@@ -708,6 +827,8 @@ def replay_queries_parallel(
             since_ts=since_ts,
             auto_decay=auto_decay,
             decay_interval=decay_interval,
+            tool_edges=tool_edges,
+            tool_provenance_config=tool_provenance_config,
         )
 
     cfg = config or TraversalConfig()
@@ -725,20 +846,24 @@ def replay_queries_parallel(
         }
 
     indexed = [
-        (idx, query, query_ts, query_response)
-        for idx, (query, query_ts, query_response, _tool_calls) in enumerate(normalized)
+        (idx, query, query_ts, query_response, tool_calls, tool_results, meta)
+        for idx, (query, query_ts, query_response, tool_calls, tool_results, meta) in enumerate(normalized)
     ]
-    shards: list[list[tuple[int, str, float | None, str | None]]] = [[] for _ in range(worker_count)]
+    shards: list[
+        list[tuple[int, str, float | None, str | None, list[dict[str, object]], list[dict[str, object]], dict[str, object]]]
+    ] = [[] for _ in range(worker_count)]
     for item in indexed:
         shards[item[0] % worker_count].append(item)
 
     def _worker_shard(
         shard_id: int,
-        shard_items: list[tuple[int, str, float | None, str | None]],
+        shard_items: list[
+            tuple[int, str, float | None, str | None, list[dict[str, object]], list[dict[str, object]], dict[str, object]]
+        ],
     ) -> tuple[int, list[list[dict[str, object]]]]:
         shard_batches: list[list[dict[str, object]]] = []
         pending: list[dict[str, object]] = []
-        for global_idx, query, query_ts, query_response in shard_items:
+        for global_idx, query, query_ts, query_response, tool_calls, tool_results, meta in shard_items:
             seeds = seed_fn(graph, query)
             result = traverse(graph=graph, seeds=seeds, config=cfg)
             event: dict[str, object] = {"idx": global_idx, "ts": query_ts}
@@ -752,6 +877,11 @@ def replay_queries_parallel(
                 )
                 event["fired_nodes"] = fired_nodes
                 event["outcome"] = query_outcome
+            if tool_edges and tool_calls:
+                event["tool_calls"] = tool_calls
+                event["tool_results"] = tool_results
+                event["meta"] = meta
+                event["seeds"] = seeds
             pending.append(event)
             if len(pending) >= batch_size:
                 shard_batches.append(pending)
@@ -818,6 +948,28 @@ def replay_queries_parallel(
                     stats["cross_file_edges_created"] += len(after_cross_edges - before_cross_edges)
                     if auto_decay and decay_interval > 0 and decay_counter % max(1, decay_interval) == 0:
                         apply_decay(graph)
+                if tool_edges and isinstance(event.get("tool_calls"), list):
+                    tool_calls = [call for call in event.get("tool_calls", []) if isinstance(call, dict)]
+                    tool_results = [res for res in event.get("tool_results", []) if isinstance(res, dict)]
+                    meta = event.get("meta")
+                    seeds = event.get("seeds") or []
+                    fired_fallback: list[str] = []
+                    if isinstance(fired_nodes, list) and fired_nodes:
+                        fired_fallback = [str(node_id) for node_id in fired_nodes]
+                    elif isinstance(seeds, list) and seeds:
+                        fired_fallback = [str(seeds[0][0])]
+                    if tool_calls:
+                        build_tool_provenance(
+                            graph=graph,
+                            fired_nodes=fired_fallback,
+                            tool_calls=tool_calls,
+                            tool_results=tool_results,
+                            session=meta.get("session") if isinstance(meta, dict) else None,
+                            session_path=meta.get("source") if isinstance(meta, dict) else None,
+                            line_no_start=meta.get("line_no_start") if isinstance(meta, dict) else None,
+                            line_no_end=meta.get("line_no_end") if isinstance(meta, dict) else None,
+                            config=tool_provenance_config,
+                        )
                 if query_ts_value is not None:
                     latest_ts = query_ts_value if latest_ts is None else max(latest_ts, query_ts_value)
                 processed += 1

--- a/openclawbrain/traverse.py
+++ b/openclawbrain/traverse.py
@@ -30,6 +30,8 @@ class TraversalConfig:
             means unlimited.
         reflex_threshold: minimum edge weight for reflex-tier edges.
         habitual_range: inclusive lower/upper bounds for habitual-tier edges.
+        include_provenance: when True, include tool evidence nodes in traversal.
+        exclude_node_prefixes: node id prefixes to exclude from traversal.
     """
 
     max_hops: int = 30
@@ -42,6 +44,8 @@ class TraversalConfig:
     max_context_chars: int | None = None
     reflex_threshold: float = 0.6
     habitual_range: tuple[float, float] = (0.15, 0.6)
+    include_provenance: bool = False
+    exclude_node_prefixes: tuple[str, ...] = ("tool_evidence::",)
 
 
 @dataclass
@@ -183,7 +187,16 @@ def traverse(
     if cfg.max_hops <= 0 or cfg.beam_width <= 0:
         return TraversalResult([], [], "")
 
-    valid_seeds = [(node_id, score) for node_id, score in seeds if graph.get_node(node_id)]
+    exclude_prefixes = () if cfg.include_provenance else cfg.exclude_node_prefixes
+
+    def _is_excluded(node_id: str) -> bool:
+        return any(node_id.startswith(prefix) for prefix in exclude_prefixes)
+
+    valid_seeds = [
+        (node_id, score)
+        for node_id, score in seeds
+        if graph.get_node(node_id) and not _is_excluded(node_id)
+    ]
     if not valid_seeds:
         return TraversalResult([], [], "")
 
@@ -232,6 +245,8 @@ def traverse(
         habitual_by_source: dict[str, list[tuple[str, str, float, float, str, Edge]]] = {}
         for source_id, source_score in frontier:
             for target_node, edge in graph.outgoing(source_id):
+                if _is_excluded(target_node.id):
+                    continue
                 use_count = used_edges.get((source_id, target_node.id), 0)
                 effective = edge.weight * (cfg.edge_damping**use_count)
                 if effective <= 0.0:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1098,8 +1098,8 @@ def test_inject_command_defaults_connect_min_sim_for_hash_embedder(tmp_path, cap
     assert out["inhibitory_edges_created"] > 0
 
 
-def test_cli_replay_default_mode_is_edges_only_and_not_full(tmp_path, capsys) -> None:
-    """replay without mode/legacy flags defaults to edges-only and prints a note."""
+def test_cli_replay_default_mode_is_full(tmp_path, capsys, monkeypatch) -> None:
+    """replay without mode/legacy flags defaults to full and prints a note."""
     state_path = tmp_path / "state.json"
     _write_state(state_path)
 
@@ -1113,6 +1113,11 @@ def test_cli_replay_default_mode_is_edges_only_and_not_full(tmp_path, capsys) ->
         ),
         encoding="utf-8",
     )
+
+    import openclawbrain.cli as cli_module
+
+    monkeypatch.setattr(cli_module, "run_fast_learning", lambda **_: {"events_injected": 0})
+    monkeypatch.setattr(cli_module, "run_harvest", lambda **_: {"harvested": 0})
 
     code = main(
         [
@@ -1128,9 +1133,9 @@ def test_cli_replay_default_mode_is_edges_only_and_not_full(tmp_path, capsys) ->
     captured = capsys.readouterr()
     result = json.loads(captured.out.strip())
     assert result["queries_replayed"] == 2
-    assert "fast_learning" not in result
-    assert "harvest" not in result
-    assert "defaulting to --mode edges-only" in captured.err
+    assert "fast_learning" in result
+    assert "harvest" in result
+    assert "defaulting to --mode full" in captured.err
 
 
 def test_cli_replay_edges_only_skips_learning(tmp_path, capsys) -> None:
@@ -1475,7 +1480,7 @@ def test_cli_replay_mode_resolution_maps_legacy_flags() -> None:
 
     parser = _build_parser()
     default_args = parser.parse_args(["replay", "--state", "/tmp/x.json", "--sessions", "/tmp/s"])
-    assert _resolve_replay_mode(default_args) == ("edges-only", True)
+    assert _resolve_replay_mode(default_args) == ("full", True)
 
     edges_args = parser.parse_args(["replay", "--state", "/tmp/x.json", "--sessions", "/tmp/s", "--edges-only"])
     assert _resolve_replay_mode(edges_args) == ("edges-only", False)

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -885,8 +885,22 @@ def test_query_brain_socket_node_id_default_follows_compact_mode(tmp_path: Path,
 
     captured: list[bool] = []
 
-    def _fake_socket(*args, **_kwargs):
-        captured.append(bool(args[-1]))
+    def _fake_socket(
+        socket_path: str | None,
+        query_text: str,
+        chat_id: str | None,
+        top: int,
+        route_mode: str,
+        route_top_k: int,
+        route_alpha_sim: float,
+        route_use_relevance: bool,
+        max_prompt_context_chars: int,
+        exclude_files: list[str],
+        exclude_file_prefixes: list[str],
+        prompt_context_include_node_ids: bool,
+        include_provenance: bool,
+    ):
+        captured.append(bool(prompt_context_include_node_ids))
         return {
             "fired_nodes": ["a"],
             "context": "ctx",
@@ -989,6 +1003,7 @@ def test_query_brain_socket_passes_route_params(tmp_path: Path, capsys, monkeypa
         exclude_files: list[str],
         exclude_file_prefixes: list[str],
         prompt_context_include_node_ids: bool,
+        include_provenance: bool,
     ) -> dict[str, object]:
         captured.update(
             {
@@ -1004,6 +1019,7 @@ def test_query_brain_socket_passes_route_params(tmp_path: Path, capsys, monkeypa
                 "exclude_files": exclude_files,
                 "exclude_file_prefixes": exclude_file_prefixes,
                 "prompt_context_include_node_ids": prompt_context_include_node_ids,
+                "include_provenance": include_provenance,
             }
         )
         return {

--- a/tests/test_inject.py
+++ b/tests/test_inject.py
@@ -79,6 +79,67 @@ def test_inject_node_with_vector() -> None:
     assert index._vectors["learning::43"] == default_embed("Never forget to commit")
 
 
+def test_inject_node_attaches_tool_evidence_provenance() -> None:
+    """inject node attaches provenance edges when session_pointer is provided."""
+    graph = Graph()
+    index = VectorIndex()
+    graph.add_node(
+        Node(
+            "tool_evidence::web_search::abc",
+            "Evidence",
+            metadata={"session": "s", "line_no": 2},
+        )
+    )
+
+    result = inject_node(
+        graph,
+        index,
+        "learning::prov",
+        "Tie learning to evidence",
+        embed_fn=default_embed,
+        connect_top_k=0,
+        connect_min_sim=0.0,
+        metadata={"session_pointer": "s:1-3"},
+    )
+
+    assert result["edges_added"] == 1
+    edge = graph._edges["learning::prov"]["tool_evidence::web_search::abc"]
+    assert edge.kind == "provenance"
+
+
+def test_inject_batch_attaches_tool_evidence_provenance() -> None:
+    """inject batch attaches provenance edges when session + line range is provided."""
+    graph = Graph()
+    index = VectorIndex()
+    graph.add_node(
+        Node(
+            "tool_evidence::web_search::def",
+            "Evidence",
+            metadata={"session": "s", "line_no": 5},
+        )
+    )
+
+    result = inject_batch(
+        graph=graph,
+        index=index,
+        nodes=[
+            {
+                "id": "learning::prov-batch",
+                "content": "Tie batch learning to evidence",
+                "type": "TEACHING",
+                "metadata": {"session": "s", "line_no_start": 5, "line_no_end": 5},
+            }
+        ],
+        embed_fn=default_embed,
+        connect_top_k=0,
+        connect_min_sim=0.0,
+    )
+
+    assert result["injected"] == 1
+    edge = graph._edges["learning::prov-batch"]["tool_evidence::web_search::def"]
+    assert edge.kind == "provenance"
+
+
 def test_inject_correction_creates_inhibitory() -> None:
     """test inject correction creates inhibitory edges."""
     graph = Graph()

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -40,6 +40,7 @@ def test_query_params_defaults_follow_daemon_behavior() -> None:
     assert params.prompt_context_include_node_ids is True
     assert params.exclude_files == ()
     assert params.exclude_file_prefixes == ()
+    assert params.include_provenance is False
     assert params.chat_id is None
 
 

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from openclawbrain.graph import Graph, Node
+from openclawbrain.provenance import build_tool_provenance
+
+
+def test_provenance_redacts_sensitive_args_and_results() -> None:
+    graph = Graph()
+    graph.add_node(Node("n1", "alpha", metadata={"file": "a.md"}))
+
+    tool_calls = [
+        {
+            "id": "call-1",
+            "name": "web_search",
+            "arguments": {"api_key": "sk-THISSHOULDNOTAPPEAR", "q": "cats"},
+        }
+    ]
+    tool_results = [
+        {
+            "tool_call_id": "call-1",
+            "tool_name": "web_search",
+            "content": "Bearer SECRET_TOKEN_12345",
+        }
+    ]
+
+    build_tool_provenance(
+        graph=graph,
+        fired_nodes=["n1"],
+        tool_calls=tool_calls,
+        tool_results=tool_results,
+        session="session.jsonl",
+    )
+
+    tool_nodes = [node for node in graph.nodes() if node.id.startswith("tool_action::")]
+    assert tool_nodes
+    action = tool_nodes[0]
+    assert "sk-THISSHOULDNOTAPPEAR" not in action.content
+    assert "[REDACTED]" in action.content
+
+    evidence_nodes = [node for node in graph.nodes() if node.id.startswith("tool_evidence::")]
+    assert evidence_nodes
+    evidence = evidence_nodes[0]
+    assert "SECRET_TOKEN_12345" not in evidence.content
+    assert "[REDACTED]" in evidence.content

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -8,6 +8,7 @@ import pytest
 from openclawbrain.cli import main
 from openclawbrain.graph import Edge, Graph, Node
 from openclawbrain import learn as _learn_mod
+from openclawbrain.provenance import TOOL_EVIDENCE_PREFIX
 from openclawbrain.replay import extract_interactions, extract_queries, extract_queries_from_dir, replay_queries
 from openclawbrain.traverse import TraversalConfig
 
@@ -136,6 +137,63 @@ def test_extract_interactions_parses_user_and_assistant_messages(tmp_path: Path)
     assert interactions[0]["query"] == "How do I run?"
     assert interactions[0]["response"] == "Use the docs."
     assert interactions[0]["tool_calls"] == [{"id": "tool-1", "name": "lookup", "arguments": "{}"}]
+
+
+def test_extract_interactions_pairs_camelcase_toolcall_and_toolresult(tmp_path: Path) -> None:
+    """CamelCase toolCall items and toolResult records are paired in interactions."""
+    path = tmp_path / "session_toolcall.jsonl"
+    path.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "type": "message",
+                        "message": {
+                            "role": "user",
+                            "content": [{"type": "text", "text": "Search the web"}],
+                        },
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "message",
+                        "message": {
+                            "role": "assistant",
+                            "content": [
+                                {
+                                    "type": "toolCall",
+                                    "id": "tc-1",
+                                    "name": "web_search",
+                                    "arguments": "{\"q\": \"alpha\"}",
+                                }
+                            ],
+                        },
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "message",
+                        "message": {
+                            "role": "toolResult",
+                            "toolName": "web_search",
+                            "toolCallId": "tc-1",
+                            "content": "result text",
+                        },
+                    }
+                ),
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    interactions = extract_interactions(path)
+    assert len(interactions) == 1
+    assert interactions[0]["tool_calls"] == [{"id": "tc-1", "name": "web_search", "arguments": "{\"q\": \"alpha\"}"}]
+    tool_results = interactions[0].get("tool_results")
+    assert isinstance(tool_results, list)
+    assert tool_results[0]["tool_call_id"] == "tc-1"
+    assert tool_results[0]["tool_name"] == "web_search"
+    assert tool_results[0]["content"] == "result text"
 
 
 def test_extract_interactions_attaches_allowlisted_tool_result_for_media_stub(tmp_path: Path) -> None:
@@ -315,6 +373,38 @@ def test_replay_queries_auto_scores_if_assistant_response_matches() -> None:
         queries=[{"query": "alpha", "response": "alpha content answered", "tool_calls": []}],
     )
     assert boosted._edges["a"]["b"].weight > base._edges["a"]["b"].weight
+
+
+def test_replay_creates_tool_action_edges_and_evidence_nodes() -> None:
+    """Replay creates tool action nodes/edges and evidence nodes for tier-1 tools."""
+    graph = Graph()
+    graph.add_node(Node("a", "alpha", metadata={"file": "a.md"}))
+    graph.add_node(Node("b", "beta", metadata={"file": "a.md"}))
+    graph.add_edge(Edge("a", "b", 0.5))
+
+    interactions = [
+        {
+            "query": "alpha",
+            "response": "done",
+            "tool_calls": [{"id": "tc-1", "name": "web_search", "arguments": "{\"q\": \"alpha\"}"}],
+            "tool_results": [{"tool_call_id": "tc-1", "tool_name": "web_search", "content": "result text"}],
+            "ts": 1.0,
+            "session": "session.jsonl",
+            "source": "session.jsonl",
+            "line_no_start": 1,
+            "line_no_end": 3,
+        }
+    ]
+
+    replay_queries(graph=graph, queries=interactions, config=TraversalConfig(max_hops=1))
+
+    tool_action_nodes = [node for node in graph.nodes() if node.id.startswith("tool_action::")]
+    assert tool_action_nodes
+    action_node_id = tool_action_nodes[0].id
+    assert graph._edges["a"][action_node_id].kind == "tool_action"
+
+    evidence_nodes = [node for node in graph.nodes() if node.id.startswith(TOOL_EVIDENCE_PREFIX)]
+    assert evidence_nodes
 
 
 def test_extract_queries_missing_file_returns_empty(tmp_path: Path) -> None:

--- a/tests/test_traverse.py
+++ b/tests/test_traverse.py
@@ -410,7 +410,24 @@ def test_traversal_with_all_edges_inhibitory_or_low_returns_seed_only() -> None:
 
     result = traverse(graph, [("a", 1.0)], config=TraversalConfig(max_hops=2, beam_width=1, reflex_threshold=0.0))
     assert result.steps == []
-    assert result.fired == ["a"]
+
+
+def test_traverse_excludes_tool_evidence_by_default() -> None:
+    """Tool evidence nodes are excluded unless include_provenance=True."""
+    graph = Graph()
+    graph.add_node(Node("seed", "Seed"))
+    graph.add_node(Node("tool_evidence::web_search::abc", "Evidence"))
+    graph.add_edge(Edge("seed", "tool_evidence::web_search::abc", 0.9))
+
+    result = traverse(graph, [("seed", 1.0)], config=TraversalConfig(max_hops=1, beam_width=2))
+    assert result.fired == ["seed"]
+
+    result_with_prov = traverse(
+        graph,
+        [("seed", 1.0)],
+        config=TraversalConfig(max_hops=1, beam_width=2, include_provenance=True),
+    )
+    assert "tool_evidence::web_search::abc" in result_with_prov.fired
 
 
 def test_traversal_tier_classification_is_stable() -> None:


### PR DESCRIPTION
Implements long-term-greedy tool/action learning:
- Parse OpenClaw session toolCall (camelCase) + toolResult events
- Create tool_action/tool_evidence nodes and edges during replay (default ON)
- Exclude tool_evidence from traversal by default; opt-in via include_provenance
- Wire provenance edges from injected learnings (fast-learning + inject/self-learning) using session_pointer/line ranges
- Change replay default mode to FULL (as requested)
- Tests + docs updates