### PR TITLE
llm: add Ollama local LLM provider (fast-learning + teacher)

### DIFF
--- a/docs/default-experience.md
+++ b/docs/default-experience.md
@@ -17,7 +17,36 @@ This pipeline intentionally does **LLM work** in replay and labeling:
 - **Replay `--mode full`** runs fast-learning transcript mining + edge replay + harvest. The fast-learning phase calls an LLM to extract learning events, so it will incur LLM usage.
 - **Async teacher labeling** (`async-route-pg --teacher openai --teacher-model gpt-5-mini`) uses the OpenAI API to label route decisions and generate training traces.
 
-The script **never uses OpenAI embeddings**. All embedding work is forced to local BGE-large (`BAAI/bge-large-en-v1.5`). If you do not want any OpenAI usage at all, set `--teacher none` and use a non-LLM replay mode; otherwise supply `OPENAI_API_KEY`.
+The script **never uses OpenAI embeddings**. All embedding work is forced to local BGE-large (`BAAI/bge-large-en-v1.5`). If you want to avoid OpenAI entirely, use Ollama for replay/teacher labeling or set `--teacher none` and use a non-LLM replay mode; otherwise supply `OPENAI_API_KEY`.
+
+## Local LLM (Ollama)
+
+You can run the full pipeline without OpenAI by using Ollama for both replay fast-learning and async teacher labeling. This is a full opt-out of OpenAI usage (embeddings are already local).
+
+Install and start Ollama:
+
+```bash
+brew install ollama
+ollama serve
+```
+
+Pull the default model:
+
+```bash
+ollama pull llama3.2:3b
+```
+
+Run replay with Ollama:
+
+```bash
+openclawbrain replay --state ./brain/state.json --sessions ./sessions/ --mode full --llm ollama
+```
+
+Run async-route-pg with Ollama:
+
+```bash
+openclawbrain async-route-pg --state ./brain/state.json --teacher ollama
+```
 
 ## One-command orchestration
 

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -73,6 +73,35 @@ Replay progress defaults:
 - Replay emits a heartbeat every 30 seconds by default.
 - Use `--quiet` to suppress banners/progress for automation.
 
+## Local LLM (Ollama)
+
+OpenClawBrain can run fast-learning + teacher labeling entirely on-device with Ollama. This is a full opt-out of OpenAI usage (embeddings are already local).
+
+Install and start Ollama:
+
+```bash
+brew install ollama
+ollama serve
+```
+
+Pull the default model:
+
+```bash
+ollama pull llama3.2:3b
+```
+
+Use Ollama for replay fast-learning:
+
+```bash
+openclawbrain replay --state ./brain/state.json --sessions ./sessions/ --mode full --llm ollama
+```
+
+Use Ollama for async teacher labeling:
+
+```bash
+openclawbrain async-route-pg --state ./brain/state.json --teacher ollama
+```
+
 Single-writer lock:
 - Writer commands lock `state.json` via `state.json.lock` to prevent clobbered writes.
 - If a lock is active, prefer rebuilding into a new state and cut over (`examples/ops/rebuild_then_cutover.sh`).

--- a/openclawbrain/cli.py
+++ b/openclawbrain/cli.py
@@ -273,7 +273,7 @@ def _build_parser() -> argparse.ArgumentParser:
     i.add_argument("--sessions")
     i.add_argument("--embedder", choices=["local", "openai", "auto"], default="auto")
     i.add_argument("--embed-model", default=None)
-    i.add_argument("--llm", choices=["none", "openai", "auto"], default="auto")
+    i.add_argument("--llm", choices=["none", "openai", "ollama", "auto"], default="auto")
     # LLM-splitting controls (default: use LLM only for larger/complex files)
     i.add_argument("--llm-split-min-chars", type=int, default=20000)
     i.add_argument("--llm-split-mode", choices=["auto", "all", "off"], default="auto")
@@ -301,7 +301,7 @@ def _build_parser() -> argparse.ArgumentParser:
     m = sub.add_parser("merge")
     m.add_argument("--state")
     m.add_argument("--graph")
-    m.add_argument("--llm", choices=["none", "openai"], default="none")
+    m.add_argument("--llm", choices=["none", "openai", "ollama"], default="none")
     m.add_argument("--json", action="store_true")
 
     a = sub.add_parser("anchor")
@@ -315,7 +315,7 @@ def _build_parser() -> argparse.ArgumentParser:
     c = sub.add_parser("connect")
     c.add_argument("--state")
     c.add_argument("--graph")
-    c.add_argument("--llm", choices=["none", "openai"], default="none")
+    c.add_argument("--llm", choices=["none", "openai", "ollama"], default="none")
     c.add_argument("--json", action="store_true")
 
     p = sub.add_parser("maintain")
@@ -324,7 +324,7 @@ def _build_parser() -> argparse.ArgumentParser:
     p.add_argument("--dry-run", action="store_true")
     p.add_argument("--max-merges", type=int, default=5)
     p.add_argument("--prune-below", type=float, default=0.01)
-    p.add_argument("--llm", choices=["none", "openai"], default="none")
+    p.add_argument("--llm", choices=["none", "openai", "ollama"], default="none")
     p.add_argument("--embedder", choices=["local", "openai"], default=None)
     p.add_argument("--force", action="store_true", help="Bypass state lock (expert use)")
     p.add_argument("--json", action="store_true")
@@ -334,7 +334,7 @@ def _build_parser() -> argparse.ArgumentParser:
     z.add_argument("--memory-dir", required=True)
     z.add_argument("--max-age-days", type=int, default=7)
     z.add_argument("--target-lines", type=int, default=15)
-    z.add_argument("--llm", choices=["none", "openai"], default="none")
+    z.add_argument("--llm", choices=["none", "openai", "ollama"], default="none")
     z.add_argument("--dry-run", action="store_true")
     z.add_argument("--force", action="store_true", help="Bypass state lock (expert use)")
     z.add_argument("--json", action="store_true")
@@ -466,6 +466,7 @@ def _build_parser() -> argparse.ArgumentParser:
     )
 
     r.add_argument("--edges-only", action="store_true")
+    r.add_argument("--llm", choices=["none", "openai", "ollama", "auto"], default=None)
     r.add_argument("--show-checkpoint", action="store_true")
     r.add_argument("--decay-during-replay", action="store_true")
     r.add_argument("--decay-interval", type=int, default=10)
@@ -553,7 +554,7 @@ def _build_parser() -> argparse.ArgumentParser:
     ar.add_argument("--max-queries", type=int, default=200)
     ar.add_argument("--sample-rate", type=float, default=0.1)
     ar.add_argument("--max-candidates-per-node", type=int, default=12)
-    ar.add_argument("--teacher", choices=["openai", "none"], default="openai")
+    ar.add_argument("--teacher", choices=["openai", "ollama", "none"], default="openai")
     ar.add_argument("--teacher-model", default="gpt-5-mini")
     ar.add_argument("--apply", action="store_true")
     ar.add_argument("--json", action="store_true")
@@ -1140,6 +1141,10 @@ def _resolve_llm(args: argparse.Namespace) -> tuple[Callable[[str, str], str] | 
         from .openai_llm import openai_llm_batch_fn, openai_llm_fn
 
         return openai_llm_fn, openai_llm_batch_fn
+    if getattr(args, "llm", None) == "ollama":
+        from .ollama_llm import ollama_llm_batch_fn, ollama_llm_fn
+
+        return ollama_llm_fn, ollama_llm_batch_fn
     return None, None
 
 
@@ -1567,12 +1572,7 @@ def cmd_compact(args: argparse.Namespace) -> int:
 
     embed_args = SimpleNamespace(embedder=None)
     embed_fn, _, _, _, _ = _resolve_embedder(embed_args, meta)
-    if args.llm == "openai":
-        from .openai_llm import openai_llm_fn
-
-        llm_fn = openai_llm_fn
-    else:
-        llm_fn = None
+    llm_fn, _ = _resolve_llm(args)
 
     if embed_fn is None:
         raise SystemExit("embedding callback missing")
@@ -2012,6 +2012,7 @@ def cmd_replay(args: argparse.Namespace) -> int:
         print(f"[{phase}] {completed}/{total} ({pct:.1f}%){extra_text}", file=sys.stderr)
 
     fast_stats: dict[str, object] | None = None
+    llm_fn, _ = _resolve_llm(args)
     if run_fast or run_full:
         fast_stats = run_fast_learning(
             state_path=str(state_path),
@@ -2032,6 +2033,7 @@ def cmd_replay(args: argparse.Namespace) -> int:
             on_progress=_emit_progress if progress_every > 0 else None,
             progress_every_windows=progress_every,
             progress_every_seconds=10 if progress_every > 0 else 0,
+            llm_fn=llm_fn,
         )
         graph, index, meta = load_state(str(state_path))
         if args.stop_after_fast_learning:

--- a/openclawbrain/ollama_llm.py
+++ b/openclawbrain/ollama_llm.py
@@ -1,0 +1,112 @@
+"""Ollama chat callbacks for optional LLM-assisted workflows."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from urllib import request
+
+
+_OLLAMA_TIMEOUT_SECONDS = 60
+_DEFAULT_OLLAMA_HOST = "http://127.0.0.1:11434"
+_DEFAULT_OLLAMA_MODEL = "llama3.2:3b"
+
+
+def _resolve_ollama_host() -> str:
+    host = (
+        os.environ.get("OPENCLAWBRAIN_OLLAMA_HOST")
+        or os.environ.get("OLLAMA_HOST")
+        or _DEFAULT_OLLAMA_HOST
+    )
+    host = host.strip() if isinstance(host, str) else _DEFAULT_OLLAMA_HOST
+    if not host:
+        host = _DEFAULT_OLLAMA_HOST
+    if "://" not in host:
+        host = f"http://{host}"
+    return host.rstrip("/")
+
+
+def _resolve_ollama_model(model: str | None) -> str:
+    if isinstance(model, str) and model.strip():
+        return model
+    env_model = os.environ.get("OPENCLAWBRAIN_OLLAMA_MODEL") or os.environ.get("OLLAMA_MODEL")
+    if isinstance(env_model, str) and env_model.strip():
+        return env_model.strip()
+    return _DEFAULT_OLLAMA_MODEL
+
+
+def _ollama_chat(system: str, user: str, *, model: str) -> str:
+    host = _resolve_ollama_host()
+    payload = {
+        "model": model,
+        "stream": False,
+        "messages": [
+            {"role": "system", "content": system},
+            {"role": "user", "content": user},
+        ],
+    }
+    data = json.dumps(payload).encode("utf-8")
+    req = request.Request(
+        f"{host}/api/chat",
+        data=data,
+        method="POST",
+        headers={"Content-Type": "application/json"},
+    )
+    with request.urlopen(req, timeout=_OLLAMA_TIMEOUT_SECONDS) as resp:
+        raw_bytes = resp.read()
+    raw_text = raw_bytes.decode("utf-8") if raw_bytes else ""
+    if not raw_text:
+        return ""
+    response = json.loads(raw_text)
+    message = response.get("message")
+    if not isinstance(message, dict):
+        return ""
+    content = message.get("content")
+    if not isinstance(content, str):
+        return ""
+    return content
+
+
+def ollama_llm_fn(system: str, user: str, *, model: str = _DEFAULT_OLLAMA_MODEL) -> str:
+    """Run a single Ollama chat request."""
+    resolved_model = _resolve_ollama_model(model)
+    return _ollama_chat(system, user, model=resolved_model)
+
+
+def ollama_llm_batch_fn(requests: list[dict], *, max_workers: int = 8) -> list[dict]:
+    """Run Ollama chat requests concurrently.
+
+    Args:
+        requests: list of {id, system, user}
+        max_workers: thread pool size
+    """
+    if not requests:
+        return []
+
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+
+    total = len(requests)
+    results: list[dict] = []
+
+    def _call(req: dict) -> dict:
+        system = str(req.get("system", ""))
+        user = str(req.get("user", ""))
+        model = _resolve_ollama_model(req.get("model"))
+        request_id = req.get("id")
+        try:
+            response = _ollama_chat(system, user, model=model)
+        except Exception as exc:  # noqa: BLE001
+            return {"id": request_id, "response": "", "error": str(exc)}
+        return {"id": request_id, "response": response}
+
+    with ThreadPoolExecutor(max_workers=max_workers) as pool:
+        futures = [pool.submit(_call, req) for req in requests]
+        completed = 0
+        for fut in as_completed(futures):
+            completed += 1
+            if completed % 5 == 0 or completed == total:
+                print(f"LLM batch progress: processing {completed}/{total}", file=sys.stderr)
+            results.append(fut.result())
+
+    return results

--- a/openclawbrain/ops/async_route_pg.py
+++ b/openclawbrain/ops/async_route_pg.py
@@ -527,6 +527,53 @@ def _teacher_labels_openai(
     return labels_per_point, errors
 
 
+def _teacher_labels_ollama(
+    decision_points: list[DecisionPoint],
+    *,
+    teacher_model: str,
+) -> tuple[list[dict[str, float]], list[str]]:
+    errors: list[str] = []
+    if not decision_points:
+        return [], errors
+
+    from ..ollama_llm import ollama_llm_batch_fn
+
+    requests = [
+        {
+            "id": idx,
+            "model": teacher_model,
+            "system": TEACHER_SYSTEM_PROMPT,
+            "user": _teacher_user_prompt(point),
+        }
+        for idx, point in enumerate(decision_points)
+    ]
+    responses = ollama_llm_batch_fn(requests)
+    by_id: dict[int, dict] = {}
+    for row in responses:
+        if not isinstance(row, dict):
+            continue
+        request_id = row.get("id")
+        if isinstance(request_id, int):
+            by_id[request_id] = row
+
+    labels_per_point: list[dict[str, float]] = []
+    for idx, point in enumerate(decision_points):
+        response = by_id.get(idx, {})
+        raw = response.get("response")
+        if not isinstance(raw, str):
+            labels_per_point.append({})
+            err = response.get("error")
+            if isinstance(err, str) and err:
+                errors.append(err)
+            continue
+        valid_ids = {str(item["target_id"]) for item in point.candidates if "target_id" in item}
+        labels_per_point.append(parse_teacher_route_labels(raw, valid_ids))
+        err = response.get("error")
+        if isinstance(err, str) and err:
+            errors.append(err)
+    return labels_per_point, errors
+
+
 def run_async_route_pg(
     *,
     state_path: str,
@@ -593,6 +640,18 @@ def run_async_route_pg(
         teacher_available = True
         try:
             labels_by_point, model_errors = _teacher_labels_openai(
+                decision_points=decision_points,
+                teacher_model=teacher_model,
+            )
+            errors.extend(model_errors)
+        except Exception as exc:  # noqa: BLE001
+            errors.append(str(exc))
+            labels_by_point = [{} for _ in decision_points]
+            teacher_available = False
+    elif teacher == "ollama":
+        teacher_available = True
+        try:
+            labels_by_point, model_errors = _teacher_labels_ollama(
                 decision_points=decision_points,
                 teacher_model=teacher_model,
             )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1506,6 +1506,15 @@ def test_cli_replay_fresh_aliases_parse() -> None:
     assert args_no_checkpoint.fresh is True
 
 
+def test_cli_async_route_pg_teacher_ollama_parses() -> None:
+    """--teacher ollama is accepted by async-route-pg."""
+    from openclawbrain.cli import _build_parser
+
+    parser = _build_parser()
+    args = parser.parse_args(["async-route-pg", "--state", "/tmp/x.json", "--teacher", "ollama"])
+    assert args.teacher == "ollama"
+
+
 
 def test_cli_replay_writes_checkpoint_and_resume_uses_it(tmp_path, capsys) -> None:
     """replay writes checkpoint and resume only replays new lines."""

--- a/tests/test_openai_embeddings.py
+++ b/tests/test_openai_embeddings.py
@@ -227,6 +227,16 @@ def test_resolve_llm_openai_returns_callbacks(monkeypatch) -> None:
     assert llm_batch_fn is not None
 
 
+def test_resolve_llm_ollama_returns_callbacks(monkeypatch) -> None:
+    """test resolve llm ollama."""
+    monkeypatch.setenv("OPENCLAWBRAIN_OLLAMA_HOST", "http://localhost:11434")
+    monkeypatch.setenv("OPENCLAWBRAIN_OLLAMA_MODEL", "llama3.2:3b")
+    llm_fn, llm_batch_fn = _resolve_llm(argparse.Namespace(llm="ollama"))
+
+    assert llm_fn is not None
+    assert llm_batch_fn is not None
+
+
 def test_openai_embedder_embed(monkeypatch) -> None:
     """test openai embedder embed."""
     embedding = [1.0] * 1536


### PR DESCRIPTION
Adds first-class Ollama support so users can opt out of OpenAI and run an on-device LLM via Ollama.

What this enables:
- Replay full fast-learning transcript mining with Ollama:

  openclawbrain replay --state ./brain/state.json --sessions ./sessions/ --mode full --llm ollama

- Async route teacher labeling with Ollama:

  openclawbrain async-route-pg --state ./brain/state.json --teacher ollama

Implementation details:
- New module: openclawbrain/ollama_llm.py (stdlib HTTP; no new deps)
- CLI integration:
  - --llm supports: none|openai|ollama|auto
  - async-route-pg --teacher supports: openai|ollama|none
- Docs updated: docs/setup-guide.md, docs/default-experience.md
- Tests added for argparse + _resolve_llm selection
