### PR TITLE
feat: PG STOP + learned-routing hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ Embedding mode defaults to `--embed-model auto`:
 - For OpenAI-based states, `auto` does not call OpenAI; use `--embed-model openai:<model>` explicitly.
 - Use `--embed-model local` to force offline query embeddings.
 
-Routing mode defaults to `--route-mode learned`. `init` writes a default identity-like `route_model.npz` beside `state.json`; if that file is missing or unloadable, daemon query routing gracefully falls back to `edge+sim`.
+Routing mode defaults to `--route-mode learned`. `init` writes a default identity-like `route_model.npz` beside `state.json`; if that file is missing or unloadable, daemon query routing falls back to `edge+sim`, emits a warning on startup, and reports `route_model_present`, `route_mode_configured`, and `route_mode_effective` in `health`.
 
 Protocol:
 
@@ -390,6 +390,8 @@ Enable deterministic query-conditioned habitual routing (no LLM calls on query p
 ```bash
 echo '{"id":"req-2","method":"query","params":{"query":"how to deploy","top_k":4,"route_mode":"edge+sim","route_top_k":5,"route_alpha_sim":0.5,"route_use_relevance":true}}' | openclawbrain daemon --state ~/.openclawbrain/main/state.json
 ```
+
+Optional STOP routing: set `route_enable_stop=true` (default false) and tune `route_stop_margin` (default `0.1`) to allow the router to return `[]` when STOP beats the best candidate by the margin.
 
 ```json
 {"id":"req-1","result":{"fired_nodes":["a"],"context":"...","seeds":[["a",0.96]],"embed_query_ms":1.1,"traverse_ms":2.4,"total_ms":3.5}}
@@ -434,6 +436,7 @@ See `examples/ops/client_example.py` for a Python client and `docs/architecture.
   - `π(j|i)` = action probability from softmax (including STOP)
   - `𝟙[j=a]` = 1 for the taken action, else 0
 - Conservation property: for each source node `i`, outgoing updates sum to zero, so total outgoing mass is preserved.
+- STOP is a learnable per-node logit stored as `node.metadata["stop_weight"]` (default `0.0`) and participates in the softmax/projection updates alongside outgoing edges.
 - Use `apply_outcome_pg` when you want smoother, probability-based updates across alternatives; use `apply_outcome` for a simpler sparse update that only touches traversed edges.
 
 ```python

--- a/docs/brainprofile.md
+++ b/docs/brainprofile.md
@@ -22,6 +22,8 @@ CLI flags are overrides, not source of truth.
 - `OPENCLAWBRAIN_ROUTE_TOP_K`
 - `OPENCLAWBRAIN_ROUTE_ALPHA_SIM`
 - `OPENCLAWBRAIN_ROUTE_USE_RELEVANCE`
+- `OPENCLAWBRAIN_ROUTE_ENABLE_STOP`
+- `OPENCLAWBRAIN_ROUTE_STOP_MARGIN`
 - `OPENCLAWBRAIN_REWARD_SOURCE`
 - `OPENCLAWBRAIN_REWARD_WEIGHT_CORRECTION`
 - `OPENCLAWBRAIN_REWARD_WEIGHT_TEACHING`
@@ -42,7 +44,9 @@ CLI flags are overrides, not source of truth.
     "route_mode": "edge+sim",
     "route_top_k": 8,
     "route_alpha_sim": 0.65,
-    "route_use_relevance": true
+    "route_use_relevance": true,
+    "route_enable_stop": false,
+    "route_stop_margin": 0.1
   },
   "reward": {
     "source": "explicit",

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -22,7 +22,7 @@ Daemon query embedder default is `--embed-model auto`:
 - OpenAI states do not auto-call OpenAI; set `--embed-model openai:<model>` to use OpenAI explicitly.
 - Force offline mode with `--embed-model local`. Legacy `hash-v1` states can force hash query embeddings with `--embed-model hash` (legacy only).
 
-Runtime route-mode default is `learned`. `init` writes a default identity-like `route_model.npz` beside `state.json`; if missing/unloadable, daemon falls back to `edge+sim`.
+Runtime route-mode default is `learned`. `init` writes a default identity-like `route_model.npz` beside `state.json`; if missing/unloadable, daemon falls back to `edge+sim`, logs a warning, and exposes the effective mode in `health`.
 
 ## Initial learning: replay your sessions
 

--- a/docs/ultimate-policy-gradient-routing-math.md
+++ b/docs/ultimate-policy-gradient-routing-math.md
@@ -80,7 +80,7 @@ p_i = \pi_\theta(a=i\mid x,u,\{v_j\}) = \frac{\exp(z_i/T)}{\sum_{j=1}^{m}\exp(z_
 - lower \(T\): sharper policy
 - higher \(T\): smoother policy
 
-**STOP note:** training includes STOP in the softmax action set; the STOP logit is fixed today. Learning a STOP logit is future work.
+**STOP note:** training includes STOP in the softmax action set; the STOP logit is learnable per node via `metadata["stop_weight"]` (default `0.0`).
 
 ## 4) Teacher Labels to Target Distribution \(\mathbf{y}\)
 

--- a/openclawbrain/cli.py
+++ b/openclawbrain/cli.py
@@ -1128,6 +1128,18 @@ def _coalesce_route_use_relevance(
     return default
 
 
+def _coalesce_route_enable_stop(
+    cli_value: str | None,
+    profile_value: bool | None,
+    default: bool,
+) -> bool:
+    if cli_value is not None:
+        return cli_value.strip().lower() == "true"
+    if profile_value is not None:
+        return profile_value
+    return default
+
+
 @contextmanager
 def _command_state_write_lock(
     args: argparse.Namespace,
@@ -1297,6 +1309,8 @@ def _build_parser() -> argparse.ArgumentParser:
     d.add_argument("--route-top-k", type=int, default=None)
     d.add_argument("--route-alpha-sim", type=float, default=None)
     d.add_argument("--route-use-relevance", choices=["true", "false"], default=None)
+    d.add_argument("--route-enable-stop", choices=["true", "false"], default=None)
+    d.add_argument("--route-stop-margin", type=float, default=None)
     d.add_argument("--route-model", default=None)
     d.add_argument("--auto-save-interval", type=int, default=10)
 
@@ -1318,6 +1332,8 @@ def _build_parser() -> argparse.ArgumentParser:
     serve.add_argument("--route-top-k", type=int, default=None)
     serve.add_argument("--route-alpha-sim", type=float, default=None)
     serve.add_argument("--route-use-relevance", choices=["true", "false"], default=None)
+    serve.add_argument("--route-enable-stop", choices=["true", "false"], default=None)
+    serve.add_argument("--route-stop-margin", type=float, default=None)
     serve.add_argument("--route-model", default=None)
     serve.add_argument(
         "--foreground",
@@ -1848,6 +1864,19 @@ def _resolve_graph_index(
     return graph, index, {}
 
 
+def _ensure_route_model_exists(state_path: str) -> None:
+    """Ensure route_model.npz exists beside state.json, creating identity model if missing."""
+    route_model_path = Path(state_path).expanduser().parent / "route_model.npz"
+    if route_model_path.exists():
+        return
+    _, _index, meta = load_state(str(Path(state_path).expanduser()))
+    embedder_dim = meta.get("embedder_dim")
+    if not isinstance(embedder_dim, int) or embedder_dim <= 0:
+        raise SystemExit("could not determine embedder dimension for route_model initialization")
+    RouteModel.init_identity(d=embedder_dim, df=1).save_npz(route_model_path)
+    print(f"wrote default route_model.npz: {route_model_path}", file=sys.stderr)
+
+
 def _graph_payload(graph: Graph) -> dict:
     """ graph payload."""
     return {
@@ -2160,6 +2189,8 @@ def _serve_start_arguments(
     route_top_k: int,
     route_alpha_sim: float,
     route_use_relevance: bool,
+    route_enable_stop: bool,
+    route_stop_margin: float,
     route_model: str | None,
 ) -> list[str]:
     argv = ["--state", state_path]
@@ -2180,6 +2211,10 @@ def _serve_start_arguments(
         str(route_alpha_sim),
         "--route-use-relevance",
         "true" if route_use_relevance else "false",
+        "--route-enable-stop",
+        "true" if route_enable_stop else "false",
+        "--route-stop-margin",
+        str(route_stop_margin),
     ])
     if route_model:
         argv.extend(["--route-model", str(route_model)])
@@ -4371,6 +4406,11 @@ def cmd_report(args: argparse.Namespace) -> int:
         raw_pid = pid_path.read_text(encoding="utf-8").strip()
         if raw_pid.isdigit():
             pid = int(raw_pid)
+    health_payload = None
+    if socket_exists:
+        ping_ok, health, _error = _socket_health_status(socket_path, timeout=2.0)
+        if ping_ok and isinstance(health, dict):
+            health_payload = health
 
     sync_payload = _read_json_optional(_sync_report_path(resolved_state))
     maintain_payload = _read_json_optional(_maintain_report_path(resolved_state))
@@ -4455,6 +4495,19 @@ def cmd_report(args: argparse.Namespace) -> int:
         f"  nodes: {graph.node_count()}  edges: {graph.edge_count()}  orphans: {health.orphan_nodes}",
         f"  reflex: {health.reflex_pct:.1%}  habitual: {health.habitual_pct:.1%}  dormant: {health.dormant_pct:.1%}",
     ]
+
+    route_model_present = None
+    route_mode_effective = None
+    if health_payload is not None:
+        route_model_present = health_payload.get("route_model_present")
+        route_mode_effective = health_payload.get("route_mode_effective")
+    if route_model_present is None:
+        route_model_present = (Path(resolved_state).expanduser().parent / "route_model.npz").exists()
+    if route_mode_effective is None:
+        route_mode_effective = "learned" if route_model_present else "edge+sim"
+
+    lines.append(f"  route_model: {'present' if route_model_present else 'missing'}")
+    lines.append(f"  route_mode_effective: {route_mode_effective}")
 
     if sync_payload:
         lines.append(
@@ -4599,6 +4652,18 @@ def cmd_daemon(args: argparse.Namespace) -> int:
         profile.policy.route_use_relevance if profile is not None else None,
         True,
     )
+    route_enable_stop = _coalesce_route_enable_stop(
+        args.route_enable_stop,
+        profile.policy.route_enable_stop if profile is not None else None,
+        False,
+    )
+    route_stop_margin = _coalesce_float(
+        args.route_stop_margin,
+        profile.policy.route_stop_margin if profile is not None else None,
+        0.1,
+    )
+    if route_stop_margin < 0.0:
+        raise SystemExit("--route-stop-margin must be >= 0.0")
     route_model = args.route_model
     from .daemon import main as daemon_main
 
@@ -4620,6 +4685,10 @@ def cmd_daemon(args: argparse.Namespace) -> int:
             str(route_alpha_sim),
             "--route-use-relevance",
             "true" if route_use_relevance else "false",
+            "--route-enable-stop",
+            "true" if route_enable_stop else "false",
+            "--route-stop-margin",
+            str(route_stop_margin),
             "--auto-save-interval",
             str(args.auto_save_interval),
         ] + (["--route-model", str(route_model)] if route_model else [])
@@ -4662,6 +4731,18 @@ def cmd_serve(args: argparse.Namespace) -> int:
         profile.policy.route_use_relevance if profile is not None else None,
         True,
     )
+    route_enable_stop = _coalesce_route_enable_stop(
+        args.route_enable_stop,
+        profile.policy.route_enable_stop if profile is not None else None,
+        False,
+    )
+    route_stop_margin = _coalesce_float(
+        args.route_stop_margin,
+        profile.policy.route_stop_margin if profile is not None else None,
+        0.1,
+    )
+    if route_stop_margin < 0.0:
+        raise SystemExit("--route-stop-margin must be >= 0.0")
     route_model = args.route_model
     from .socket_server import main as socket_server_main
 
@@ -4680,6 +4761,8 @@ def cmd_serve(args: argparse.Namespace) -> int:
         route_top_k=route_top_k,
         route_alpha_sim=route_alpha_sim,
         route_use_relevance=route_use_relevance,
+        route_enable_stop=route_enable_stop,
+        route_stop_margin=route_stop_margin,
         route_model=route_model,
     )
     launchd_program_arguments = _resolve_serve_launchd_program_arguments(start_argv)
@@ -4692,6 +4775,9 @@ def cmd_serve(args: argparse.Namespace) -> int:
                 file=sys.stderr,
             )
             return 1
+
+        if not args.dry_run:
+            _ensure_route_model_exists(state_path)
 
         label = args.label or _derive_serve_label(state_path)
         plist_path = Path(args.plist_path).expanduser() if args.plist_path else _derive_launchd_plist_path(label)

--- a/openclawbrain/daemon.py
+++ b/openclawbrain/daemon.py
@@ -58,6 +58,8 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--route-top-k", type=int, default=5)
     parser.add_argument("--route-alpha-sim", type=float, default=0.5)
     parser.add_argument("--route-use-relevance", choices=["true", "false"], default="true")
+    parser.add_argument("--route-enable-stop", choices=["true", "false"], default="false")
+    parser.add_argument("--route-stop-margin", type=float, default=0.1)
     parser.add_argument("--route-model", default=None)
     parser.add_argument("--auto-save-interval", type=int, default=10)
     parser.add_argument("--force", action="store_true", help="Bypass state lock (expert use)")
@@ -145,6 +147,21 @@ def _real_graph_updates(updates: dict[str, float]) -> int:
     return sum(1 for key in updates if not key.endswith("->__STOP__"))
 
 
+def _stop_weight_lookup(graph: Graph) -> Callable[[str], tuple[float, float]]:
+    """Return a lookup function for per-node stop relevance/weight."""
+    def _lookup(node_id: str) -> tuple[float, float]:
+        node = graph.get_node(node_id)
+        if node is None or not isinstance(node.metadata, dict):
+            return 0.0, 0.0
+        raw_weight = node.metadata.get("stop_weight", 0.0)
+        raw_relevance = node.metadata.get("stop_relevance", 0.0)
+        stop_weight = float(raw_weight) if isinstance(raw_weight, (int, float)) else 0.0
+        stop_relevance = float(raw_relevance) if isinstance(raw_relevance, (int, float)) else 0.0
+        return stop_weight, stop_relevance
+
+    return _lookup
+
+
 def _health_payload(graph: Graph) -> dict[str, object]:
     """Build health payload with node/edge counts included."""
     health = measure_health(graph)
@@ -220,6 +237,8 @@ def _build_query_route_fn(
     route_top_k: int,
     route_alpha_sim: float,
     route_use_relevance: bool,
+    route_enable_stop: bool = False,
+    route_stop_margin: float = 0.1,
     query_vector: list[float],
     index: VectorIndex,
 ) -> Callable[[str | None, list[object], str], list[str]] | None:
@@ -229,6 +248,8 @@ def _build_query_route_fn(
         top_k=parse_int(route_top_k, "route_top_k", default=5),
         alpha_sim=parse_float(route_alpha_sim, "route_alpha_sim", default=0.5),
         use_relevance=parse_bool(route_use_relevance, "route_use_relevance", default=True),
+        enable_stop=parse_bool(route_enable_stop, "route_enable_stop", default=False),
+        stop_margin=parse_float(route_stop_margin, "route_stop_margin", required=False, default=0.1),
     )
     return make_runtime_route_fn(policy=policy, query_vector=query_vector, index=index)
 
@@ -406,6 +427,8 @@ def _handle_query(
         top_k=query.route_top_k,
         alpha_sim=query.route_alpha_sim,
         use_relevance=query.route_use_relevance,
+        enable_stop=query.route_enable_stop,
+        stop_margin=query.route_stop_margin,
         debug_allow_confidence_override=query.debug_allow_confidence_override,
         router_conf_override=query.router_conf_override,
         relevance_conf_override=query.relevance_conf_override,
@@ -418,6 +441,7 @@ def _handle_query(
         learned_model=learned_model,
         target_projections=target_projections,
         decision_log=decision_log,
+        stop_weight_fn=_stop_weight_lookup(graph),
     )
     result = traverse(
         graph=graph,
@@ -944,9 +968,12 @@ def _handle_maintain(
     return asdict(report), should_write
 
 
-def _handle_health(graph: Graph) -> dict[str, object]:
+def _handle_health(graph: Graph, route_status: dict[str, object] | None = None) -> dict[str, object]:
     """Handle health request."""
-    return _health_payload(graph)
+    payload = _health_payload(graph)
+    if route_status:
+        payload.update(route_status)
+    return payload
 
 
 def _handle_info(graph: Graph, meta: dict[str, object]) -> dict[str, object]:
@@ -982,6 +1009,8 @@ class QueryDefaults:
     route_top_k: int = 5
     route_alpha_sim: float = 0.5
     route_use_relevance: bool = True
+    route_enable_stop: bool = False
+    route_stop_margin: float = 0.1
 
 
 def _with_query_defaults(params: dict[str, object], defaults: QueryDefaults) -> dict[str, object]:
@@ -993,6 +1022,8 @@ def _with_query_defaults(params: dict[str, object], defaults: QueryDefaults) -> 
     merged.setdefault("route_top_k", defaults.route_top_k)
     merged.setdefault("route_alpha_sim", defaults.route_alpha_sim)
     merged.setdefault("route_use_relevance", defaults.route_use_relevance)
+    merged.setdefault("route_enable_stop", defaults.route_enable_stop)
+    merged.setdefault("route_stop_margin", defaults.route_stop_margin)
     return merged
 
 
@@ -1011,6 +1042,7 @@ def main(argv: list[str] | None = None) -> int:
     lock_cm = state_write_lock(state_path, force=args.force, command_hint="openclawbrain daemon")
     with lock_cm if state_path else nullcontext():
         graph, index, meta = state_store.load(state_path)
+        route_mode_configured = parse_route_mode(args.route_mode)
         route_model: RouteModel | None = None
         target_projections: dict[str, object] = {}
         if route_model_path.exists():
@@ -1018,9 +1050,26 @@ def main(argv: list[str] | None = None) -> int:
                 route_model = RouteModel.load_npz(route_model_path)
                 target_projections = route_model.precompute_target_projections(index)
             except Exception as exc:  # noqa: BLE001
-                print(f"warning: failed to load route model at {route_model_path}: {exc}", file=sys.stderr)
+                print(
+                    f"warning: failed to load route model at {route_model_path}: {exc}; falling back to edge+sim",
+                    file=sys.stderr,
+                )
                 route_model = None
                 target_projections = {}
+        elif route_mode_configured == "learned":
+            print(
+                f"warning: route_model.npz missing at {route_model_path}; falling back to edge+sim",
+                file=sys.stderr,
+            )
+        route_model_present = route_model is not None
+        route_mode_effective = route_mode_configured
+        if route_mode_configured == "learned" and route_model is None:
+            route_mode_effective = "edge+sim"
+        route_status = {
+            "route_model_present": route_model_present,
+            "route_mode_configured": route_mode_configured,
+            "route_mode_effective": route_mode_effective,
+        }
         daemon_state = _DaemonState(
             graph=graph,
             index=index,
@@ -1032,6 +1081,9 @@ def main(argv: list[str] | None = None) -> int:
             ),
         )
         embed_fn = _resolve_embed_fn(args.embed_model, meta)
+        route_stop_margin = parse_float(args.route_stop_margin, "route_stop_margin", required=False, default=0.1)
+        if route_stop_margin < 0.0:
+            raise ValueError("route_stop_margin must be >= 0.0")
         query_defaults = QueryDefaults(
             max_prompt_context_chars=parse_int(
                 args.max_prompt_context_chars,
@@ -1043,7 +1095,7 @@ def main(argv: list[str] | None = None) -> int:
                 "max_fired_nodes",
                 default=30,
             ),
-            route_mode=parse_route_mode(args.route_mode),
+            route_mode=route_mode_effective,
             route_top_k=parse_int(
                 args.route_top_k,
                 "route_top_k",
@@ -1055,6 +1107,8 @@ def main(argv: list[str] | None = None) -> int:
                 default=0.5,
             ),
             route_use_relevance=str(args.route_use_relevance).strip().lower() == "true",
+            route_enable_stop=str(args.route_enable_stop).strip().lower() == "true",
+            route_stop_margin=route_stop_margin,
         )
         if query_defaults.route_mode == "learned" and route_model is None:
             query_defaults = QueryDefaults(
@@ -1064,6 +1118,8 @@ def main(argv: list[str] | None = None) -> int:
                 route_top_k=query_defaults.route_top_k,
                 route_alpha_sim=query_defaults.route_alpha_sim,
                 route_use_relevance=query_defaults.route_use_relevance,
+                route_enable_stop=query_defaults.route_enable_stop,
+                route_stop_margin=query_defaults.route_stop_margin,
             )
         auto_save_interval = max(1, args.auto_save_interval) if args.auto_save_interval > 0 else 0
 
@@ -1162,7 +1218,7 @@ def main(argv: list[str] | None = None) -> int:
                             state_store,
                         )
                     elif method == "health":
-                        payload = _handle_health(daemon_state.graph)
+                        payload = _handle_health(daemon_state.graph, route_status)
                     elif method == "info":
                         payload = _handle_info(daemon_state.graph, daemon_state.meta)
                     elif method == "save":

--- a/openclawbrain/learn.py
+++ b/openclawbrain/learn.py
@@ -104,6 +104,61 @@ def _clip_weight(weight: float, bounds: tuple[float, float]) -> float:
     return max(bounds[0], min(bounds[1], weight))
 
 
+def _node_stop_values(node: Node | None) -> tuple[float, float]:
+    """Extract stop relevance/weight from node metadata with safe fallbacks."""
+    if node is None or not isinstance(node.metadata, dict):
+        return 0.0, 0.0
+    raw_relevance = node.metadata.get("stop_relevance", 0.0)
+    raw_weight = node.metadata.get("stop_weight", 0.0)
+    stop_relevance = float(raw_relevance) if isinstance(raw_relevance, (int, float)) else 0.0
+    stop_weight = float(raw_weight) if isinstance(raw_weight, (int, float)) else 0.0
+    return stop_relevance, stop_weight
+
+
+def _project_conserving_updates(
+    weights: list[float],
+    deltas: list[float],
+    bounds: tuple[float, float],
+    *,
+    tol: float = 1e-12,
+) -> list[float]:
+    """Project proposed updates onto box constraints while conserving total weight."""
+    if len(weights) != len(deltas):
+        raise ValueError("weights and deltas must be the same length")
+    if not weights:
+        return []
+
+    lo, hi = bounds
+    target_sum = sum(weights)
+    proposed = [weight + delta for weight, delta in zip(weights, deltas)]
+    new_weights = [min(hi, max(lo, value)) for value in proposed]
+    diff = sum(new_weights) - target_sum
+    if abs(diff) <= tol:
+        return new_weights
+
+    max_iters = max(1, len(weights) * 5)
+    for _ in range(max_iters):
+        if abs(diff) <= tol:
+            break
+        if diff > 0:
+            free = [idx for idx, value in enumerate(new_weights) if value > lo + tol]
+            if not free:
+                break
+            share = diff / len(free)
+            for idx in free:
+                new_weights[idx] = max(lo, new_weights[idx] - share)
+        else:
+            free = [idx for idx, value in enumerate(new_weights) if value < hi - tol]
+            if not free:
+                break
+            share = (-diff) / len(free)
+            for idx in free:
+                new_weights[idx] = min(hi, new_weights[idx] + share)
+        diff = sum(new_weights) - target_sum
+
+    return new_weights
+
+
 def hebbian_update(
     graph: Graph,
     fired_nodes: list[str],
@@ -174,7 +229,9 @@ def _softmax_with_stop(graph: Graph, node_id: str, temperature: float) -> tuple[
         if logit > max_logit:
             max_logit = logit
 
-    exp_stop = math.exp(0.0 - max_logit)
+    stop_relevance, stop_weight = _node_stop_values(graph.get_node(node_id))
+    stop_logit = (stop_relevance + stop_weight) / temperature
+    exp_stop = math.exp(stop_logit - max_logit)
     exp_sum = exp_stop
     probs_by_target: dict[str, float] = {"__STOP__": exp_stop}
     for target_id, logit in logits_by_target.items():
@@ -228,14 +285,26 @@ def apply_outcome_pg(
         probs, _ = _softmax_with_stop(graph, source_id, effective_temperature)
         scalar = cfg.learning_rate * (node_outcome - baseline) * (cfg.discount ** idx) / effective_temperature
 
+        node = graph.get_node(source_id)
+        _stop_relevance, stop_weight = _node_stop_values(node)
+
+        weights = [edge.weight for _target_node, edge in outgoing]
+        deltas: list[float] = []
         for _target_node, edge in outgoing:
             pi_j = probs.get(edge.target, 0.0)
             if edge.target == target_id:
                 delta = scalar * (1.0 - pi_j)
             else:
                 delta = -scalar * pi_j
+            deltas.append(delta)
 
-            new_weight = _clip_weight(edge.weight + delta, cfg.weight_bounds)
+        stop_delta = -scalar * probs.get("__STOP__", 0.0)
+        weights.append(stop_weight)
+        deltas.append(stop_delta)
+
+        new_weights = _project_conserving_updates(weights, deltas, cfg.weight_bounds)
+
+        for (edge_target_node, edge), new_weight in zip(outgoing, new_weights[:-1]):
             delta_actual = new_weight - edge.weight
             edge.weight = new_weight
             if edge.weight < -0.01:
@@ -245,8 +314,13 @@ def apply_outcome_pg(
             graph._edges[source_id][edge.target] = edge
             updates[f"{source_id}->{edge.target}"] += delta_actual
 
-        if "__STOP__" in probs:
-            updates[f"{source_id}->__STOP__"] = -scalar * probs["__STOP__"]
+        if node is not None:
+            new_stop_weight = new_weights[-1]
+            delta_actual = new_stop_weight - stop_weight
+            if not isinstance(node.metadata, dict):
+                node.metadata = {}
+            node.metadata["stop_weight"] = new_stop_weight
+            updates[f"{source_id}->__STOP__"] += delta_actual
 
     hebbian_update(graph, fired_nodes, cfg)
     _apply_outcome_call_count += 1

--- a/openclawbrain/policy.py
+++ b/openclawbrain/policy.py
@@ -19,6 +19,8 @@ class RoutingPolicy:
     top_k: int = 5
     alpha_sim: float = 0.5
     use_relevance: bool = True
+    enable_stop: bool = False
+    stop_margin: float = 0.1
     debug_allow_confidence_override: bool = False
     router_conf_override: float | None = None
     relevance_conf_override: float | None = None
@@ -117,6 +119,7 @@ def make_runtime_route_fn(
     learned_model: RouteModel | None = None,
     target_projections: dict[str, object] | None = None,
     decision_log: list[DecisionMetrics] | None = None,
+    stop_weight_fn: Callable[[str], tuple[float, float]] | None = None,
 ) -> Callable[[str | None, list[object], str], list[str]] | None:
     """Build deterministic local route policy for habitual candidates."""
     if policy.route_mode == "off":
@@ -131,6 +134,7 @@ def make_runtime_route_fn(
             config=policy,
             query_vector=query_vector,
             decision_log=decision_log,
+            stop_weight_fn=stop_weight_fn,
         )
 
     use_similarity = policy.route_mode == "edge+sim"
@@ -156,10 +160,34 @@ def make_runtime_route_fn(
         return weight + relevance + (policy.alpha_sim * similarity)
 
     def _route_fn(_source_id: str | None, candidates: list[object], _query_text: str) -> list[str]:
+        scored = [
+            (str(getattr(edge, "target", "")), _score(edge), edge)
+            for edge in candidates
+            if str(getattr(edge, "target", ""))
+        ]
         ranked = sorted(
-            ((str(getattr(edge, "target", "")), _score(edge)) for edge in candidates),
+            ((target_id, score) for target_id, score, _edge in scored),
             key=lambda item: (-item[1], item[0]),
         )
+        if not ranked:
+            return []
+
+        if policy.enable_stop and stop_weight_fn is not None and _source_id:
+            if policy.use_relevance:
+                relevances = []
+                for _target_id, _score_value, edge in scored:
+                    metadata = getattr(edge, "metadata", None)
+                    raw_relevance = metadata.get("relevance", 0.0) if isinstance(metadata, dict) else 0.0
+                    relevances.append(float(raw_relevance) if isinstance(raw_relevance, (int, float)) else 0.0)
+                _entropy, relevance_conf, _margin = _confidence(relevances)
+            else:
+                relevance_conf = 0.0
+            stop_weight, stop_relevance = stop_weight_fn(_source_id)
+            stop_score = (relevance_conf * stop_relevance) + ((1.0 - relevance_conf) * stop_weight)
+            best_score = ranked[0][1]
+            if stop_score >= best_score + policy.stop_margin:
+                return []
+
         return [target_id for target_id, _score_value in ranked[: policy.top_k] if target_id]
 
     return _route_fn
@@ -172,6 +200,7 @@ def make_learned_route_fn(
     config: RoutingPolicy,
     query_vector: list[float],
     decision_log: list[DecisionMetrics] | None = None,
+    stop_weight_fn: Callable[[str], tuple[float, float]] | None = None,
 ) -> Callable[[str | None, list[object], str], list[str]]:
     """Build deterministic learned route function using low-rank scoring."""
     q_proj = model.project_query(query_vector)
@@ -228,6 +257,13 @@ def make_learned_route_fn(
             ranked.append((target_id, graph_prior, router_score, final_score))
 
         ranked.sort(key=lambda item: (-item[3], item[0]))
+
+        if config.enable_stop and stop_weight_fn is not None and source_id and ranked:
+            stop_weight, stop_relevance = stop_weight_fn(source_id)
+            stop_score = (relevance_conf * stop_relevance) + ((1.0 - relevance_conf) * stop_weight)
+            best_score = ranked[0][3]
+            if stop_score >= best_score + config.stop_margin:
+                return []
 
         if decision_log is not None and ranked:
             chosen_target, chosen_graph_prior, chosen_router, chosen_final = ranked[0]

--- a/openclawbrain/profile.py
+++ b/openclawbrain/profile.py
@@ -28,6 +28,8 @@ class ProfilePolicy:
     route_top_k: int = 5
     route_alpha_sim: float = 0.5
     route_use_relevance: bool = True
+    route_enable_stop: bool = False
+    route_stop_margin: float = 0.1
 
 
 @dataclass(frozen=True)
@@ -93,6 +95,8 @@ class BrainProfile:
                     "route_top_k",
                     "route_alpha_sim",
                     "route_use_relevance",
+                    "route_enable_stop",
+                    "route_stop_margin",
                 },
                 "policy",
             )
@@ -138,6 +142,18 @@ class BrainProfile:
                 "policy.route_use_relevance",
                 default=True,
             )
+            route_enable_stop = parse_bool(
+                raw_policy.get("route_enable_stop"),
+                "policy.route_enable_stop",
+                default=False,
+            )
+            route_stop_margin = parse_float(
+                raw_policy.get("route_stop_margin"),
+                "policy.route_stop_margin",
+                default=0.1,
+            )
+            if route_stop_margin < 0.0:
+                raise ValueError("policy.route_stop_margin must be >= 0.0")
 
             reward_source = _parse_non_empty_str(raw_reward.get("source"), "reward.source", default="explicit")
             reward_weight_correction = parse_float(
@@ -175,6 +191,8 @@ class BrainProfile:
                     route_top_k=route_top_k,
                     route_alpha_sim=route_alpha_sim,
                     route_use_relevance=route_use_relevance,
+                    route_enable_stop=route_enable_stop,
+                    route_stop_margin=route_stop_margin,
                 ),
                 reward=ProfileReward(
                     source=reward_source,
@@ -202,6 +220,8 @@ class BrainProfile:
                 "route_top_k": self.policy.route_top_k,
                 "route_alpha_sim": self.policy.route_alpha_sim,
                 "route_use_relevance": self.policy.route_use_relevance,
+                "route_enable_stop": self.policy.route_enable_stop,
+                "route_stop_margin": self.policy.route_stop_margin,
             },
             "reward": {
                 "source": self.reward.source,
@@ -230,6 +250,8 @@ def _env_overrides(*, env_prefix: str) -> dict[str, object]:
         "ROUTE_TOP_K": (("policy", "route_top_k"), int),
         "ROUTE_ALPHA_SIM": (("policy", "route_alpha_sim"), float),
         "ROUTE_USE_RELEVANCE": (("policy", "route_use_relevance"), _parse_env_bool),
+        "ROUTE_ENABLE_STOP": (("policy", "route_enable_stop"), _parse_env_bool),
+        "ROUTE_STOP_MARGIN": (("policy", "route_stop_margin"), float),
         "REWARD_SOURCE": (("reward", "source"), str),
         "REWARD_WEIGHT_CORRECTION": (("reward", "weight_correction"), float),
         "REWARD_WEIGHT_TEACHING": (("reward", "weight_teaching"), float),

--- a/openclawbrain/protocol.py
+++ b/openclawbrain/protocol.py
@@ -116,6 +116,8 @@ class QueryParams:
     route_top_k: int = 5
     route_alpha_sim: float = 0.5
     route_use_relevance: bool = True
+    route_enable_stop: bool = False
+    route_stop_margin: float = 0.1
     debug_allow_confidence_override: bool = False
     router_conf_override: float | None = None
     relevance_conf_override: float | None = None
@@ -152,6 +154,8 @@ class QueryParams:
             route_top_k=parse_int(params.get("route_top_k"), "route_top_k", default=5),
             route_alpha_sim=parse_float(params.get("route_alpha_sim"), "route_alpha_sim", default=0.5),
             route_use_relevance=parse_bool(params.get("route_use_relevance"), "route_use_relevance", default=True),
+            route_enable_stop=parse_bool(params.get("route_enable_stop"), "route_enable_stop", default=False),
+            route_stop_margin=_parse_stop_margin(params.get("route_stop_margin")),
             debug_allow_confidence_override=parse_bool(
                 params.get("debug_allow_confidence_override"),
                 "debug_allow_confidence_override",
@@ -190,6 +194,8 @@ class QueryParams:
             "route_top_k": self.route_top_k,
             "route_alpha_sim": self.route_alpha_sim,
             "route_use_relevance": self.route_use_relevance,
+            "route_enable_stop": self.route_enable_stop,
+            "route_stop_margin": self.route_stop_margin,
             "debug_allow_confidence_override": self.debug_allow_confidence_override,
             "router_conf_override": self.router_conf_override,
             "relevance_conf_override": self.relevance_conf_override,
@@ -199,6 +205,14 @@ class QueryParams:
             "include_provenance": self.include_provenance,
             "chat_id": self.chat_id,
         }
+
+
+def _parse_stop_margin(value: object) -> float:
+    """Parse non-negative stop margin with default."""
+    parsed = parse_float(value, "route_stop_margin", required=False, default=0.1)
+    if parsed < 0.0:
+        raise ValueError("route_stop_margin must be >= 0.0")
+    return parsed
 
 
 @dataclass(frozen=True)

--- a/openclawbrain/socket_client.py
+++ b/openclawbrain/socket_client.py
@@ -67,6 +67,8 @@ class OCBClient:
         route_top_k: int = 5,
         route_alpha_sim: float = 0.5,
         route_use_relevance: bool = True,
+        route_enable_stop: bool = False,
+        route_stop_margin: float = 0.1,
     ) -> dict[str, Any]:
         params = {
             "query": query,
@@ -75,6 +77,8 @@ class OCBClient:
             "route_top_k": route_top_k,
             "route_alpha_sim": route_alpha_sim,
             "route_use_relevance": route_use_relevance,
+            "route_enable_stop": route_enable_stop,
+            "route_stop_margin": route_stop_margin,
         }
         if chat_id is not None:
             params["chat_id"] = chat_id

--- a/tests/test_learn.py
+++ b/tests/test_learn.py
@@ -222,6 +222,60 @@ def test_apply_outcome_pg_updates_conserve_mass_including_stop() -> None:
     assert isclose(updates["a->b"] + updates["a->c"] + updates["a->__STOP__"], 0.0, rel_tol=1e-12, abs_tol=1e-12)
 
 
+def test_apply_outcome_pg_projects_updates_under_bounds() -> None:
+    """test apply outcome pg projects updates under bounds and conserves mass."""
+    graph = Graph()
+    graph.add_node(Node("a", "A", metadata={"stop_weight": 0.0}))
+    graph.add_node(Node("b", "B"))
+    graph.add_node(Node("c", "C"))
+    graph.add_edge(Edge("a", "b", 1.0))
+    graph.add_edge(Edge("a", "c", 0.0))
+
+    updates = apply_outcome_pg(
+        graph,
+        ["a", "b"],
+        outcome=1.0,
+        config=LearningConfig(learning_rate=2.0, discount=1.0),
+    )
+
+    assert isclose(updates["a->b"] + updates["a->c"] + updates["a->__STOP__"], 0.0, rel_tol=1e-12, abs_tol=1e-12)
+    assert -1.0 <= graph._edges["a"]["b"].weight <= 1.0
+    assert -1.0 <= graph._edges["a"]["c"].weight <= 1.0
+    assert -1.0 <= graph.get_node("a").metadata["stop_weight"] <= 1.0
+
+
+def test_apply_outcome_pg_updates_stop_weight_and_persists(tmp_path) -> None:
+    """test apply outcome pg updates stop weight and persists to disk."""
+    graph = Graph()
+    graph.add_node(Node("a", "A", metadata={"stop_weight": 0.2}))
+    graph.add_node(Node("b", "B"))
+    graph.add_edge(Edge("a", "b", 0.0))
+
+    updates = apply_outcome_pg(
+        graph,
+        ["a", "b"],
+        outcome=1.0,
+        config=LearningConfig(learning_rate=1.0, discount=1.0),
+    )
+
+    node = graph.get_node("a")
+    assert node is not None
+    assert "stop_weight" in node.metadata
+    assert isclose(node.metadata["stop_weight"], 0.2 + updates["a->__STOP__"], rel_tol=1e-12, abs_tol=1e-12)
+
+    path = tmp_path / "graph.json"
+    graph.save(str(path))
+    loaded = Graph.load(str(path))
+    loaded_node = loaded.get_node("a")
+    assert loaded_node is not None
+    assert isclose(
+        loaded_node.metadata["stop_weight"],
+        node.metadata["stop_weight"],
+        rel_tol=1e-12,
+        abs_tol=1e-12,
+    )
+
+
 def test_apply_outcome_pg_chosen_edge_positive_and_non_chosen_negative_on_positive_outcome() -> None:
     """test apply outcome pg chosen edge positive while non chosen negative on positive outcome."""
     graph = Graph()

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -135,6 +135,29 @@ def test_make_runtime_route_fn_learned_populates_decision_log() -> None:
     assert 0.0 <= metrics.relevance_conf <= 1.0
 
 
+def test_make_runtime_route_fn_can_choose_stop() -> None:
+    index = VectorIndex()
+    index.upsert("a", [1.0, 0.0])
+    index.upsert("b", [0.0, 1.0])
+
+    route_fn = make_runtime_route_fn(
+        policy=RoutingPolicy(route_mode="edge", top_k=1, use_relevance=False, enable_stop=True, stop_margin=0.1),
+        query_vector=[1.0, 0.0],
+        index=index,
+        stop_weight_fn=lambda _node_id: (1.0, 0.0),
+    )
+    assert route_fn is not None
+    chosen = route_fn(
+        "src",
+        [
+            Edge("src", "a", weight=0.0),
+            Edge("src", "b", weight=0.0),
+        ],
+        "q",
+    )
+    assert chosen == []
+
+
 def test_learned_route_confidence_overrides_are_debug_gated() -> None:
     index = VectorIndex()
     index.upsert("a", [1.0, 0.0])

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -34,6 +34,8 @@ def test_query_params_defaults_follow_daemon_behavior() -> None:
     assert params.route_top_k == 5
     assert params.route_alpha_sim == 0.5
     assert params.route_use_relevance is True
+    assert params.route_enable_stop is False
+    assert params.route_stop_margin == 0.1
     assert params.debug_allow_confidence_override is False
     assert params.router_conf_override is None
     assert params.relevance_conf_override is None
@@ -70,6 +72,9 @@ def test_query_params_validation_errors() -> None:
 
     with pytest.raises(ValueError, match="router_conf_override must be between 0.0 and 1.0"):
         QueryParams.from_dict({"query": "x", "router_conf_override": 1.1})
+
+    with pytest.raises(ValueError, match="route_stop_margin must be >= 0.0"):
+        QueryParams.from_dict({"query": "x", "route_stop_margin": -0.1})
 
 
 def test_query_response_to_dict_result_and_error() -> None:


### PR DESCRIPTION
This ships the long-term-greedy hardening pass for learned routing + aligns PG updates with the paper's STOP action.

### Learned routing hardening
- `serve install` now ensures `route_model.npz` exists (identity init) so `route_mode=learned` can't silently be ineffective.
- Daemon warns loudly when `route_mode=learned` but the model is missing/unloadable and falls back to `edge+sim`.
- `health` now includes: `route_model_present`, `route_mode_configured`, `route_mode_effective`.

### PG STOP (paper alignment)
- Per-node learnable `stop_weight` stored in `Node.metadata`.
- STOP logit uses `(stop_relevance + stop_weight)/temperature`.
- `apply_outcome_pg` applies STOP updates and uses a conservative projection under bounds to preserve per-state mass (edges + STOP).

### Runtime STOP (optional)
- Routing policy supports `route_enable_stop` + `route_stop_margin` to allow returning `[]` (stop) when STOP beats best candidate by margin.

### Tests
- Added/updated unit tests for conservation under bounds, STOP weight persistence, protocol parsing, and stop routing behavior.