### PR TITLE
docs: make OpenClaw integration guide production-ready

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,45 +30,17 @@ OpenClawBrain is designed to be the memory layer for **OpenClaw agents**.
 - Guide: **[docs/openclaw-integration.md](docs/openclaw-integration.md)**
 - Recommended OpenClaw hook install: **[docs/openclawbrain-openclaw-hooks.md](docs/openclawbrain-openclaw-hooks.md)**
 
-Quickstart (OpenClaw users):
+### Brain-first OpenClaw integration (recommended)
+
+Enable brain-backed context injection with zero AGENTS wiring. If you don’t have a brain yet, follow **[docs/openclaw-integration.md](docs/openclaw-integration.md)**.
+
+5-minute quickstart (daemon + hook install/enable + gateway restart):
 
 ```bash
-pip install openclawbrain
-openclawbrain init --workspace ~/.openclaw/workspace --output ~/.openclawbrain/main
-openclawbrain serve start --state ~/.openclawbrain/main/state.json
-```
-
-Production Deployment (socket):
-
-Use LaunchAgent/systemd to keep the socket server running:
-
-```bash
-openclawbrain serve start --state ~/.openclawbrain/main/state.json
-```
-
-macOS (`~/Library/LaunchAgents/com.openclawbrain.daemon.plist`):
-
-```xml
-<key>ProgramArguments</key>
-<array>
-  <string>/usr/bin/env</string>
-  <string>openclawbrain</string>
-  <string>serve</string>
-  <string>start</string>
-  <string>--state</string>
-  <string>/Users/YOU/.openclawbrain/main/state.json</string>
-</array>
-```
-
-Linux (`/etc/systemd/system/openclawbrain-daemon.service`):
-
-```ini
-[Service]
-ExecStart=/usr/bin/env openclawbrain serve start --state /home/YOUR_USER/.openclawbrain/main/state.json
-```
-
-```bash
-python3 -m openclawbrain.socket_client --socket ~/.openclawbrain/main/daemon.sock --method health --params "{}"
+openclawbrain serve --state ~/.openclawbrain/main/state.json
+openclaw hooks install /path/to/openclawbrain/integrations/openclaw/hooks/openclawbrain-context-injector
+openclaw hooks enable openclawbrain-context-injector
+openclaw gateway restart
 ```
 
 OpenClaw adapter query example with runtime routing (`route_mode=edge+sim`):

--- a/docs/new-agent-sop.md
+++ b/docs/new-agent-sop.md
@@ -199,7 +199,9 @@ python3 -m openclawbrain.ops.audit_secret_leaks \
   --strict
 ```
 
-## F) Pin the query command in workspace `AGENTS.md`
+## F) Pin the query command in workspace `AGENTS.md` (legacy/optional)
+
+If you are using the recommended OpenClaw hook integration, you can skip this section.
 
 Use packaged CLI module invocation (no `~/openclawbrain` clone required):
 

--- a/docs/openclaw-integration-troubleshooting.md
+++ b/docs/openclaw-integration-troubleshooting.md
@@ -1,0 +1,70 @@
+# OpenClaw Integration Troubleshooting
+
+This page covers the most common integration failures and quick fixes.
+
+## 1) Hook not discovered (wrong path or no restart)
+
+**Symptom:** `openclaw hooks info openclawbrain-context-injector` says not found.
+
+**Fix:**
+
+```bash
+openclaw hooks install /path/to/openclawbrain/integrations/openclaw/hooks/openclawbrain-context-injector
+openclaw gateway restart
+openclaw hooks list
+```
+
+Make sure the hook exists under `~/.openclaw/hooks/` after install.
+
+## 2) Hook discovered but not eligible
+
+**Symptom:** `openclaw hooks check` shows the hook as not eligible.
+
+**Likely causes:** missing `python3`, or missing OpenClaw config `workspace.dir`.
+
+**Fix:**
+
+- Install `python3` so the hook can execute.
+- Ensure your OpenClaw config sets `workspace.dir` (the hook requires it).
+- Re-run `openclaw hooks check` after fixing requirements.
+
+## 3) Daemon not running / `daemon.sock` missing
+
+**Symptom:** No context is injected and `~/.openclawbrain/main/daemon.sock` does not exist.
+
+**Fix:**
+
+```bash
+openclawbrain serve --state ~/.openclawbrain/main/state.json
+```
+
+If you prefer the explicit subcommand, use:
+
+```bash
+openclawbrain serve start --state ~/.openclawbrain/main/state.json
+```
+
+## 4) Slow query -> hook times out (2s) and fails open
+
+**Symptom:** OpenClaw answers as usual, but no brain context appears. This can happen when the hook exceeds its 2s timeout.
+
+**Fix:**
+
+- Ensure the daemon is running (so queries are hot).
+- Reduce brain size or trim context budget if needed.
+- Check that the state file is local (not on a slow network mount).
+
+## 5) Slash commands are skipped
+
+**Symptom:** Messages starting with `/` never receive brain context.
+
+**Explanation:** This is by design. The hook skips slash commands.
+
+## 6) How to tell if injection is happening
+
+**Simple test:**
+
+1. Send a normal (non-slash) message that includes “remember”.
+2. Look for a `[BRAIN_CONTEXT ...]` block at the top of `bodyForAgent`.
+
+If your OpenClaw deployment logs prompts, search gateway logs for `[BRAIN_CONTEXT`. If you do not log prompts, temporarily enable request logging and repeat the test.

--- a/docs/openclaw-integration.md
+++ b/docs/openclaw-integration.md
@@ -12,8 +12,102 @@ If you’re already running OpenClaw, this guide shows the fastest path to:
 
 - Build a brain (`state.json`) from your OpenClaw workspace
 - Run the **persistent daemon service** (`openclawbrain serve`) so queries stay fast
-- Wire your OpenClaw agent’s **AGENTS.md** to query → respond → learn
-- Operate it like a runbook: launchd/systemd, maintenance cron, troubleshooting
+- Enable **brain-first** OpenClaw integration (no AGENTS wiring required)
+- Verify it’s working, and roll back cleanly
+
+---
+
+## Brain-first OpenClaw integration (recommended)
+
+Brain-first mode injects OpenClawBrain context automatically at the hook layer. This keeps your existing prompts intact and avoids manual AGENTS wiring.
+
+**BEFORE (no hook):**
+- OpenClaw uses only its base prompt (`AGENTS.md`, `SOUL.md`, etc.).
+- You must manually run `query_brain` or wire commands into AGENTS.
+
+**AFTER (hook enabled):**
+- Each non-slash user message gets a `[BRAIN_CONTEXT ...]` block prepended to `bodyForAgent`.
+- Retrieval is automatic and fail-open (if anything breaks, OpenClaw proceeds unchanged).
+- Corrections and recall language get a deeper context budget.
+
+### 5-minute quickstart (copy/paste)
+
+```bash
+openclawbrain serve --state ~/.openclawbrain/main/state.json
+openclaw hooks install /path/to/openclawbrain/integrations/openclaw/hooks/openclawbrain-context-injector
+openclaw hooks enable openclawbrain-context-injector
+openclaw gateway restart
+```
+
+Use `/path/to` as a placeholder for your local `openclawbrain` repo path.
+
+### Step-by-step install (managed)
+
+1. Build a brain if you do not already have one:
+
+```bash
+openclawbrain init --workspace ~/.openclaw/workspace --output ~/.openclawbrain/main
+```
+
+2. Start the daemon (hot socket):
+
+```bash
+openclawbrain serve --state ~/.openclawbrain/main/state.json
+```
+
+3. Install + enable the hook:
+
+```bash
+openclaw hooks install /path/to/openclawbrain/integrations/openclaw/hooks/openclawbrain-context-injector
+openclaw hooks enable openclawbrain-context-injector
+```
+
+4. Restart the gateway so hooks load:
+
+```bash
+openclaw gateway restart
+```
+
+### Verification (expect “Ready”)
+
+```bash
+openclaw hooks check
+openclaw hooks list
+openclaw hooks info openclawbrain-context-injector
+```
+
+**“Ready”** means the hook is discovered, eligible, and enabled for the gateway (no missing requirements like `python3` or `workspace.dir`).
+
+### Rollback (clean and fast)
+
+```bash
+openclaw hooks disable openclawbrain-context-injector
+openclaw gateway restart
+```
+
+If you want to stop the daemon too:
+
+```bash
+openclawbrain serve stop --state ~/.openclawbrain/main/state.json
+```
+
+### Why the gateway restart is required
+
+OpenClaw loads hook manifests on gateway start. Restarting ensures the new hook is discovered and activated. This is a normal, quick reload and does not change your agent data.
+
+### Budgets and “remember” behavior
+
+- Default context budget: **12,000** chars.
+- Recall/correction language (for example: “remember”, “last time”, “earlier”, “correction”, “audit”) raises the budget to **20,000** chars.
+
+### Security defaults and guardrails
+
+- **Exclude paths**: use `--exclude-paths` with manual wiring (or a custom hook) to drop sensitive directories from retrieval.
+- **Redaction**: prompt context is redacted for common secret patterns before injection.
+- **Data-only delimiter**: injected context is marked as `[BRAIN_CONTEXT ...]` (context, not instructions).
+- **Fail-open**: if the hook can’t run or times out, OpenClaw continues with the original prompt.
+
+Troubleshooting guide: [docs/openclaw-integration-troubleshooting.md](openclaw-integration-troubleshooting.md)
 
 ---
 
@@ -159,7 +253,7 @@ Notes:
 
 ---
 
-## Step 2 — Install the recommended OpenClaw hook (opt-in)
+## Step 2 — Install the recommended OpenClaw hook (if not already done)
 
 The recommended path is the OpenClaw hook pack:
 
@@ -184,7 +278,7 @@ The hook behavior is:
 
 - Keep OpenClaw working as-is (fail-open).
 - Append a retrieved `[BRAIN_CONTEXT ...]` block to `bodyForAgent` for normal messages.
-- Use 12,000-char budget by default, 20,000-char budget for recall/correction language.
+- Use 12,000-char budget by default, 20,000-char budget for recall/correction language (e.g., “remember”, “last time”, “correction”).
 - Keep `--exclude-bootstrap` and `--redact` enabled.
 - Skip slash commands.
 
@@ -195,10 +289,10 @@ What changes when enabled:
 - Retrieval is automatic each qualifying message (no manual copy/paste per-agent edits required).
 - Failures are non-blocking: if query context cannot be loaded within 2s, OpenClaw proceeds with the original message.
 
-## Step 2 fallback — manual AGENTS.md integration
+## Step 2 fallback — manual AGENTS.md integration (legacy/optional)
 
-If you do not want hook-based integration, keep the old manual path in `AGENTS.md`.
-This still works and remains fully supported:
+If you do not want hook-based integration, you can keep the legacy manual path in `AGENTS.md`.
+This still works and remains fully supported, but is not required for brain-first mode:
 
 ```bash
 python3 -m openclawbrain.openclaw_adapter.query_brain ~/.openclawbrain/AGENT/state.json '<summary of user message>' --chat-id '<chat_id from inbound metadata>' --format prompt --exclude-bootstrap --max-prompt-context-chars 12000

--- a/docs/openclawbrain-openclaw-hooks.md
+++ b/docs/openclawbrain-openclaw-hooks.md
@@ -15,7 +15,7 @@ When `openclawbrain-context-injector` is enabled on `message:preprocessed`:
 - The injected block is marked as prompt data (`[BRAIN_CONTEXT ...]`) and is intended to be used as context, not instruction text.
 - You keep normal OpenClaw flow and fall back to standard behavior if retrieval fails.
 
-## Install and enable
+## Install and enable (recommended)
 
 ```bash
 openclaw hooks install /path/to/openclawbrain/integrations/openclaw/hooks/openclawbrain-context-injector
@@ -25,10 +25,23 @@ openclaw gateway restart
 
 Note: `--link` is dev-only. If you use it, set `hooks.internal.load.extraDirs` to the parent hooks directory (the directory that contains `openclawbrain-context-injector/`), then restart the gateway.
 
+Why the gateway restart? OpenClaw loads hook manifests at gateway start, so a restart is required for discovery.
+
+## Verify
+
+```bash
+openclaw hooks check
+openclaw hooks list
+openclaw hooks info openclawbrain-context-injector
+```
+
+“Ready” means the hook is discovered, eligible, and enabled (no missing requirements such as `python3` or `workspace.dir`).
+
 To disable:
 
 ```bash
 openclaw hooks disable openclawbrain-context-injector
+openclaw gateway restart
 ```
 
 Troubleshooting:
@@ -44,6 +57,8 @@ Troubleshooting:
 
 - `--exclude-bootstrap` is enabled so AGENTS/USER/memory bootstrap files are not re-injected from the brain context.
 - `--redact` is enabled so common token-like patterns are masked before injection.
-- Prompt data is data-only context (not instruction text).
-- Keep secrets out of user-visible prompts and training data; redaction is conservative, not perfect.
+- Prompt data is marked as data-only context (`[BRAIN_CONTEXT ...]`), not instruction text.
+- Fail-open: if the hook errors or times out, OpenClaw continues unchanged.
 - Use OpenClaw `chat_id` consistently to preserve per-turn firing logs for later `capture_feedback`.
+
+Troubleshooting: [docs/openclaw-integration-troubleshooting.md](openclaw-integration-troubleshooting.md)

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -140,9 +140,8 @@ Use this when building your query handler:
   - `-1.0` for bad output
 - Persist feedback with `openclawbrain learn`
 
-For an AGENTS.md drop-in hook, use:
-
-`examples/openclaw_adapter/agents_hook.md`
+For a legacy AGENTS.md drop-in hook, use `examples/openclaw_adapter/agents_hook.md`.
+For the recommended hook-based integration, see `docs/openclaw-integration.md`.
 
 ## Step 3: Wire up the slow loop (maintenance)
 


### PR DESCRIPTION
## Summary
- add brain-first OpenClaw integration quickstart and verification/rollback guidance
- make docs/openclaw-integration.md the canonical managed install guide with BEFORE/AFTER, budgets, security defaults, and troubleshooting link
- add troubleshooting guide for common hook/daemon failure modes
- align hook docs and related references to reduce AGENTS wiring ambiguity

## Checklist
- [ ] Docs updated and copy/paste commands verified
- [ ] No code or behavior changes
- [ ] Troubleshooting coverage added
