### PR TITLE
fix(loop): pause serve releases state lock

### DIFF
--- a/openclawbrain/cli.py
+++ b/openclawbrain/cli.py
@@ -11,6 +11,7 @@ import hashlib
 import time
 import warnings
 import threading
+import signal
 from datetime import datetime, timezone, timedelta
 import sys
 import tempfile
@@ -503,6 +504,42 @@ def _wait_for_state_unlock(state_path: Path, timeout_seconds: int) -> bool:
 def _state_lock_available(state_path: str | Path) -> bool:
     """Return True if the state write lock is currently available."""
     return _wait_for_state_unlock(Path(state_path).expanduser(), 0)
+
+
+def _read_state_lock_owner(lock_path: Path) -> dict[str, object]:
+    try:
+        payload = json.loads(lock_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _get_state_lock_owner_pid(lock_path: Path) -> int | None:
+    owner = _read_state_lock_owner(lock_path)
+    pid = owner.get("pid")
+    return pid if isinstance(pid, int) else None
+
+
+def _get_process_command(pid: int) -> str | None:
+    try:
+        result = subprocess.run(
+            ["ps", "-p", str(pid), "-o", "command="],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError:
+        return None
+    if result.returncode != 0:
+        return None
+    command = result.stdout.strip()
+    return command or None
+
+
+def _lock_owner_matches(command: str, state_path: str | Path) -> bool:
+    expected_state = f"--state {Path(state_path).expanduser()}"
+    return "openclawbrain daemon" in command and expected_state in command
 
 
 def _run_logged_command(
@@ -1982,12 +2019,19 @@ def _maybe_pause_serve_for_state_lock(
     timeout_seconds: int,
     run_launchctl: Callable[[list[str]], int] | None = None,
     wait_for_unlock: Callable[[Path, int], bool] = _wait_for_state_unlock,
+    get_lock_owner_pid: Callable[[Path], int | None] | None = None,
+    get_process_command: Callable[[int], str | None] | None = None,
     platform: str | None = None,
 ) -> tuple[bool, list[str] | None, str | None]:
     """Attempt to pause launchd-managed serve daemon if state lock is held."""
     if run_launchctl is None:
         run_launchctl = _run_launchctl_returncode
-    if wait_for_unlock(Path(state_path).expanduser(), 0):
+    if get_lock_owner_pid is None:
+        get_lock_owner_pid = _get_state_lock_owner_pid
+    if get_process_command is None:
+        get_process_command = _get_process_command
+    state_path_obj = Path(state_path).expanduser()
+    if wait_for_unlock(state_path_obj, 0):
         return True, None, None
 
     if not pause_when_locked:
@@ -2010,12 +2054,33 @@ def _maybe_pause_serve_for_state_lock(
     if bootout_rc != 0:
         return False, None, "state_lock_held"
 
-    unlocked = wait_for_unlock(Path(state_path).expanduser(), max(0, int(timeout_seconds)))
-    if not unlocked:
+    grace_seconds = min(3, max(0, int(timeout_seconds)))
+    if wait_for_unlock(state_path_obj, grace_seconds):
+        return True, bootstrap_cmd, None
+
+    try:
+        lock_path = lock_path_for_state(state_path_obj)
+        owner_pid = get_lock_owner_pid(lock_path)
+        if owner_pid is None:
+            raise ValueError("state lock owner pid missing")
+        command = get_process_command(owner_pid)
+        if command is None or not _lock_owner_matches(command, state_path_obj):
+            raise ValueError("state lock owner mismatch")
+
+        os.kill(owner_pid, signal.SIGTERM)
+        if wait_for_unlock(state_path_obj, max(0, int(timeout_seconds))):
+            return True, bootstrap_cmd, None
+
+        os.kill(owner_pid, signal.SIGKILL)
+        if wait_for_unlock(state_path_obj, max(0, int(timeout_seconds))):
+            return True, bootstrap_cmd, None
+    except Exception:
         run_launchctl(bootstrap_cmd)
         return False, None, "state_lock_held"
 
-    return True, bootstrap_cmd, None
+    run_launchctl(bootstrap_cmd)
+    return False, None, "state_lock_held"
+
 
 
 def _parse_env_file(env_path: str) -> dict[str, str]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,7 @@ import os
 import sys
 import hashlib
 import plistlib
+import signal
 from io import StringIO
 from pathlib import Path
 
@@ -1009,6 +1010,66 @@ def test_loop_pause_serve_when_locked_uses_launchctl(monkeypatch, tmp_path) -> N
     assert calls[0][:2] == ["launchctl", "bootout"]
     fake_launchctl(resume_cmd)
     assert calls[1][:2] == ["launchctl", "bootstrap"]
+
+
+def test_loop_pause_serve_kills_orphan_daemon(monkeypatch, tmp_path) -> None:
+    """Loop pause-serve should terminate orphan daemon if lock persists after bootout."""
+    state_path = tmp_path / "main" / "state.json"
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(json.dumps({"nodes": []}), encoding="utf-8")
+
+    import openclawbrain.cli as cli_module
+
+    monkeypatch.setattr(cli_module.Path, "home", lambda: tmp_path)
+    plist_path = tmp_path / "Library" / "LaunchAgents" / "com.openclawbrain.main.plist"
+    plist_path.parent.mkdir(parents=True, exist_ok=True)
+    plist_path.write_text("plist", encoding="utf-8")
+
+    calls: list[list[str]] = []
+
+    def fake_launchctl(argv: list[str]) -> int:
+        calls.append(argv)
+        return 0
+
+    wait_results = [False, False, False, True]
+
+    def fake_wait(_path: Path, _timeout_seconds: int) -> bool:
+        return wait_results.pop(0)
+
+    owner_pid = 4242
+
+    def fake_get_pid(lock_path: Path) -> int | None:
+        assert lock_path == lock_path_for_state(state_path)
+        return owner_pid
+
+    def fake_ps(pid: int) -> str | None:
+        assert pid == owner_pid
+        return f"python -m openclawbrain daemon --state {state_path} --other"
+
+    kills: list[tuple[int, int]] = []
+
+    def fake_kill(pid: int, sig: int) -> None:
+        kills.append((pid, sig))
+
+    monkeypatch.setattr(cli_module.os, "kill", fake_kill)
+
+    ready, resume_cmd, reason = cli_module._maybe_pause_serve_for_state_lock(
+        state_path=str(state_path),
+        pause_when_locked=True,
+        timeout_seconds=30,
+        run_launchctl=fake_launchctl,
+        wait_for_unlock=fake_wait,
+        get_lock_owner_pid=fake_get_pid,
+        get_process_command=fake_ps,
+        platform="darwin",
+    )
+
+    assert ready is True
+    assert reason is None
+    assert resume_cmd is not None
+    assert calls[0][:2] == ["launchctl", "bootout"]
+    assert len(calls) == 1
+    assert kills == [(owner_pid, signal.SIGTERM), (owner_pid, signal.SIGKILL)]
 
 
 def test_loop_pause_serve_disabled_skips(monkeypatch, tmp_path) -> None:


### PR DESCRIPTION
Fixes loop/serve lock contention: when launchd bootout leaves an orphan openclawbrain daemon holding the fcntl state lock, the loop now verifies the lock owner pid/command and terminates it (TERM then KILL) so replay/harvest can run. Adds tests.