### PR TITLE
fix(bench): locomo embedder mode resolution

### DIFF
--- a/benchmarks/gold_standard_eval/state_utils.py
+++ b/benchmarks/gold_standard_eval/state_utils.py
@@ -17,7 +17,27 @@ class EmbedderConfig:
     mode: str
 
 
-def resolve_embedder() -> EmbedderConfig:
+def resolve_embedder(mode: str | None = None) -> EmbedderConfig:
+    cleaned: str | None
+    if mode is None:
+        cleaned = None
+    else:
+        cleaned = str(mode).strip().lower()
+        if not cleaned:
+            cleaned = None
+
+    if cleaned not in (None, "local", "hash"):
+        raise ValueError(f"Unsupported embedder mode: {mode}")
+
+    if cleaned == "hash":
+        fallback = HashEmbedder()
+        return EmbedderConfig(
+            embed_fn=fallback.embed,
+            name=fallback.name,
+            dim=fallback.dim,
+            mode="hash",
+        )
+
     try:
         embedder = LocalEmbedder(model_name=resolve_local_model())
         # Force initialization to detect missing fastembed.

--- a/tests/test_gold_standard_eval_locomo.py
+++ b/tests/test_gold_standard_eval_locomo.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+
+from benchmarks.gold_standard_eval.state_utils import resolve_embedder
+
+
+def test_resolve_embedder_accepts_none_and_hash():
+    embedder_default = resolve_embedder(None)
+    assert embedder_default.mode in ("local", "hash")
+
+    embedder_hash = resolve_embedder("hash")
+    assert embedder_hash.mode == "hash"
+
+
+def test_run_locomo_help():
+    result = subprocess.run(
+        [sys.executable, "-m", "benchmarks.gold_standard_eval.run_locomo", "--help"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0


### PR DESCRIPTION
Fix LoCoMo benchmark: state_utils.resolve_embedder now accepts optional mode (local/hash) to match run_locomo.py. Adds unit tests + --help smoke test.