### PR TITLE
Harden hook and loop python resolution

### DIFF
--- a/docs/openclaw-integration.md
+++ b/docs/openclaw-integration.md
@@ -78,11 +78,17 @@ openclaw hooks install /path/to/openclawbrain/integrations/openclaw/hooks/opencl
 openclaw hooks enable openclawbrain-context-injector
 ```
 
+Hook Python resolution:
+- `OPENCLAWBRAIN_HOOK_PYTHON`, then `~/.openclaw/venvs/openclawbrain/bin/python`, then `python3`.
+
 4. Install the always-learning loop (recommended default):
 
 ```bash
 openclawbrain loop install --state ~/.openclawbrain/main/state.json
 ```
+
+Loop Python resolution (launchd/systemd templates):
+- `OPENCLAWBRAIN_LOOP_PYTHON` or `OPENCLAWBRAIN_PYTHON`, then `~/.openclaw/venvs/openclawbrain/bin/python`, then the current `sys.executable`.
 
 On Linux/systemd hosts, run `openclawbrain loop --systemd` to print a unit template.
 When the serve daemon is managed by launchd on macOS, the loop will briefly pause it to acquire the state lock while applying updates (short downtime). Disable with `--no-pause-serve-when-locked` if needed.

--- a/docs/openclawbrain-openclaw-hooks.md
+++ b/docs/openclawbrain-openclaw-hooks.md
@@ -11,6 +11,7 @@ It keeps OpenClaw behavior **fail-open**:
 When `openclawbrain-context-injector` is enabled on `message:preprocessed`:
 
 - The hook runs `query_brain.py` for each non-slash user message.
+- The hook resolves Python in this order: `OPENCLAWBRAIN_HOOK_PYTHON`, `~/.openclaw/venvs/openclawbrain/bin/python`, then `python3`.
 - The returned prompt block is prepended to `event.context.bodyForAgent`.
 - The injected block is marked as prompt data (`[BRAIN_CONTEXT ...]`) and is intended to be used as context, not instruction text.
 - You keep normal OpenClaw flow and fall back to standard behavior if retrieval fails.

--- a/integrations/openclaw/hooks/openclawbrain-context-injector/HOOK.md
+++ b/integrations/openclaw/hooks/openclawbrain-context-injector/HOOK.md
@@ -37,12 +37,16 @@ On each `message:preprocessed` event, the hook does:
 6. Budget:
    - default 20,000 chars.
    - upgrade to 80,000 chars when message indicates recall/correction context.
-7. Invoke:
-   - `python3 -m openclawbrain.openclaw_adapter.query_brain <state-path> <message> --format prompt --exclude-bootstrap --redact --max-prompt-context-chars <budget>`
+7. Resolve Python executable:
+   - `OPENCLAWBRAIN_HOOK_PYTHON` when set.
+   - `~/.openclaw/venvs/openclawbrain/bin/python` when available.
+   - fallback: `python3`.
+8. Invoke:
+   - `<python> -m openclawbrain.openclaw_adapter.query_brain <state-path> <message> --format prompt --exclude-bootstrap --redact --max-prompt-context-chars <budget>`
    - include `--chat-id` when available.
    - command timeout: 2s, fail-open.
-8. On success, prepend returned text to `event.context.bodyForAgent`.
-9. If the user message starts with `Correction:`, `Fix:`, `Teaching:`, or `Note:`, invoke `capture_feedback` (best-effort, fail-open).
+9. On success, prepend returned text to `event.context.bodyForAgent`.
+10. If the user message starts with `Correction:`, `Fix:`, `Teaching:`, or `Note:`, invoke `capture_feedback` (best-effort, fail-open).
    - Use the OpenClaw message id when available.
    - Otherwise compute a deterministic dedup key from `(chat_id, timestamp, text)`.
 

--- a/integrations/openclaw/hooks/openclawbrain-context-injector/handler.ts
+++ b/integrations/openclaw/hooks/openclawbrain-context-injector/handler.ts
@@ -6,6 +6,14 @@ import { createHash } from "node:crypto";
 import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
+const HOOK_VENV_PYTHON = path.join(
+  homedir(),
+  ".openclaw",
+  "venvs",
+  "openclawbrain",
+  "bin",
+  "python",
+);
 
 const RECALL_OR_CORRECTION_KEYWORDS = [
   "remember",
@@ -116,7 +124,21 @@ function deriveDedupKey(
   return { dedupKey: `${chatId}:${hash}`, messageId: null };
 }
 
+async function resolveHookPython(): Promise<string> {
+  const override = normalizeText(process.env.OPENCLAWBRAIN_HOOK_PYTHON);
+  if (override) {
+    return override;
+  }
+  try {
+    await fs.access(HOOK_VENV_PYTHON);
+    return HOOK_VENV_PYTHON;
+  } catch (_error) {
+    return "python3";
+  }
+}
+
 async function runQueryBrain(
+  pythonPath: string,
   statePath: string,
   message: string,
   chatId: string,
@@ -140,7 +162,7 @@ async function runQueryBrain(
   }
 
   try {
-    const { stdout } = await execFileAsync("python3", args, {
+    const { stdout } = await execFileAsync(pythonPath, args, {
       timeout: 2000,
       maxBuffer: 1024 * 1024,
     });
@@ -156,6 +178,7 @@ async function runQueryBrain(
 }
 
 function runCaptureFeedback(
+  pythonPath: string,
   statePath: string,
   chatId: string,
   directive: { kind: "CORRECTION" | "TEACHING"; content: string; outcome: number | null },
@@ -188,7 +211,7 @@ function runCaptureFeedback(
     args.push("--dedup-key", dedupKey);
   }
 
-  void execFileAsync("python3", args, {
+  void execFileAsync(pythonPath, args, {
     timeout: 1000,
     maxBuffer: 128 * 1024,
   }).catch(() => undefined);
@@ -208,15 +231,16 @@ export default async function handler(event: any): Promise<any> {
     normalizeText(context?.channelId) && normalizeText(context?.conversationId)
       ? `${normalizeText(context.channelId)}:${normalizeText(context.conversationId)}`
       : normalizeText(context?.chatId) || normalizeText(context?.messageId);
+  const pythonPath = await resolveHookPython();
   const directive = parseFeedbackDirective(message);
   if (directive) {
     const rawMessageId = resolveMessageId(context, event);
     const timestamp = resolveMessageTimestamp(context, event);
     const dedup = deriveDedupKey(chatId, message, rawMessageId, timestamp);
-    runCaptureFeedback(statePath, chatId, directive, dedup.dedupKey, dedup.messageId);
+    runCaptureFeedback(pythonPath, statePath, chatId, directive, dedup.dedupKey, dedup.messageId);
   }
 
-  const promptContext = await runQueryBrain(statePath, message, chatId, budget);
+  const promptContext = await runQueryBrain(pythonPath, statePath, message, chatId, budget);
   if (!promptContext) {
     return event;
   }

--- a/openclawbrain/cli.py
+++ b/openclawbrain/cli.py
@@ -2205,6 +2205,18 @@ def _resolve_serve_launchd_program_arguments(start_argv: list[str]) -> list[str]
     ] + start_argv
 
 
+def _resolve_loop_python() -> str:
+    override = os.environ.get("OPENCLAWBRAIN_LOOP_PYTHON") or os.environ.get("OPENCLAWBRAIN_PYTHON")
+    if isinstance(override, str) and override.strip():
+        return str(Path(override).expanduser())
+
+    venv_python = Path.home() / ".openclaw" / "venvs" / "openclawbrain" / "bin" / "python"
+    if venv_python.is_file():
+        return str(venv_python)
+
+    return sys.executable
+
+
 def _render_loop_launchd_plist(
     *,
     label: str,
@@ -4822,7 +4834,7 @@ def cmd_loop(args: argparse.Namespace) -> int:
         else Path.home() / ".openclaw" / "agents" / agent_id / "sessions"
     )
 
-    ocb_prefix = [sys.executable, "-m", "openclawbrain.cli"]
+    ocb_prefix = [_resolve_loop_python(), "-m", "openclawbrain.cli"]
 
     def _loop_run_program_arguments() -> list[str]:
         argv = ocb_prefix + [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -958,6 +958,9 @@ def test_loop_install_dry_run_prints_launchd_plist(monkeypatch, tmp_path, capsys
     import openclawbrain.cli as cli_module
 
     monkeypatch.setattr(cli_module.sys, "platform", "darwin")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("OPENCLAWBRAIN_LOOP_PYTHON", raising=False)
+    monkeypatch.delenv("OPENCLAWBRAIN_PYTHON", raising=False)
 
     code = main([
         "loop",
@@ -981,6 +984,37 @@ def test_loop_install_dry_run_prints_launchd_plist(monkeypatch, tmp_path, capsys
     assert str(state_path) in program_arguments
 
 
+def test_loop_install_dry_run_prefers_openclaw_venv_python(monkeypatch, tmp_path, capsys) -> None:
+    """loop install --dry-run should prefer the OpenClaw venv python when present."""
+    state_path = tmp_path / "main" / "state.json"
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(json.dumps({"nodes": []}), encoding="utf-8")
+
+    venv_python = tmp_path / ".openclaw" / "venvs" / "openclawbrain" / "bin" / "python"
+    venv_python.parent.mkdir(parents=True, exist_ok=True)
+    venv_python.write_text("#!/bin/sh\n", encoding="utf-8")
+
+    import openclawbrain.cli as cli_module
+
+    monkeypatch.setattr(cli_module.sys, "platform", "darwin")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("OPENCLAWBRAIN_LOOP_PYTHON", raising=False)
+    monkeypatch.delenv("OPENCLAWBRAIN_PYTHON", raising=False)
+
+    code = main([
+        "loop",
+        "install",
+        "--state",
+        str(state_path),
+        "--dry-run",
+    ])
+    assert code == 0
+
+    payload = _extract_plist_from_output(capsys.readouterr().out)
+    program_arguments = payload["ProgramArguments"]
+    assert program_arguments[0] == str(venv_python)
+
+
 def test_loop_install_dry_run_includes_env_file(monkeypatch, tmp_path, capsys) -> None:
     """loop install --dry-run should include EnvironmentVariables from --env-file."""
     state_path = tmp_path / "main" / "state.json"
@@ -993,6 +1027,9 @@ def test_loop_install_dry_run_includes_env_file(monkeypatch, tmp_path, capsys) -
     import openclawbrain.cli as cli_module
 
     monkeypatch.setattr(cli_module.sys, "platform", "darwin")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("OPENCLAWBRAIN_LOOP_PYTHON", raising=False)
+    monkeypatch.delenv("OPENCLAWBRAIN_PYTHON", raising=False)
 
     code = main([
         "loop",


### PR DESCRIPTION
Hardens OpenClaw hook + loop to prefer OpenClaw venv python (or env overrides) so integration does not depend on system python3 having openclawbrain/fastembed installed. Updates docs and adds loop install test coverage.