### PR TITLE
docs: recommend "best brain" full pipeline; fix replay snippet to use --mode edges-only

### DIFF
--- a/docs/openclaw-integration.md
+++ b/docs/openclaw-integration.md
@@ -417,7 +417,7 @@ That’s the ergonomic way to do “same-turn correction” inside OpenClaw.
 
 For full-history rebuilds, replay your sessions. Default mode is `full` and the recommended operator experience (the "best brain") is the full, bells-and-whistles pipeline.
 
-See `examples/ops/default_experience.sh` for the recommended sequence: local BGE-large + `replay --mode full` + `maintain` + `harvest` + `async-route-pg` (teacher `gpt-5-mini`) + `train-route-model`.
+See `examples/ops/default_experience.sh` for the recommended sequence: local BGE-large reembed + `replay --mode full` (fast-learning + edge replay + harvest) + `maintain` + `async-route-pg` (teacher `gpt-5-mini`) + `train-route-model` (may be skipped if no traces were produced).
 
 Use `--mode edges-only` for cheap edge-only replay when you explicitly want a minimal, low-cost pass.
 

--- a/docs/openclaw-integration.md
+++ b/docs/openclaw-integration.md
@@ -415,9 +415,11 @@ OpenClawBrain ships an OpenClaw adapter that logs fired IDs per chat.
 
 That’s the ergonomic way to do “same-turn correction” inside OpenClaw.
 
-For full-history rebuilds, replay your sessions. Default mode is `full`; use `--mode edges-only` for cheap edge-only replay.
+For full-history rebuilds, replay your sessions. Default mode is `full` and the recommended operator experience (the "best brain") is the full, bells-and-whistles pipeline.
 
-Note: examples/ops/default_experience.sh demonstrates the recommended "all bells and whistles" path (local BGE-large + replay --mode full + maintain + async-route-pg teacher gpt-5-mini + train-route-model).
+See `examples/ops/default_experience.sh` for the recommended sequence: local BGE-large + `replay --mode full` + `maintain` + `harvest` + `async-route-pg` (teacher `gpt-5-mini`) + `train-route-model`.
+
+Use `--mode edges-only` for cheap edge-only replay when you explicitly want a minimal, low-cost pass.
 
 ```bash
 openclawbrain replay \

--- a/docs/openclaw-integration.md
+++ b/docs/openclaw-integration.md
@@ -415,7 +415,9 @@ OpenClawBrain ships an OpenClaw adapter that logs fired IDs per chat.
 
 That’s the ergonomic way to do “same-turn correction” inside OpenClaw.
 
-For full-history rebuilds, replay your sessions. Default mode is `full`; use `--mode edges-only` for cheap edge-only replay:
+For full-history rebuilds, replay your sessions. Default mode is `full`; use `--mode edges-only` for cheap edge-only replay.
+
+Note: examples/ops/default_experience.sh demonstrates the recommended "all bells and whistles" path (local BGE-large + replay --mode full + maintain + async-route-pg teacher gpt-5-mini + train-route-model).
 
 ```bash
 openclawbrain replay \

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -37,7 +37,7 @@ Use `--mode full` when you explicitly want the full pipeline (LLM mining + edge 
 For cheap edge-only replay (no LLM, no harvest):
 
 ```bash
-openclawbrain replay --state ./brain/state.json --sessions ./sessions/ --mode full
+openclawbrain replay --state ./brain/state.json --sessions ./sessions/ --mode edges-only
 ```
 
 For fine-grained control over the LLM mining pass:

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -26,7 +26,12 @@ Runtime route-mode default is `learned`. `init` writes a default identity-like `
 
 ## Initial learning: replay your sessions
 
-After init, replay your existing sessions to seed graph edges and extract learning signals. By default, `replay` runs `--mode full` (fast-learning + replay + harvest):
+After init, replay your existing sessions to seed graph edges and extract learning signals.
+
+Recommended default ("best brain"): run the full, bells-and-whistles pipeline — this is the operator-recommended default experience.
+The example script `examples/ops/default_experience.sh` runs the recommended sequence: local BGE-large embedder, `replay --mode full` (fast-learning + edge replay + harvest), `maintain`, `harvest`, `async-route-pg` using `gpt-5-mini` as the teacher, and `train-route-model`.
+
+By default, `replay` runs `--mode full` (fast-learning + replay + harvest):
 
 ```bash
 openclawbrain replay --state ./brain/state.json --sessions ./sessions/

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -29,7 +29,7 @@ Runtime route-mode default is `learned`. `init` writes a default identity-like `
 After init, replay your existing sessions to seed graph edges and extract learning signals.
 
 Recommended default ("best brain"): run the full, bells-and-whistles pipeline — this is the operator-recommended default experience.
-The example script `examples/ops/default_experience.sh` runs the recommended sequence: local BGE-large embedder, `replay --mode full` (fast-learning + edge replay + harvest), `maintain`, `harvest`, `async-route-pg` using `gpt-5-mini` as the teacher, and `train-route-model`.
+The example script `examples/ops/default_experience.sh` runs the recommended sequence: local BGE-large reembed, `replay --mode full` (fast-learning + edge replay + harvest), `maintain`, `async-route-pg` using `gpt-5-mini` as the teacher, and `train-route-model` (may be skipped if no traces were produced).
 
 By default, `replay` runs `--mode full` (fast-learning + replay + harvest):
 


### PR DESCRIPTION
Fix docs to present the recommended operator default ("best brain") as the full, bells-and-whistles pipeline: examples/ops/default_experience.sh (local BGE-large embeddings + replay --mode full + harvest/maintain structural tasks + async-route-pg teacher=gpt-5-mini + train-route-model).\n\nAlso fix docs/setup-guide.md where the "cheap edge-only replay" snippet incorrectly used `--mode full` — it now shows `--mode edges-only`.\n\nCLI note: the replay command currently defaults to `full` when no mode is provided (see openclawbrain/openclawbrain/cli.py::_resolve_replay_mode and README). That aligns with this docs recommendation. If maintainers prefer a conservative CLI default (edges-only), we should change the CLI default and update callers/tests. Alternatively, keep the CLI default as-is and frame the docs as the recommended operator experience. Leaving this as a discussion point.