### PR TITLE
Docs: Always-on learning as default OpenClawBrain experience

### DIFF
--- a/docs/openclaw-integration.md
+++ b/docs/openclaw-integration.md
@@ -123,6 +123,12 @@ Instead of “top-k similarity every time”, it learns which context routes act
 - You can add knowledge without rebuilding the whole index (`inject --type TEACHING`).
 - With the socket server, the brain stays **hot in memory**, avoiding per-call reload overhead.
 
+**Always-on learning (recommended default experience):**
+
+- Clear user **corrections** and **teachings** should be captured automatically in the same turn via `capture_feedback`.
+- Operators should *not* need to say “inject teaching” / “log this” / special phrasing.
+- Use `--message-id` or `--dedup-key` so retries cannot double-inject.
+
 OpenClawBrain stores everything in a single portable file:
 
 - `state.json` — graph + embeddings + metadata

--- a/docs/openclawbrain-openclaw-hooks.md
+++ b/docs/openclawbrain-openclaw-hooks.md
@@ -15,6 +15,16 @@ When `openclawbrain-context-injector` is enabled on `message:preprocessed`:
 - The injected block is marked as prompt data (`[BRAIN_CONTEXT ...]`) and is intended to be used as context, not instruction text.
 - You keep normal OpenClaw flow and fall back to standard behavior if retrieval fails.
 
+## Always-on learning (recommended default experience)
+
+Brain-first context injection is only half the loop. The other half is **same-turn learning**:
+
+- When a user clearly corrects the agent, call `capture_feedback --kind CORRECTION` in the same turn.
+- When a user teaches a durable rule/fact, call `capture_feedback --kind TEACHING`.
+- Use `--message-id` or `--dedup-key` so retries cannot double-inject.
+
+OpenClawBrain provides the adapter CLIs; your OpenClaw agent prompt/policy should make this automatic so operators do not need to say “inject teaching” or “log this.”
+
 ## Install and enable (recommended)
 
 ```bash


### PR DESCRIPTION
Adds explicit guidance that clear user corrections/teachings should be captured automatically via capture_feedback (no operator 'inject teaching' phrasing). Updates OpenClaw integration + OpenClaw hook-pack docs.