### PR TITLE
perf: fast-learning prefilter (skip existing pointers + low-signal windows)

### DIFF
--- a/openclawbrain/full_learning.py
+++ b/openclawbrain/full_learning.py
@@ -72,6 +72,16 @@ FEEDBACK_REINFORCE = [
     "correct",
     "good",
 ]
+_LOW_SIGNAL_TOKENS = (
+    "correction",
+    "wrong",
+    "no",
+    "actually",
+    "do instead",
+    "next time",
+    "remember",
+    "note:",
+)
 
 LEARNING_EXTRACTOR_PROMPT = """Extract feedback signals from a compact conversation window.
 
@@ -351,6 +361,48 @@ def _turn_score(turn: SessionTurn) -> int:
             score += 1
             break
     return score
+
+
+def _window_has_feedback_signal(window: list[SessionTurn]) -> bool:
+    """Conservative filter for windows likely to contain feedback."""
+    for turn in window:
+        if turn.role != "user":
+            continue
+        if _turn_score(turn) > 0:
+            return True
+        text = turn.content.lower()
+        for token in _LOW_SIGNAL_TOKENS:
+            if token in text:
+                return True
+    return False
+
+
+def _session_pointer_for_window(session: str, window: list[SessionTurn]) -> str:
+    """Build deterministic pointer string for a window."""
+    return f"{session}:{window[0].line_no}-{window[-1].line_no}"
+
+
+def _filter_learning_windows_for_llm(
+    candidate_windows: list[tuple[str, list[SessionTurn], int]],
+    *,
+    existing_pointers: set[str],
+) -> tuple[list[tuple[str, list[SessionTurn], int]], int, int]:
+    """Filter windows before expensive LLM calls."""
+    filtered: list[tuple[str, list[SessionTurn], int]] = []
+    skipped_low_signal = 0
+    skipped_existing_pointer = 0
+
+    for source, segment, idx in candidate_windows:
+        if not _window_has_feedback_signal(segment):
+            skipped_low_signal += 1
+            continue
+        pointer = _session_pointer_for_window(source, segment)
+        if pointer in existing_pointers:
+            skipped_existing_pointer += 1
+            continue
+        filtered.append((source, segment, idx))
+
+    return filtered, skipped_low_signal, skipped_existing_pointer
 
 
 def select_feedback_windows(
@@ -807,7 +859,7 @@ def run_fast_learning(
         tool_result_allowlist=tool_result_allowlist,
         tool_result_max_chars=tool_result_max_chars,
     )
-    windows: list[tuple[str, list[SessionTurn], int]] = []
+    candidate_windows: list[tuple[str, list[SessionTurn], int]] = []
     for source, turns in grouped_turns:
         for idx, (start, end) in enumerate(
             select_feedback_windows(
@@ -819,11 +871,23 @@ def run_fast_learning(
             start=1,
         ):
             if start < end:
-                windows.append((source, turns[start:end], idx))
+                candidate_windows.append((source, turns[start:end], idx))
+
+    windows_total = len(candidate_windows)
+    existing_pointers = {
+        entry.get("session_pointer")
+        for entry in event_log_entries(learning_event_path(state_path))
+        if isinstance(entry.get("session_pointer"), str)
+    }
+    windows, windows_skipped_low_signal, windows_skipped_existing_pointer = _filter_learning_windows_for_llm(
+        candidate_windows,
+        existing_pointers=existing_pointers,
+    )
+    windows_sent_to_llm = len(windows)
 
     all_events: list[dict] = []
     completed_windows = 0
-    total_windows = len(windows)
+    total_windows = windows_sent_to_llm
     fast_started_at = time.monotonic()
     checkpoint_every_windows = max(0, checkpoint_every)
     checkpoint_interval_seconds = max(0, checkpoint_every_seconds)
@@ -889,7 +953,7 @@ def run_fast_learning(
         last_progress_completed = completed_windows
 
     if windows:
-        request_ctx = [(source, idx + 1, len(windows), segment) for idx, (source, segment, _) in enumerate(windows)]
+        request_ctx = [(source, idx + 1, total_windows, segment) for idx, (source, segment, _) in enumerate(windows)]
         if workers == 1:
             for source, idx, total, segment in request_ctx:
                 all_events.extend(_window_to_payload(session=source, window=segment, window_idx=idx, total_windows=total, llm_fn=llm_fn))
@@ -985,7 +1049,11 @@ def run_fast_learning(
         )
 
     return {
-        "windows": total_windows,
+        "windows": windows_sent_to_llm,
+        "windows_total": windows_total,
+        "windows_skipped_existing_pointer": windows_skipped_existing_pointer,
+        "windows_skipped_low_signal": windows_skipped_low_signal,
+        "windows_sent_to_llm": windows_sent_to_llm,
         "events_extracted": len(all_events),
         "events_appended": len(deduped),
         "events_skipped": skipped,

--- a/tests/test_full_learning.py
+++ b/tests/test_full_learning.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from openclawbrain.full_learning import (
     SessionTurn,
     collect_session_files,
     dedupe_learning_events,
+    _filter_learning_windows_for_llm,
+    _session_pointer_for_window,
     run_fast_learning,
     select_feedback_windows,
     _collect_turns,
@@ -52,6 +55,96 @@ def test_select_feedback_windows_merges_overlapping_regions() -> None:
         hard_max_turns=3,
     )
     assert windows == [(0, 6)]
+
+
+def test_filter_learning_windows_for_llm_skips_existing_session_pointers() -> None:
+    """Skip windows already represented by session_pointer in existing logs."""
+    source = "session.jsonl"
+    turn_a = SessionTurn(role="user", content="that is wrong", line_no=1, source=source)
+    turn_b = SessionTurn(role="assistant", content="ok", line_no=2, source=source)
+    turn_c = SessionTurn(role="user", content="thanks for help", line_no=3, source=source)
+    turn_d = SessionTurn(role="assistant", content="you're welcome", line_no=4, source=source)
+
+    existing_pointer = _session_pointer_for_window(source, [turn_a, turn_b])
+    candidate_windows = [
+        (source, [turn_a, turn_b], 1),
+        (source, [turn_c, turn_d], 2),
+    ]
+    filtered, skipped_low_signal, skipped_existing_pointer = _filter_learning_windows_for_llm(
+        candidate_windows,
+        existing_pointers={existing_pointer},
+    )
+
+    assert skipped_low_signal == 0
+    assert skipped_existing_pointer == 1
+    assert filtered == [(source, [turn_c, turn_d], 2)]
+
+
+def test_run_fast_learning_skips_windows_already_in_learning_log(
+    tmp_path: Path,
+) -> None:
+    """run_fast_learning should skip windows when session_pointer already exists."""
+    state_path = tmp_path / "state.json"
+    state_path.write_text(
+        '{"graph":{"nodes":[],"edges":[]},"index":{},"meta":{"embedder_name":"hash-v1","embedder_dim":1024}}',
+        encoding="utf-8",
+    )
+    session_path = tmp_path / "session.jsonl"
+    session_path.write_text(
+        "\n".join(
+            [
+                '{"role":"user","content":"that is wrong","ts":1.0}',
+                '{"role":"assistant","content":"acknowledged","ts":1.1}',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    pointer = _session_pointer_for_window(str(session_path), [
+        SessionTurn(role="user", content="that is wrong", line_no=1, source=str(session_path)),
+        SessionTurn(role="assistant", content="acknowledged", line_no=2, source=str(session_path)),
+    ])
+    learning_events = tmp_path / "learning_events.jsonl"
+    learning_events.write_text(
+        json.dumps(
+            {
+                "type": "CORRECTION",
+                "content": "existing",
+                "content_hash": "abc",
+                "session_pointer": pointer,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    llm_calls = 0
+
+    def fake_llm(_: str, __: str) -> str:
+        nonlocal llm_calls
+        llm_calls += 1
+        return (
+            '{"corrections":[{"content":"Do X instead.","context":"ctx","severity":"high"}],'
+            '"teachings":[],"reinforcements":[]}'
+        )
+
+    result = run_fast_learning(
+        state_path=str(state_path),
+        session_paths=[session_path],
+        workers=1,
+        max_windows=1,
+        llm_fn=fake_llm,
+        checkpoint_every=0,
+        checkpoint_every_seconds=0,
+        progress_every_windows=0,
+        progress_every_seconds=0,
+        backup=False,
+    )
+
+    assert llm_calls == 0
+    assert result["windows_total"] == 1
+    assert result["windows_skipped_existing_pointer"] == 1
+    assert result["windows_sent_to_llm"] == 0
 
 
 def test_dedupe_learning_events_is_idempotent() -> None:


### PR DESCRIPTION
Speed up fast-learning by skipping windows that cannot produce new learning events.

- Pre-dedup by `session_pointer` BEFORE LLM calls: skip windows already present in `learning_events.jsonl`.
- Conservative low-signal filter to skip windows unlikely to contain feedback.
- Adds detailed window stats in fast-learning return payload.
- Tests covering both helper filtering and run_fast_learning behavior.

Tests: pytest tests/test_full_learning.py
