### PR TITLE
ollama: configurable timeout (default 600s)

### DIFF
--- a/openclawbrain/ollama_llm.py
+++ b/openclawbrain/ollama_llm.py
@@ -8,7 +8,7 @@ import sys
 from urllib import request
 
 
-_OLLAMA_TIMEOUT_SECONDS = 60
+_DEFAULT_OLLAMA_TIMEOUT_SECONDS = 600
 _DEFAULT_OLLAMA_HOST = "http://127.0.0.1:11434"
 _DEFAULT_OLLAMA_MODEL = "llama3.2:3b"
 
@@ -36,8 +36,28 @@ def _resolve_ollama_model(model: str | None) -> str:
     return _DEFAULT_OLLAMA_MODEL
 
 
+def _resolve_ollama_timeout_seconds() -> int:
+    env_timeout = (
+        os.environ.get("OPENCLAWBRAIN_OLLAMA_TIMEOUT_SECONDS")
+        or os.environ.get("OLLAMA_TIMEOUT_SECONDS")
+    )
+    if not isinstance(env_timeout, str):
+        return _DEFAULT_OLLAMA_TIMEOUT_SECONDS
+    env_timeout = env_timeout.strip()
+    if not env_timeout:
+        return _DEFAULT_OLLAMA_TIMEOUT_SECONDS
+    try:
+        timeout = int(env_timeout)
+    except ValueError:
+        return _DEFAULT_OLLAMA_TIMEOUT_SECONDS
+    if timeout < 1:
+        return _DEFAULT_OLLAMA_TIMEOUT_SECONDS
+    return timeout
+
+
 def _ollama_chat(system: str, user: str, *, model: str) -> str:
     host = _resolve_ollama_host()
+    timeout_seconds = _resolve_ollama_timeout_seconds()
     payload = {
         "model": model,
         "stream": False,
@@ -53,7 +73,7 @@ def _ollama_chat(system: str, user: str, *, model: str) -> str:
         method="POST",
         headers={"Content-Type": "application/json"},
     )
-    with request.urlopen(req, timeout=_OLLAMA_TIMEOUT_SECONDS) as resp:
+    with request.urlopen(req, timeout=timeout_seconds) as resp:
         raw_bytes = resp.read()
     raw_text = raw_bytes.decode("utf-8") if raw_bytes else ""
     if not raw_text:

--- a/tests/test_ollama_llm.py
+++ b/tests/test_ollama_llm.py
@@ -20,3 +20,27 @@ def test_ollama_llm_fn_honors_env_model(monkeypatch) -> None:
 
     assert module.ollama_llm_fn("system", "user") == "ok"
     assert calls == ["sentinel-model"]
+
+
+def test_resolve_ollama_timeout_seconds(monkeypatch) -> None:
+    """Timeout resolver prefers OPENCLAWBRAIN_OLLAMA_TIMEOUT_SECONDS with validation."""
+    module = importlib.import_module("openclawbrain.ollama_llm")
+
+    monkeypatch.delenv("OPENCLAWBRAIN_OLLAMA_TIMEOUT_SECONDS", raising=False)
+    monkeypatch.delenv("OLLAMA_TIMEOUT_SECONDS", raising=False)
+    assert module._resolve_ollama_timeout_seconds() == 600
+
+    monkeypatch.setenv("OLLAMA_TIMEOUT_SECONDS", "120")
+    assert module._resolve_ollama_timeout_seconds() == 120
+
+    monkeypatch.setenv("OPENCLAWBRAIN_OLLAMA_TIMEOUT_SECONDS", "42")
+    assert module._resolve_ollama_timeout_seconds() == 42
+
+    monkeypatch.setenv("OPENCLAWBRAIN_OLLAMA_TIMEOUT_SECONDS", "0")
+    assert module._resolve_ollama_timeout_seconds() == 600
+
+    monkeypatch.setenv("OPENCLAWBRAIN_OLLAMA_TIMEOUT_SECONDS", "-5")
+    assert module._resolve_ollama_timeout_seconds() == 600
+
+    monkeypatch.setenv("OPENCLAWBRAIN_OLLAMA_TIMEOUT_SECONDS", "not-a-number")
+    assert module._resolve_ollama_timeout_seconds() == 600


### PR DESCRIPTION
Make Ollama request timeout configurable and increase default for long qwen32b prompts.

- Replaces hardcoded 60s timeout with resolver:
  - OPENCLAWBRAIN_OLLAMA_TIMEOUT_SECONDS
  - OLLAMA_TIMEOUT_SECONDS
  - default 600s
- Validates int >= 1
- Adds unit test
