### PR TITLE
ops: fast-learning counters in logs/checkpoint/show-checkpoint

### DIFF
--- a/openclawbrain/cli.py
+++ b/openclawbrain/cli.py
@@ -2672,8 +2672,12 @@ def _build_checkpoint_status_payload(
         "phases": phase_plan,
         "fast_learning": {
             "status": str(fast_raw.get("status", "unknown")),
-            "windows_processed": int(fast_raw.get("windows_processed", 0)) if isinstance(fast_raw.get("windows_processed"), (int, float)) else 0,
-            "windows_total": int(fast_raw.get("windows_total", 0)) if isinstance(fast_raw.get("windows_total"), (int, float)) else 0,
+            "windows_processed": int(fast_raw.get("windows_processed", 0))
+            if isinstance(fast_raw.get("windows_processed"), (int, float))
+            else 0,
+            "windows_total": int(fast_raw.get("windows_total", 0))
+            if isinstance(fast_raw.get("windows_total"), (int, float))
+            else 0,
             "updated_at": fast_raw.get("updated_at"),
             "session_offsets_count": len(fast_offsets),
             "legacy_offsets_fallback": bool(fast_legacy and fast_offsets),
@@ -2687,6 +2691,15 @@ def _build_checkpoint_status_payload(
             "legacy_offsets_fallback": bool(replay_legacy and replay_offsets),
         },
     }
+    for counter_name in (
+        "windows_candidate",
+        "windows_sent_to_llm",
+        "windows_skipped_low_signal",
+        "windows_skipped_existing_pointer",
+    ):
+        value = fast_raw.get(counter_name)
+        if isinstance(value, (int, float)):
+            payload["fast_learning"][counter_name] = int(value)
     return payload, bool(fast_legacy and fast_offsets), bool(replay_legacy and replay_offsets)
 
 
@@ -2732,6 +2745,17 @@ def cmd_replay(args: argparse.Namespace) -> int:
             f"status={fast_status.get('status', 'unknown')}, "
             f"updated_at={_checkpoint_time_display(fast_status.get('updated_at'))}"
         )
+        fast_counter_bits = []
+        for counter_name in (
+            "windows_candidate",
+            "windows_sent_to_llm",
+            "windows_skipped_low_signal",
+            "windows_skipped_existing_pointer",
+        ):
+            if counter_name in fast_status:
+                fast_counter_bits.append(f"{counter_name}={fast_status[counter_name]}")
+        if fast_counter_bits:
+            print(f"  Fast learning counters: {', '.join(fast_counter_bits)}")
         print(
             "Replay: "
             f"{replay_status.get('queries_processed', 0)}/{replay_status.get('queries_total', 0)} queries, "

--- a/openclawbrain/full_learning.py
+++ b/openclawbrain/full_learning.py
@@ -379,7 +379,16 @@ def _window_has_feedback_signal(window: list[SessionTurn]) -> bool:
 
 def _session_pointer_for_window(session: str, window: list[SessionTurn]) -> str:
     """Build deterministic pointer string for a window."""
-    return f"{session}:{window[0].line_no}-{window[-1].line_no}"
+    normalized_session = _normalize_session_source(session)
+    return f"{normalized_session}:{window[0].line_no}-{window[-1].line_no}"
+
+
+def _normalize_session_source(source: str) -> str:
+    """Normalize session path for stable dedupe identity."""
+    try:
+        return str(Path(source).expanduser().resolve())
+    except (OSError, RuntimeError):
+        return source
 
 
 def _filter_learning_windows_for_llm(
@@ -465,7 +474,7 @@ def _window_to_payload(
     if not isinstance(payload, dict):
         return []
 
-    pointer = f"{session}:{window[0].line_no}-{window[-1].line_no}"
+    pointer = _session_pointer_for_window(session, window)
     events: list[dict] = []
 
     for event_type, key in (("CORRECTION", "corrections"), ("TEACHING", "teachings"), ("REINFORCEMENT", "reinforcements")):
@@ -873,7 +882,7 @@ def run_fast_learning(
             if start < end:
                 candidate_windows.append((source, turns[start:end], idx))
 
-    windows_total = len(candidate_windows)
+    windows_candidate = len(candidate_windows)
     existing_pointers = {
         entry.get("session_pointer")
         for entry in event_log_entries(learning_event_path(state_path))
@@ -884,6 +893,14 @@ def run_fast_learning(
         existing_pointers=existing_pointers,
     )
     windows_sent_to_llm = len(windows)
+    windows_total = windows_sent_to_llm
+
+    print(
+        "[fast_learning] "
+        f"windows_candidate={windows_candidate} windows_sent_to_llm={windows_sent_to_llm} "
+        f"skipped_low_signal={windows_skipped_low_signal} skipped_existing_pointer={windows_skipped_existing_pointer}",
+        file=sys.stderr,
+    )
 
     all_events: list[dict] = []
     completed_windows = 0
@@ -917,6 +934,10 @@ def run_fast_learning(
                 "status": "running",
                 "windows_processed": completed_windows,
                 "windows_total": total_windows,
+                "windows_candidate": windows_candidate,
+                "windows_sent_to_llm": windows_sent_to_llm,
+                "windows_skipped_low_signal": windows_skipped_low_signal,
+                "windows_skipped_existing_pointer": windows_skipped_existing_pointer,
                 "updated_at": time.time(),
             },
         )
@@ -1044,6 +1065,10 @@ def run_fast_learning(
                 "status": "complete",
                 "windows_processed": completed_windows,
                 "windows_total": total_windows,
+                "windows_candidate": windows_candidate,
+                "windows_sent_to_llm": windows_sent_to_llm,
+                "windows_skipped_low_signal": windows_skipped_low_signal,
+                "windows_skipped_existing_pointer": windows_skipped_existing_pointer,
                 "updated_at": time.time(),
             },
         )
@@ -1051,6 +1076,7 @@ def run_fast_learning(
     return {
         "windows": windows_sent_to_llm,
         "windows_total": windows_total,
+        "windows_candidate": windows_candidate,
         "windows_skipped_existing_pointer": windows_skipped_existing_pointer,
         "windows_skipped_low_signal": windows_skipped_low_signal,
         "windows_sent_to_llm": windows_sent_to_llm,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1389,6 +1389,50 @@ def test_cli_replay_show_checkpoint_json_uses_new_schema_fixture(tmp_path, capsy
     assert payload["resume"]["would_take_effect"] is True
 
 
+def test_cli_replay_show_checkpoint_text_includes_fast_learning_counters(tmp_path, capsys) -> None:
+    """replay --show-checkpoint prints fast-learning counter fields when present."""
+    state_path = tmp_path / "state.json"
+    _write_state(state_path)
+    checkpoint_path = tmp_path / "replay_checkpoint.json"
+    checkpoint_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "fast_learning": {
+                    "status": "running",
+                    "windows_processed": 4,
+                    "windows_total": 10,
+                    "windows_candidate": 12,
+                    "windows_sent_to_llm": 10,
+                    "windows_skipped_low_signal": 2,
+                    "windows_skipped_existing_pointer": 0,
+                    "updated_at": 1700000100.0,
+                },
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+    code = main(
+        [
+            "replay",
+            "--state",
+            str(state_path),
+            "--checkpoint",
+            str(checkpoint_path),
+            "--show-checkpoint",
+        ]
+    )
+    assert code == 0
+    out = capsys.readouterr().out
+    assert "Fast learning: 4/10 windows, status=running" in out
+    assert "windows_candidate=12" in out
+    assert "windows_sent_to_llm=10" in out
+    assert "windows_skipped_low_signal=2" in out
+    assert "windows_skipped_existing_pointer=0" in out
+
+
 def test_cli_replay_show_checkpoint_text_legacy_fixture_warns(tmp_path, capsys) -> None:
     """replay --show-checkpoint warns when legacy top-level sessions are used."""
     state_path = tmp_path / "state.json"

--- a/tests/test_full_learning.py
+++ b/tests/test_full_learning.py
@@ -3,11 +3,14 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import openclawbrain.full_learning as full_learning_module
+
 from openclawbrain.full_learning import (
     SessionTurn,
     collect_session_files,
     dedupe_learning_events,
     _filter_learning_windows_for_llm,
+    _window_to_payload,
     _session_pointer_for_window,
     run_fast_learning,
     select_feedback_windows,
@@ -55,6 +58,49 @@ def test_select_feedback_windows_merges_overlapping_regions() -> None:
         hard_max_turns=3,
     )
     assert windows == [(0, 6)]
+
+
+def test_session_pointer_normalization_reuses_resolved_path_for_filtering_and_payload(tmp_path: Path) -> None:
+    """Normalize symlinked sources to avoid duplicate fast-learning work."""
+    real_session = tmp_path / "real.jsonl"
+    linked_session = tmp_path / "linked.jsonl"
+    real_session.write_text(
+        "\n".join(
+            [
+                '{"role":"user","content":"that is wrong","ts":1.0}',
+                '{"role":"assistant","content":"acknowledged","ts":1.1}',
+            ]
+        ),
+        encoding="utf-8",
+    )
+    linked_session.symlink_to(real_session)
+
+    turn_a = SessionTurn(role="user", content="that is wrong", line_no=1, source=str(linked_session))
+    turn_b = SessionTurn(role="assistant", content="acknowledged", line_no=2, source=str(linked_session))
+    normalized_pointer = _session_pointer_for_window(str(real_session), [turn_a, turn_b])
+
+    filtered, skipped_low_signal, skipped_existing_pointer = _filter_learning_windows_for_llm(
+        candidate_windows=[(str(linked_session), [turn_a, turn_b], 1)],
+        existing_pointers={normalized_pointer},
+    )
+    assert skipped_existing_pointer == 1
+    assert skipped_low_signal == 0
+    assert filtered == []
+
+    def fake_llm(_: str, __: str) -> str:
+        return (
+            '{"corrections":[{"content":"Do X instead.","context":"ctx","severity":"high"}],'
+            '"teachings":[],"reinforcements":[]}'
+        )
+
+    events = _window_to_payload(
+        session=str(linked_session),
+        window=[turn_a, turn_b],
+        window_idx=1,
+        total_windows=1,
+        llm_fn=fake_llm,
+    )
+    assert events[0]["session_pointer"] == normalized_pointer
 
 
 def test_filter_learning_windows_for_llm_skips_existing_session_pointers() -> None:
@@ -142,9 +188,68 @@ def test_run_fast_learning_skips_windows_already_in_learning_log(
     )
 
     assert llm_calls == 0
-    assert result["windows_total"] == 1
+    assert result["windows_total"] == 0
+    assert result["windows_candidate"] == 1
     assert result["windows_skipped_existing_pointer"] == 1
     assert result["windows_sent_to_llm"] == 0
+
+
+def test_run_fast_learning_checkpoint_extras_include_counters(tmp_path: Path, monkeypatch) -> None:
+    """_save_checkpoint includes fast-learning counters during running and completion."""
+    state_path = tmp_path / "state.json"
+    state_path.write_text(
+        '{"graph":{"nodes":[],"edges":[]},"index":{},"meta":{"embedder_name":"hash-v1","embedder_dim":1024}}',
+        encoding="utf-8",
+    )
+    sessions = tmp_path / "sessions.jsonl"
+    sessions.write_text(
+        "\n".join(
+            [
+                '{"role":"user","content":"that guidance is wrong","ts":1.0}',
+                '{"role":"assistant","content":"acknowledged","ts":1.1}',
+            ]
+        ),
+        encoding="utf-8",
+    )
+    checkpoint_path = tmp_path / "replay_checkpoint.json"
+    recorded_extras: list[dict[str, object]] = []
+
+    def fake_save_checkpoint(
+        path: str,
+        *,
+        phase: str,
+        session_offsets: dict[str, int] | None = None,
+        extra: dict[str, object] | None = None,
+    ) -> None:
+        if phase == "fast_learning" and isinstance(extra, dict):
+            recorded_extras.append(extra)
+
+    monkeypatch.setattr(full_learning_module, "_save_checkpoint", fake_save_checkpoint)
+
+    def fake_llm(_: str, __: str) -> str:
+        return (
+            '{"corrections":[{"content":"Do X instead.","context":"ctx","severity":"high"}],'
+            '"teachings":[],"reinforcements":[]}'
+        )
+
+    run_fast_learning(
+        state_path=str(state_path),
+        session_paths=[sessions],
+        workers=1,
+        max_windows=1,
+        llm_fn=fake_llm,
+        checkpoint_path=str(checkpoint_path),
+        checkpoint_every=1,
+        checkpoint_every_seconds=0,
+        backup=False,
+    )
+
+    assert recorded_extras
+    for extra in recorded_extras:
+        assert extra["windows_candidate"] == 1
+        assert extra["windows_sent_to_llm"] == 1
+        assert extra["windows_skipped_low_signal"] == 0
+        assert extra["windows_skipped_existing_pointer"] == 0
 
 
 def test_dedupe_learning_events_is_idempotent() -> None:


### PR DESCRIPTION
Implements issue #98: fast-learning prefilter/skip counters in logs + checkpoint + show-checkpoint.

- Adds a single stderr summary line with windows_candidate/sent/skipped counts.
- Persists counters into fast-learning checkpoint extra fields.
- Normalizes session_pointer source paths to avoid symlink-induced dedupe misses.
- Surfaces counters in `replay --show-checkpoint` when present.
- Tests included.
