### PR TITLE
docs: raise brain-first context budgets (20k/80k)

### DIFF
--- a/docs/new-agent-sop.md
+++ b/docs/new-agent-sop.md
@@ -206,7 +206,7 @@ If you are using the recommended OpenClaw hook integration, you can skip this se
 Use packaged CLI module invocation (no `~/openclawbrain` clone required):
 
 ```bash
-python3 -m openclawbrain.openclaw_adapter.query_brain ~/.openclawbrain/<agentId>/state.json '<summary>' --chat-id '<chat_id>' --format prompt --exclude-bootstrap --max-prompt-context-chars 12000
+python3 -m openclawbrain.openclaw_adapter.query_brain ~/.openclawbrain/<agentId>/state.json '<summary>' --chat-id '<chat_id>' --format prompt --exclude-bootstrap --max-prompt-context-chars 20000
 ```
 
 Learn command (no fired node IDs in prompt payload):

--- a/docs/openclaw-integration.md
+++ b/docs/openclaw-integration.md
@@ -10,6 +10,7 @@ OpenClaw hook pack (recommended): [docs/openclawbrain-openclaw-hooks.md](opencla
 Glossary: [docs/glossary.md](glossary.md)
 State directory lifecycle: [docs/state-directory.md](state-directory.md)
 Guardrails and rollback: [docs/guardrails-and-rollback.md](guardrails-and-rollback.md)
+Benchmarks: [docs/benchmarks.md](benchmarks.md)
 End-to-end trace: [docs/end-to-end-trace.md](end-to-end-trace.md)
 
 If you’re already running OpenClaw, this guide shows the fastest path to:
@@ -37,9 +38,10 @@ Brain-first mode injects OpenClawBrain context automatically at the hook layer. 
 ### 5-minute quickstart (copy/paste)
 
 ```bash
-openclawbrain serve --state ~/.openclawbrain/main/state.json
+openclawbrain serve install --state ~/.openclawbrain/main/state.json
 openclaw hooks install /path/to/openclawbrain/integrations/openclaw/hooks/openclawbrain-context-injector
 openclaw hooks enable openclawbrain-context-injector
+openclawbrain loop install --state ~/.openclawbrain/main/state.json
 openclaw gateway restart
 ```
 
@@ -56,8 +58,11 @@ openclawbrain init --workspace ~/.openclaw/workspace --output ~/.openclawbrain/m
 2. Start the daemon (hot socket):
 
 ```bash
-openclawbrain serve --state ~/.openclawbrain/main/state.json
+openclawbrain serve install --state ~/.openclawbrain/main/state.json
 ```
+
+macOS launchd is the default. For Linux, use `openclawbrain serve --systemd` to print a unit template.
+For a foreground daemon, run `openclawbrain serve start --state ~/.openclawbrain/main/state.json`.
 
 3. Install + enable the hook:
 
@@ -66,7 +71,19 @@ openclaw hooks install /path/to/openclawbrain/integrations/openclaw/hooks/opencl
 openclaw hooks enable openclawbrain-context-injector
 ```
 
-4. Restart the gateway so hooks load:
+4. Install the always-learning loop (recommended default):
+
+```bash
+openclawbrain loop install --state ~/.openclawbrain/main/state.json
+```
+
+On Linux/systemd hosts, run `openclawbrain loop --systemd` to print unit/timer templates.
+
+Default schedule:
+- Hourly cheap job: edges-only replay (LLM-free)
+- Nightly heavier job: full replay (fast-learning + harvest) + maintenance
+
+5. Restart the gateway so hooks load:
 
 ```bash
 openclaw gateway restart
@@ -95,14 +112,33 @@ If you want to stop the daemon too:
 openclawbrain serve stop --state ~/.openclawbrain/main/state.json
 ```
 
+If you want to stop the loop too:
+
+```bash
+openclawbrain loop uninstall --state ~/.openclawbrain/main/state.json
+```
+
 ### Why the gateway restart is required
 
 OpenClaw loads hook manifests on gateway start. Restarting ensures the new hook is discovered and activated. This is a normal, quick reload and does not change your agent data.
 
 ### Budgets and “remember” behavior
 
-- Default context budget: **12,000** chars.
-- Recall/correction language (for example: “remember”, “last time”, “earlier”, “correction”, “audit”) raises the budget to **20,000** chars.
+- Default context budget: **20,000** chars.
+- Recall/correction language (for example: “remember”, “last time”, “earlier”, “correction”, “audit”) raises the budget to **80,000** chars.
+
+### Context budget slices (why tool caps matter)
+
+Context budgets are shared across multiple prompt slices, so comparisons must cap tool outputs as well as brain context.
+
+| Slice | What it includes | Why it matters |
+| --- | --- | --- |
+| System/boot | AGENTS/SOUL/USER/TOOLS/bootstrap files loaded by OpenClaw | These are fixed and already present; avoid re-injecting them. |
+| Transcript | Recent user/assistant turns from OpenClaw | Grows quickly; can crowd out retrieval if left unchecked. |
+| Tool outputs | `tool_result` payloads, logs, JSON blobs | Large tool payloads can dwarf brain context if not capped. |
+| Brain context | `[BRAIN_CONTEXT ...]` from OpenClawBrain | This is the budget you tune for recall depth. |
+
+If you raise brain budgets without capping tool outputs, the prompt can still be dominated by tools. Always keep `--tool-result-max-chars` (or equivalent OpenClaw limits) aligned with your context target.
 
 ### Security defaults and guardrails
 
@@ -112,6 +148,8 @@ OpenClaw loads hook manifests on gateway start. Restarting ensures the new hook 
 - **Fail-open**: if the hook can’t run or times out, OpenClaw continues with the original prompt.
 
 Troubleshooting guide: [docs/openclaw-integration-troubleshooting.md](openclaw-integration-troubleshooting.md)
+Guardrails and rollback: [docs/guardrails-and-rollback.md](guardrails-and-rollback.md)
+Benchmarks: [docs/benchmarks.md](benchmarks.md)
 
 ---
 
@@ -282,7 +320,7 @@ The hook behavior is:
 
 - Keep OpenClaw working as-is (fail-open).
 - Append a retrieved `[BRAIN_CONTEXT ...]` block to `bodyForAgent` for normal messages.
-- Use 12,000-char budget by default, 20,000-char budget for recall/correction language (e.g., “remember”, “last time”, “correction”).
+- Use 20,000-char budget by default, 80,000-char budget for recall/correction language (e.g., “remember”, “last time”, “correction”).
 - Keep `--exclude-bootstrap` and `--redact` enabled.
 - Skip slash commands.
 
@@ -299,7 +337,7 @@ If you do not want hook-based integration, you can keep the legacy manual path i
 This still works and remains fully supported, but is not required for brain-first mode:
 
 ```bash
-python3 -m openclawbrain.openclaw_adapter.query_brain ~/.openclawbrain/AGENT/state.json '<summary of user message>' --chat-id '<chat_id from inbound metadata>' --format prompt --exclude-bootstrap --max-prompt-context-chars 12000
+python3 -m openclawbrain.openclaw_adapter.query_brain ~/.openclawbrain/AGENT/state.json '<summary of user message>' --chat-id '<chat_id from inbound metadata>' --format prompt --exclude-bootstrap --max-prompt-context-chars 20000
 ```
 
 For same-turn learning:
@@ -338,7 +376,7 @@ Use prompt format and exclusions to keep context “tight and right”:
 
 - Prefer `--format prompt` so only `[BRAIN_CONTEXT]` is appended to the model prompt.
 - Keep `--exclude-bootstrap` enabled (default in the adapter).
-- Start with `--max-prompt-context-chars 8000` to `12000`; only increase when needed.
+- Start with `--max-prompt-context-chars 20000` when matching hook defaults; allow up to `80000` for deep recall only when needed.
 - Use `--exclude-recent-memory ...` only for explicit daily notes already injected into the same OpenClaw turn.
 
 This aligns retrieval output with OpenClawBrain’s context-efficiency goal: preserve high-value retrieved nodes while minimizing repeated bootstrap content.
@@ -495,7 +533,7 @@ sudo systemctl status openclawbrain-daemon --no-pager
 
 ---
 
-## Step 4 — Wire up the learning loop (query → feedback → learn)
+## Step 6 — Wire up the learning loop (query → feedback → learn)
 
 In OpenClaw terms, you want a stable ritual:
 
@@ -527,6 +565,8 @@ OpenClawBrain ships an OpenClaw adapter that logs fired IDs per chat.
 - Correction: `correction` daemon method (`method:"correction"`) penalizes recent fired IDs *and* injects a correction node
 
 That’s the ergonomic way to do “same-turn correction” inside OpenClaw.
+
+If you use the hook pack, user messages starting with `Correction:`, `Fix:`, `Teaching:`, or `Note:` automatically call `capture_feedback` in a fail-open way (deduped by message-id when available).
 
 For full-history rebuilds, replay your sessions. Default mode is `full` and the recommended operator experience (the "best brain") is the full, bells-and-whistles pipeline.
 

--- a/docs/openclawbrain-openclaw-hooks.md
+++ b/docs/openclawbrain-openclaw-hooks.md
@@ -14,6 +14,7 @@ When `openclawbrain-context-injector` is enabled on `message:preprocessed`:
 - The returned prompt block is prepended to `event.context.bodyForAgent`.
 - The injected block is marked as prompt data (`[BRAIN_CONTEXT ...]`) and is intended to be used as context, not instruction text.
 - You keep normal OpenClaw flow and fall back to standard behavior if retrieval fails.
+- If a user message starts with `Correction:`, `Fix:`, `Teaching:`, or `Note:`, the hook best-effort calls `capture_feedback` (fail-open).
 
 ## Install and enable (recommended)
 
@@ -50,8 +51,9 @@ Troubleshooting:
 
 ## Runtime context budget
 
-- **Default budget**: 12,000 chars.
-- **Recall/correction messages** (for example: `remember`, `last time`, `earlier`, `we decided`, `correction`, `audit`) use **20,000** chars.
+- **Default budget**: 20,000 chars.
+- **Recall/correction messages** (for example: `remember`, `last time`, `earlier`, `we decided`, `correction`, `audit`) use **80,000** chars.
+- Budgets are tunable if you maintain a custom hook or wrapper.
 
 ## Security notes
 

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -258,7 +258,7 @@ For OpenClaw integration, keep prompts token-tight and avoid re-sending files Op
 - Use `python3 -m openclawbrain.openclaw_adapter.query_brain ... --format prompt`.
 - Learn/inject in one canonical call with `python3 -m openclawbrain.openclaw_adapter.capture_feedback --state ... --chat-id ... --kind ... --content ... [--outcome ...] [--dedup-key ...]`.
 - Keep `--exclude-bootstrap` enabled (adapter default) so `AGENTS.md`, `SOUL.md`, `USER.md`, `MEMORY.md`, and `active-tasks.md` are not duplicated in `prompt_context`.
-- Start with `--max-prompt-context-chars 8000` to `12000`; increase only when retrieval quality requires it.
+- For hook-based brain-first, start with `--max-prompt-context-chars 20000`, and allow deep recall up to `80000` only when retrieval quality requires it (watch for attention dilution).
 - Use `--exclude-recent-memory <today> <yesterday>` only when those daily notes are already loaded elsewhere in the same turn.
 
 This preserves deterministic `prompt_context` while cutting duplicate tokens, matching the project’s “context efficiency/compression” operating model.

--- a/integrations/openclaw/hooks/openclawbrain-context-injector/handler.ts
+++ b/integrations/openclaw/hooks/openclawbrain-context-injector/handler.ts
@@ -2,6 +2,7 @@ import { execFile } from "node:child_process";
 import { promises as fs } from "node:fs";
 import { homedir } from "node:os";
 import * as path from "node:path";
+import { createHash } from "node:crypto";
 import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
@@ -16,6 +17,16 @@ const RECALL_OR_CORRECTION_KEYWORDS = [
   "audit",
 ];
 
+const FEEDBACK_PREFIXES: Record<
+  string,
+  { kind: "CORRECTION" | "TEACHING"; outcome: number | null }
+> = {
+  correction: { kind: "CORRECTION", outcome: -1.0 },
+  fix: { kind: "CORRECTION", outcome: -1.0 },
+  teaching: { kind: "TEACHING", outcome: 0.0 },
+  note: { kind: "TEACHING", outcome: 0.0 },
+};
+
 function normalizeText(value: unknown): string {
   return typeof value === "string" ? value.trim() : "";
 }
@@ -27,6 +38,25 @@ function isSlashCommand(message: string): boolean {
 function keywordIncreasedBudget(message: string): boolean {
   const haystack = message.toLowerCase();
   return RECALL_OR_CORRECTION_KEYWORDS.some((keyword) => haystack.includes(keyword));
+}
+
+function parseFeedbackDirective(
+  message: string,
+): { kind: "CORRECTION" | "TEACHING"; content: string; outcome: number | null } | null {
+  const match = message.match(/^\s*(Correction|Fix|Teaching|Note):\s*(.*)$/i);
+  if (!match) {
+    return null;
+  }
+  const prefix = match[1]?.toLowerCase();
+  const content = normalizeText(match[2]);
+  if (!prefix || !content) {
+    return null;
+  }
+  const entry = FEEDBACK_PREFIXES[prefix];
+  if (!entry) {
+    return null;
+  }
+  return { kind: entry.kind, content, outcome: entry.outcome };
 }
 
 function resolveAgentId(context: any): string {
@@ -44,6 +74,27 @@ function resolveAgentId(context: any): string {
   }
 
   return "main";
+}
+
+function resolveMessageId(context: any, event: any): string {
+  return (
+    normalizeText(context?.messageId) ||
+    normalizeText(context?.message?.id) ||
+    normalizeText(context?.message?.messageId) ||
+    normalizeText(event?.messageId) ||
+    ""
+  );
+}
+
+function deriveDedupKey(chatId: string, message: string, messageId: string): { dedupKey: string | null; messageId: string | null } {
+  if (messageId) {
+    return { dedupKey: null, messageId };
+  }
+  if (!chatId) {
+    return { dedupKey: null, messageId: null };
+  }
+  const hash = createHash("sha256").update(message).digest("hex");
+  return { dedupKey: `${chatId}:${hash}`, messageId: null };
 }
 
 async function runQueryBrain(
@@ -85,6 +136,45 @@ async function runQueryBrain(
   }
 }
 
+function runCaptureFeedback(
+  statePath: string,
+  chatId: string,
+  directive: { kind: "CORRECTION" | "TEACHING"; content: string; outcome: number | null },
+  dedupKey: string | null,
+  messageId: string | null,
+): void {
+  if (!chatId) {
+    return;
+  }
+  const args = [
+    "-m",
+    "openclawbrain.openclaw_adapter.capture_feedback",
+    "--state",
+    statePath,
+    "--chat-id",
+    chatId,
+    "--kind",
+    directive.kind,
+    "--content",
+    directive.content,
+    "--lookback",
+    "1",
+  ];
+  if (directive.outcome !== null) {
+    args.push("--outcome", String(directive.outcome));
+  }
+  if (messageId) {
+    args.push("--message-id", messageId);
+  } else if (dedupKey) {
+    args.push("--dedup-key", dedupKey);
+  }
+
+  void execFileAsync("python3", args, {
+    timeout: 1000,
+    maxBuffer: 128 * 1024,
+  }).catch(() => undefined);
+}
+
 export default async function handler(event: any): Promise<any> {
   const context = event?.context;
   const message = normalizeText(context?.message ?? event?.message);
@@ -94,11 +184,17 @@ export default async function handler(event: any): Promise<any> {
 
   const agentId = resolveAgentId(context);
   const statePath = path.join(homedir(), ".openclawbrain", agentId, "state.json");
-  const budget = keywordIncreasedBudget(message) ? 20000 : 12000;
+  const budget = keywordIncreasedBudget(message) ? 80000 : 20000;
   const chatId =
     normalizeText(context?.channelId) && normalizeText(context?.conversationId)
       ? `${normalizeText(context.channelId)}:${normalizeText(context.conversationId)}`
       : normalizeText(context?.chatId) || normalizeText(context?.messageId);
+  const directive = parseFeedbackDirective(message);
+  if (directive) {
+    const rawMessageId = resolveMessageId(context, event);
+    const dedup = deriveDedupKey(chatId, message, rawMessageId);
+    runCaptureFeedback(statePath, chatId, directive, dedup.dedupKey, dedup.messageId);
+  }
 
   const promptContext = await runQueryBrain(statePath, message, chatId, budget);
   if (!promptContext) {


### PR DESCRIPTION
## Summary
- raise hook budgets to 20k default / 80k deep recall
- update hook + integration docs and examples
- add context budget slice table to explain tool-output caps

## Testing
- not run (docs + hook change only)