### PR TITLE
ollama: honor OPENCLAWBRAIN_OLLAMA_MODEL in ollama_llm_fn

### DIFF
--- a/openclawbrain/ollama_llm.py
+++ b/openclawbrain/ollama_llm.py
@@ -68,7 +68,7 @@ def _ollama_chat(system: str, user: str, *, model: str) -> str:
     return content
 
 
-def ollama_llm_fn(system: str, user: str, *, model: str = _DEFAULT_OLLAMA_MODEL) -> str:
+def ollama_llm_fn(system: str, user: str, *, model: str | None = None) -> str:
     """Run a single Ollama chat request."""
     resolved_model = _resolve_ollama_model(model)
     return _ollama_chat(system, user, model=resolved_model)

--- a/tests/test_ollama_llm.py
+++ b/tests/test_ollama_llm.py
@@ -1,0 +1,22 @@
+"""Tests for Ollama LLM integration."""
+
+from __future__ import annotations
+
+import importlib
+
+
+def test_ollama_llm_fn_honors_env_model(monkeypatch) -> None:
+    """ollama_llm_fn uses OPENCLAWBRAIN_OLLAMA_MODEL when model is None."""
+    monkeypatch.setenv("OPENCLAWBRAIN_OLLAMA_MODEL", "sentinel-model")
+
+    module = importlib.import_module("openclawbrain.ollama_llm")
+    calls: list[str] = []
+
+    def _fake_chat(system: str, user: str, *, model: str) -> str:
+        calls.append(model)
+        return "ok"
+
+    monkeypatch.setattr(module, "_ollama_chat", _fake_chat)
+
+    assert module.ollama_llm_fn("system", "user") == "ok"
+    assert calls == ["sentinel-model"]


### PR DESCRIPTION
Fix Ollama model resolution so OPENCLAWBRAIN_OLLAMA_MODEL / OLLAMA_MODEL env vars actually take effect.

Bug:
- ollama_llm_fn had a default model value (llama3.2:3b) which prevented env-based selection.
- This caused replay/fast-learning to hit Ollama with a missing model and return 404.

Change:
- ollama_llm_fn now defaults model to None so env vars are honored.
- Adds a unit test to prevent regression.
