### PR TITLE
Prefer OpenClaw wrapper for serve launchd

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ OpenClawBrain is designed to be the memory layer for **OpenClaw agents**.
 - Canonical one-page quickstart: **[docs/operator-quickstart.md](docs/operator-quickstart.md)**
 - Guide: **[docs/openclaw-integration.md](docs/openclaw-integration.md)**
 - Recommended OpenClaw hook install: **[docs/openclawbrain-openclaw-hooks.md](docs/openclawbrain-openclaw-hooks.md)**
+- macOS launchd: `openclawbrain serve install` auto-detects the OpenClaw venv wrapper at `~/.openclaw/scripts/openclawbrain-serve` (or `OPENCLAWBRAIN_SERVE_WRAPPER`) so local deps like `fastembed` are available.
 
 ### Brain-first OpenClaw integration (recommended)
 

--- a/openclawbrain/cli.py
+++ b/openclawbrain/cli.py
@@ -2185,6 +2185,26 @@ def _render_launchd_plist(
     return payload_bytes.decode("utf-8")
 
 
+def _resolve_serve_launchd_program_arguments(start_argv: list[str]) -> list[str]:
+    wrapper_override = os.environ.get("OPENCLAWBRAIN_SERVE_WRAPPER")
+    if isinstance(wrapper_override, str) and wrapper_override.strip():
+        wrapper_path = Path(wrapper_override).expanduser()
+        if wrapper_path.is_file():
+            return [str(wrapper_path)] + start_argv
+
+    wrapper_path = Path.home() / ".openclaw" / "scripts" / "openclawbrain-serve"
+    if wrapper_path.is_file():
+        return [str(wrapper_path)] + start_argv
+
+    return [
+        sys.executable,
+        "-m",
+        "openclawbrain.cli",
+        "serve",
+        "start",
+    ] + start_argv
+
+
 def _render_loop_launchd_plist(
     *,
     label: str,
@@ -4427,13 +4447,7 @@ def cmd_serve(args: argparse.Namespace) -> int:
         route_use_relevance=route_use_relevance,
         route_model=route_model,
     )
-    launchd_program_arguments = [
-        sys.executable,
-        "-m",
-        "openclawbrain.cli",
-        "serve",
-        "start",
-    ] + start_argv
+    launchd_program_arguments = _resolve_serve_launchd_program_arguments(start_argv)
 
     if action == "install":
         if sys.platform != "darwin":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -877,6 +877,8 @@ def test_serve_install_dry_run_prints_launchd_plist(monkeypatch, tmp_path, capsy
     import openclawbrain.cli as cli_module
 
     monkeypatch.setattr(cli_module.sys, "platform", "darwin")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("OPENCLAWBRAIN_SERVE_WRAPPER", raising=False)
 
     code = main([
         "serve",
@@ -900,6 +902,42 @@ def test_serve_install_dry_run_prints_launchd_plist(monkeypatch, tmp_path, capsy
     assert program_arguments[2] == "openclawbrain.cli"
     assert program_arguments[3] == "serve"
     assert program_arguments[4] == "start"
+    assert "--state" in program_arguments
+    assert str(state_path) in program_arguments
+
+
+def test_serve_install_uses_openclaw_wrapper(monkeypatch, tmp_path, capsys) -> None:
+    """serve install --dry-run should prefer OpenClaw wrapper when available."""
+    state_path = tmp_path / "main" / "state.json"
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(json.dumps({"nodes": []}), encoding="utf-8")
+
+    wrapper_path = tmp_path / ".openclaw" / "scripts" / "openclawbrain-serve"
+    wrapper_path.parent.mkdir(parents=True, exist_ok=True)
+    wrapper_path.write_text("#!/bin/sh\n", encoding="utf-8")
+
+    import openclawbrain.cli as cli_module
+
+    monkeypatch.setattr(cli_module.sys, "platform", "darwin")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("OPENCLAWBRAIN_SERVE_WRAPPER", raising=False)
+
+    code = main([
+        "serve",
+        "install",
+        "--state",
+        str(state_path),
+        "--socket-path",
+        str(tmp_path / "daemon.sock"),
+        "--dry-run",
+    ])
+    assert code == 0
+
+    payload_xml, _sep, _commands = capsys.readouterr().out.partition("Planned launchctl commands:")
+    payload = plistlib.loads(payload_xml.encode("utf-8"))
+
+    program_arguments = payload["ProgramArguments"]
+    assert program_arguments[0] == str(wrapper_path)
     assert "--state" in program_arguments
     assert str(state_path) in program_arguments
 


### PR DESCRIPTION
Fixes macOS/OpenClaw launchd installs where serve was started with system Python lacking fastembed. When ~/.openclaw/scripts/openclawbrain-serve exists (or OPENCLAWBRAIN_SERVE_WRAPPER is set), serve install/--launchd emits ProgramArguments using that wrapper.