### PR TITLE
ops: build-all uses current CLI binary (argv0)

### DIFF
--- a/openclawbrain/cli.py
+++ b/openclawbrain/cli.py
@@ -169,10 +169,13 @@ def _coalesce(cli_value: str | None, profile_value: str | None, default: str) ->
 
 def _resolve_openclawbrain_bin() -> str:
     """Resolve the installed openclawbrain CLI binary."""
+    argv0 = Path(sys.argv[0]).expanduser()
+    if argv0.is_file() and os.access(argv0, os.X_OK):
+        return str(argv0)
     candidate = shutil.which("openclawbrain")
     if candidate:
         return candidate
-    return str(Path(sys.argv[0]).expanduser())
+    return str(argv0)
 
 
 def _discover_agent_ids(config_path: Path | None = None) -> list[str]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 import json
 import os
+import sys
 from io import StringIO
 from pathlib import Path
 
 import pytest
 
-from openclawbrain.cli import main, _read_replay_checkpoint_progress
+from openclawbrain.cli import main, _read_replay_checkpoint_progress, _resolve_openclawbrain_bin
 from openclawbrain.graph import Graph, Node
 from openclawbrain.hasher import default_embed
 from openclawbrain.journal import read_journal
@@ -170,6 +171,19 @@ def test_init_sets_authority_metadata_for_mapped_files(tmp_path, monkeypatch) ->
     assert "constitutional" in authorities_for("SOUL.md")
     assert "constitutional" in authorities_for("AGENTS.md")
     assert "canonical" in authorities_for("USER.md")
+
+
+def test_resolve_openclawbrain_bin_prefers_sys_argv(tmp_path, monkeypatch) -> None:
+    """resolve openclawbrain bin prefers sys.argv[0] when executable."""
+    monkeypatch.chdir(tmp_path)
+    bin_path = Path("openclawbrain")
+    bin_path.write_text("#!/bin/sh\n", encoding="utf-8")
+    os.chmod(bin_path, 0o755)
+
+    monkeypatch.setattr(sys, "argv", [str(bin_path)])
+    monkeypatch.setattr("openclawbrain.cli.shutil.which", lambda _: "/opt/homebrew/bin/openclawbrain")
+
+    assert _resolve_openclawbrain_bin() == str(bin_path)
 
 
 def test_query_command_returns_json_with_fired_nodes(tmp_path, capsys, monkeypatch) -> None:


### PR DESCRIPTION
Fix build-all to use the currently-invoked openclawbrain binary.

- `_resolve_openclawbrain_bin()` now prefers an executable `sys.argv[0]` over `shutil.which('openclawbrain')`
- Prevents accidentally invoking a different installation (e.g. /opt/homebrew/bin) when multiple installs exist
- Adds unit test

Tests: `pytest -q`
