### PR TITLE
openai_llm: sanitize invalid Unicode surrogates in prompts

### DIFF
--- a/openclawbrain/openai_llm.py
+++ b/openclawbrain/openai_llm.py
@@ -12,6 +12,11 @@ _OPENAI_MAX_RETRIES = 2
 _thread_local = threading.local()
 
 
+def sanitize_text(text: str) -> str:
+    """Return text that is safe to UTF-8 encode for JSON payloads."""
+    return text.encode("utf-8", "replace").decode("utf-8")
+
+
 def _extract_unsupported_kwarg(exc: TypeError) -> str | None:
     """Return a clearly unsupported keyword argument from an OpenAI TypeError."""
     message = str(exc).lower()
@@ -65,6 +70,8 @@ def _get_client():
 def openai_llm_fn(system: str, user: str, *, model: str = "gpt-5-mini") -> str:
     """Run a single OpenAI chat request."""
     client = _get_client()
+    system = sanitize_text(system)
+    user = sanitize_text(user)
     try:
         response = client.chat.completions.create(
             model=model,
@@ -120,8 +127,8 @@ def openai_llm_batch_fn(requests: list[dict], *, max_workers: int = 8) -> list[d
     results: list[dict] = []
 
     def _call(req: dict) -> dict:
-        system = str(req.get("system", ""))
-        user = str(req.get("user", ""))
+        system = sanitize_text(str(req.get("system", "")))
+        user = sanitize_text(str(req.get("user", "")))
         model = str(req.get("model", "gpt-5-mini"))
         request_id = req.get("id")
         try:

--- a/tests/test_openai_embeddings.py
+++ b/tests/test_openai_embeddings.py
@@ -156,6 +156,28 @@ def test_openai_llm_fn_falls_back_for_timeout_kwarg(monkeypatch) -> None:
     assert len(calls) == 1
 
 
+def test_openai_llm_fn_sanitizes_invalid_unicode(monkeypatch) -> None:
+    """test openai llm fn sanitizes invalid unicode."""
+    calls, module = _install_fake_openai_llm(
+        monkeypatch,
+        [lambda _, __: "ok"],
+    )
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    bad_text = "bad\ud83dtext"
+    module.openai_llm_fn(bad_text, bad_text)
+    sanitized = module.sanitize_text(bad_text)
+
+    assert calls == [
+        (
+            "gpt-5-mini",
+            [
+                {"role": "system", "content": sanitized},
+                {"role": "user", "content": sanitized},
+            ],
+        )
+    ]
+
+
 def test_openai_llm_batch_fn_uses_thread_local_clients(monkeypatch) -> None:
     """test openai llm batch fn uses thread local clients."""
     _, module = _install_fake_openai_llm(


### PR DESCRIPTION
Fixes fast-learning crashes caused by invalid Unicode surrogates in session text. Adds sanitize_text() and applies it to system/user strings for both single and batch OpenAI calls. Includes unit test.