### PR TITLE
ops: guard embedder/index dim mismatch

### DIFF
--- a/docs/default-experience.md
+++ b/docs/default-experience.md
@@ -162,6 +162,10 @@ Each agent run writes auditable artifacts under `~/.openclawbrain/<agent>/scratc
 - The script expects existing agent state files at `~/.openclawbrain/<agent>/state.json`.
 - The script does **not** start or stop `launchd` services; it only builds artifacts.
 - If you need a clean rebuild + cutover workflow, use `examples/ops/rebuild_then_cutover.sh` after this completes.
+- `build-all` now snapshots `openclawbrain status --json` before replay and enforces embedding compatibility:
+  - it requires both `embedder_dim` and `index_dim` to match (if both are present),
+  - it prints a clear warning and continues when `--reembed` is enabled,
+  - otherwise it fails fast with a suggestion to rerun with `--reembed` or `openclawbrain reembed --state ...`.
 
 ## Tool provenance edges
 

--- a/openclawbrain/cli.py
+++ b/openclawbrain/cli.py
@@ -148,6 +148,7 @@ def _build_all_root_manifest_payload(
             "agents": getattr(args, "agents", None),
             "parallel_agents": parallel_agents,
             "reembed": bool(args.reembed),
+            "require_local_embedder": bool(args.require_local_embedder),
             "embed_model": str(args.embed_model),
             "mode": str(args.mode),
             "llm": str(args.llm),
@@ -173,6 +174,60 @@ def _build_all_root_manifest_payload(
             "failed": failed,
         },
     }
+
+
+def _evaluate_build_all_preflight(
+    *,
+    state_path: str,
+    status_before_path: str,
+    reembed: bool,
+    require_local_embedder: bool,
+) -> tuple[int, str | None]:
+    """Evaluate build-all preflight checks from a status snapshot.
+
+    Returns (exit_code, optional_error). exit_code 0 indicates continue.
+    """
+    try:
+        payload = _load_json(status_before_path)
+    except SystemExit as exc:
+        message = f"failed to read status_before snapshot: {exc}"
+        print(f"[build-all] preflight: {message}")
+        return 1, message
+
+    embedder_name = payload.get("embedder_name")
+    embedder_dim = payload.get("embedder_dim")
+    index_dim = payload.get("index_dim")
+
+    if (
+        require_local_embedder
+        and isinstance(embedder_name, str)
+        and embedder_name.startswith("openai")
+        and not reembed
+    ):
+        message = (
+            "state is using an OpenAI embedder. "
+            "Re-run with --reembed to switch to local embeddings, "
+            f"or run: openclawbrain reembed --state {state_path}"
+        )
+        print(f"[build-all] preflight: {message}")
+        return 1, message
+
+    if isinstance(embedder_dim, int) and isinstance(index_dim, int) and embedder_dim != index_dim:
+        if reembed:
+            print(
+                f"[build-all] preflight: embedder_dim mismatch "
+                f"(index={index_dim}, meta={embedder_dim}); continuing because --reembed is enabled."
+            )
+        else:
+            message = (
+                "embedder_dim differs from index_dim. "
+                "Re-run with --reembed or run: "
+                f"openclawbrain reembed --state {state_path}"
+            )
+            print(f"[build-all] preflight: {message}")
+            return 1, message
+
+    return 0, None
 
 
 def _parse_positive_float(value: str) -> float:
@@ -760,6 +815,17 @@ def _build_all_agent_pipeline(
             [ocb_bin, "status", "--state", str(state_path), "--json"],
             stdout_path=status_before_path,
         )
+
+    if exit_code == 0:
+        preflight_code, preflight_error = _evaluate_build_all_preflight(
+            state_path=str(state_path),
+            status_before_path=str(status_before_path),
+            reembed=bool(args.reembed),
+            require_local_embedder=bool(args.require_local_embedder),
+        )
+        if preflight_code != 0:
+            exit_code = preflight_code
+            set_last_error(preflight_error)
 
     if exit_code == 0 and args.reembed:
         exit_code = run_step(
@@ -1510,6 +1576,11 @@ def _build_parser() -> argparse.ArgumentParser:
     build_all.add_argument("--agents", help="Comma-separated agent ids to run (default: discover from openclaw.json)")
     build_all.add_argument("--parallel-agents", type=int, default=1)
     build_all.add_argument("--reembed", action=argparse.BooleanOptionalAction, default=True)
+    build_all.add_argument(
+        "--require-local-embedder",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+    )
     build_all.add_argument("--embed-model", default="BAAI/bge-large-en-v1.5")
     build_all.add_argument("--mode", choices=REPLAY_MODES, default="full")
     build_all.add_argument("--llm", choices=["none", "openai", "ollama", "auto"], default="auto")
@@ -1798,8 +1869,18 @@ def _last_replayed_display(value: object) -> str:
     return datetime.fromtimestamp(float(value), tz=timezone.utc).isoformat()
 
 
-def _status_payload(state_path: str, meta: dict[str, object], graph: Graph) -> dict[str, object]:
+def _infer_index_dim(index: VectorIndex) -> int | None:
+    """Infer vector dimension from any vector in the index."""
+    for vector in index._vectors.values():
+        return len(vector)
+    return None
+
+
+def _status_payload(state_path: str, meta: dict[str, object], graph: Graph, index: VectorIndex) -> dict[str, object]:
     """Build status payload details."""
+    embedder_dim = meta.get("embedder_dim")
+    index_dim = _infer_index_dim(index)
+
     health = measure_health(graph)
     inhibitory_edges = 0
     for source_edges in graph._edges.values():
@@ -1836,7 +1917,8 @@ def _status_payload(state_path: str, meta: dict[str, object], graph: Graph) -> d
         "decay_half_life": decay_value,
         "last_replayed": _last_replayed_display(meta.get("last_replayed_ts")),
         "embedder_name": meta.get("embedder_name", "unknown"),
-        "embedder_dim": meta.get("embedder_dim", "unknown"),
+        "embedder_dim": embedder_dim if isinstance(embedder_dim, int) else "unknown",
+        "index_dim": index_dim,
         "daemon_running": daemon_running,
         "daemon_socket_path": daemon_socket,
     }
@@ -3503,8 +3585,8 @@ def cmd_status(args: argparse.Namespace) -> int:
     if state_path is None:
         raise SystemExit("--state is required")
 
-    graph, _, meta = load_state(state_path)
-    payload = _status_payload(state_path, meta, graph)
+    graph, index, meta = load_state(state_path)
+    payload = _status_payload(state_path, meta, graph, index)
     if args.json:
         print(json.dumps(payload, indent=2))
         return 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1655,6 +1655,106 @@ def test_cli_build_all_parser_accepts_subcommand() -> None:
     args = parser.parse_args(["build-all"])
     assert args.command == "build-all"
     assert args.parallel_agents == 1
+    assert args.require_local_embedder is False
+
+
+def test_cmd_status_json_includes_embedder_dim_and_index_dim(tmp_path, capsys) -> None:
+    """status --json includes embedder and index dimensions."""
+    state_path = tmp_path / "state.json"
+    _write_state(
+        state_path,
+        index_payload={"a": [0.0, 1.0, 0.0], "b": [1.0, 0.0, 0.0]},
+        meta={"embedder_name": "local:bge-large-en-v1.5", "embedder_dim": 3},
+    )
+    code = main(["status", "--state", str(state_path), "--json"])
+    assert code == 0
+    payload = json.loads(capsys.readouterr().out.strip())
+    assert payload["embedder_dim"] == 3
+    assert payload["index_dim"] == 3
+
+
+def test_build_all_preflight_guard_blocks_dim_mismatch_without_reembed(tmp_path) -> None:
+    """build-all preflight fails when embedder_dim and index_dim mismatch and reembed is disabled."""
+    import openclawbrain.cli as cli_module
+
+    state_path = tmp_path / "state.json"
+    status_before = tmp_path / "status_before.json"
+    state_path.write_text(json.dumps({"nodes": []}), encoding="utf-8")
+    status_before.write_text(
+        json.dumps(
+            {
+                "embedder_name": "local:bge-large-en-v1.5",
+                "embedder_dim": 1536,
+                "index_dim": 1024,
+            }
+        ),
+        encoding="utf-8",
+    )
+    code, message = cli_module._evaluate_build_all_preflight(
+        state_path=str(state_path),
+        status_before_path=str(status_before),
+        reembed=False,
+        require_local_embedder=False,
+    )
+    assert code == 1
+    assert message is not None
+    assert "Re-run with --reembed" in message
+
+
+def test_build_all_preflight_guard_allows_dim_mismatch_with_reembed(tmp_path, capsys) -> None:
+    """build-all preflight continues on mismatch when reembed is enabled."""
+    import openclawbrain.cli as cli_module
+
+    state_path = tmp_path / "state.json"
+    status_before = tmp_path / "status_before.json"
+    state_path.write_text(json.dumps({"nodes": []}), encoding="utf-8")
+    status_before.write_text(
+        json.dumps(
+            {
+                "embedder_name": "local:bge-large-en-v1.5",
+                "embedder_dim": 1536,
+                "index_dim": 1024,
+            }
+        ),
+        encoding="utf-8",
+    )
+    code, message = cli_module._evaluate_build_all_preflight(
+        state_path=str(state_path),
+        status_before_path=str(status_before),
+        reembed=True,
+        require_local_embedder=False,
+    )
+    assert code == 0
+    assert message is None
+    assert "continuing because --reembed is enabled" in capsys.readouterr().out
+
+
+def test_build_all_preflight_guard_blocks_openai_without_reembed_when_local_required(tmp_path) -> None:
+    """build-all local-only preflight fails for openai states when --reembed is disabled."""
+    import openclawbrain.cli as cli_module
+
+    state_path = tmp_path / "state.json"
+    status_before = tmp_path / "status_before.json"
+    state_path.write_text(json.dumps({"nodes": []}), encoding="utf-8")
+    status_before.write_text(
+        json.dumps(
+            {
+                "embedder_name": "openai-text-embedding-3-small",
+                "embedder_dim": 3,
+                "index_dim": 3,
+            }
+        ),
+        encoding="utf-8",
+    )
+    code, message = cli_module._evaluate_build_all_preflight(
+        state_path=str(state_path),
+        status_before_path=str(status_before),
+        reembed=False,
+        require_local_embedder=True,
+    )
+    assert code == 1
+    assert message is not None
+    assert "OpenAI embedder" in message
 
 
 def test_build_all_root_manifest_written_before_agents_run(tmp_path, monkeypatch) -> None:
@@ -1704,7 +1804,22 @@ def test_cmd_build_all_events_jsonl_contains_run_and_agent_events(tmp_path, monk
     )
     _write_state(tmp_path / ".openclawbrain" / "agent-1" / "state.json")
 
-    monkeypatch.setattr(cli_module, "_run_logged_command", lambda *args, **kwargs: 0)
+    def fake_run_logged_command(cmd: list[str], **kwargs) -> int:
+        stdout_path = kwargs.get("stdout_path")
+        if isinstance(stdout_path, Path) and stdout_path.name.endswith("status_before.json"):
+            stdout_path.write_text(
+                json.dumps(
+                    {
+                        "embedder_name": "local:bge-large-en-v1.5",
+                        "embedder_dim": 3,
+                        "index_dim": 3,
+                    }
+                ),
+                encoding="utf-8",
+            )
+        return 0
+
+    monkeypatch.setattr(cli_module, "_run_logged_command", fake_run_logged_command)
     monkeypatch.setattr(cli_module, "_run_logged_replay_command", lambda *args, **kwargs: 0)
 
     events_path = tmp_path / ".openclawbrain" / "scratch" / "events.jsonl"
@@ -1743,11 +1858,26 @@ def test_cli_build_all_forwards_workers_and_llm_model_to_replay_and_records_mani
 
     captured_replay_cmd: list[list[str]] = []
 
+    def fake_run_logged_command(cmd: list[str], **kwargs) -> int:
+        stdout_path = kwargs.get("stdout_path")
+        if isinstance(stdout_path, Path) and stdout_path.name.endswith("status_before.json"):
+            stdout_path.write_text(
+                json.dumps(
+                    {
+                        "embedder_name": "local:bge-large-en-v1.5",
+                        "embedder_dim": 3,
+                        "index_dim": 3,
+                    }
+                ),
+                encoding="utf-8",
+            )
+        return 0
+
     def fake_run_logged_replay_command(cmd: list[str], **kwargs) -> int:
         captured_replay_cmd.append(cmd)
         return 0
 
-    monkeypatch.setattr(cli_module, "_run_logged_command", lambda *args, **kwargs: 0)
+    monkeypatch.setattr(cli_module, "_run_logged_command", fake_run_logged_command)
     monkeypatch.setattr(cli_module, "_run_logged_replay_command", fake_run_logged_replay_command)
 
     code = cli_module.main(


### PR DESCRIPTION
Guard against embedder/index dimension mismatches (prevents pelican-style failures).

- `status --json` now includes `embedder_dim` and inferred `index_dim`.
- build-all preflight detects mismatched dims and:
  - proceeds if reembed enabled
  - fails fast with actionable message if reembed disabled
- Adds `build-all --require-local-embedder` option.
- Docs + tests included.

Tests: pytest
