### PR TITLE
Fix socket_server route stop args

### DIFF
--- a/openclawbrain/socket_server.py
+++ b/openclawbrain/socket_server.py
@@ -28,6 +28,8 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--route-alpha-sim", type=float, default=0.5)
     parser.add_argument("--route-use-relevance", choices=["true", "false"], default="true")
     parser.add_argument("--route-model", default=None)
+    parser.add_argument("--route-enable-stop", choices=["true", "false"], default="false")
+    parser.add_argument("--route-stop-margin", type=float, default=0.1)
     parser.add_argument("--auto-save-interval", type=int, default=10)
     parser.add_argument("--force", action="store_true", help="Bypass state lock (expert use)")
     parser.add_argument("--verbose", action="store_true", help="Enable verbose logging")
@@ -63,6 +65,8 @@ class SocketDaemonServer:
         route_alpha_sim: float,
         route_use_relevance: str,
         route_model: str | None,
+        route_enable_stop: str,
+        route_stop_margin: float,
         auto_save_interval: int,
         force: bool,
         verbose: bool,
@@ -81,6 +85,8 @@ class SocketDaemonServer:
         self.route_alpha_sim = route_alpha_sim
         self.route_use_relevance = route_use_relevance
         self.route_model = route_model
+        self.route_enable_stop = route_enable_stop
+        self.route_stop_margin = route_stop_margin
         self.auto_save_interval = auto_save_interval
         self.force = force
         self.pid_path = Path(_default_pid_path(str(self.socket_path)))
@@ -151,6 +157,10 @@ class SocketDaemonServer:
             str(self.route_alpha_sim),
             "--route-use-relevance",
             self.route_use_relevance,
+            "--route-enable-stop",
+            self.route_enable_stop,
+            "--route-stop-margin",
+            str(self.route_stop_margin),
             "--auto-save-interval",
             str(self.auto_save_interval),
         ]
@@ -382,6 +392,8 @@ def main(argv: list[str] | None = None) -> int:
         route_alpha_sim=args.route_alpha_sim,
         route_use_relevance=args.route_use_relevance,
         route_model=args.route_model,
+        route_enable_stop=args.route_enable_stop,
+        route_stop_margin=args.route_stop_margin,
         auto_save_interval=args.auto_save_interval,
         force=args.force,
         verbose=args.verbose,

--- a/tests/test_socket_server_args.py
+++ b/tests/test_socket_server_args.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from openclawbrain import socket_server
+
+
+def test_socket_server_parses_route_stop_flags() -> None:
+    args = socket_server._parse_args(
+        [
+            "--state",
+            "/tmp/state.json",
+            "--route-enable-stop",
+            "false",
+            "--route-stop-margin",
+            "0.1",
+        ]
+    )
+
+    assert args.route_enable_stop == "false"
+    assert args.route_stop_margin == 0.1


### PR DESCRIPTION
## Summary
- accept route stop flags in socket_server arg parsing
- forward route stop flags to daemon invocation
- add socket_server arg parsing smoke test

## Testing
- pytest -q tests/test_socket_server_args.py

## Notes
- Unbreaks launchd serve after PR #123.