### PR TITLE
Persist teacher labels for unified labels store

### DIFF
--- a/README.md
+++ b/README.md
@@ -772,7 +772,9 @@ Storage boundary modules:
 
 Unified label schema:
 - `openclawbrain.labels.LabelRecord` with `reward_source` + `weight`
-- works across teacher labels, human corrections, and self-learning events
+- works across teacher labels, human corrections, self-learning events, and harvest outputs
+- **labels** = async teacher labels + human labels + self-learned labels + harvested labels
+- `--labels-out` appends JSONL records for long-lived label stores
 
 Training flow:
 
@@ -781,13 +783,20 @@ Training flow:
 openclawbrain async-route-pg \
   --state /tmp/brain/state.json \
   --traces-out /tmp/brain/route_traces.jsonl \
+  --labels-out /tmp/brain/labels.jsonl \
   --include-query-vector \
   --teacher none
 
-# 2) Train route model
+# 2) Collect harvest/self labels (optional; appends)
+openclawbrain harvest \
+  --state /tmp/brain/state.json \
+  --labels-out /tmp/brain/labels.jsonl
+
+# 3) Train route model
 openclawbrain train-route-model \
   --state /tmp/brain/state.json \
   --traces-in /tmp/brain/route_traces.jsonl \
+  --labels-in /tmp/brain/labels.jsonl \
   --out /tmp/brain/route_model.npz \
   --rank 16 \
   --epochs 3 \
@@ -795,7 +804,7 @@ openclawbrain train-route-model \
   --label-temp 0.5 \
   --json
 
-# 3) Run daemon with learned route mode
+# 4) Run daemon with learned route mode
 openclawbrain daemon \
   --state /tmp/brain/state.json \
   --route-mode learned \

--- a/openclawbrain/cli.py
+++ b/openclawbrain/cli.py
@@ -1558,6 +1558,7 @@ def _build_parser() -> argparse.ArgumentParser:
     ar.add_argument("--max-decision-points", type=int, default=500)
     ar.add_argument("--traces-out", default=None)
     ar.add_argument("--traces-in", default=None)
+    ar.add_argument("--labels-out", default=None)
     ar.add_argument("--include-query-vector", action="store_true")
     ar.add_argument(
         "--reward-source",
@@ -4972,6 +4973,7 @@ def cmd_async_route_pg(args: argparse.Namespace) -> int:
         score_scale=float(args.score_scale),
         traces_out=str(args.traces_out) if args.traces_out else None,
         traces_in=str(args.traces_in) if args.traces_in else None,
+        labels_out=str(args.labels_out) if args.labels_out else None,
         include_query_vector=bool(args.include_query_vector),
         reward_source=RewardSource.parse(args.reward_source),
         reward_weights=parsed_weights,

--- a/openclawbrain/labels.py
+++ b/openclawbrain/labels.py
@@ -121,6 +121,16 @@ def write_labels_jsonl(path: str | Path, records: list[LabelRecord]) -> None:
             handle.write(json.dumps(record.to_dict(), ensure_ascii=True, sort_keys=True) + "\n")
 
 
+def append_labels_jsonl(path: str | Path, records: list[LabelRecord]) -> None:
+    if not records:
+        return
+    destination = Path(path).expanduser()
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with destination.open("a", encoding="utf-8") as handle:
+        for record in records:
+            handle.write(json.dumps(record.to_dict(), ensure_ascii=True, sort_keys=True) + "\n")
+
+
 def read_labels_jsonl(path: str | Path) -> list[LabelRecord]:
     source = Path(path).expanduser()
     if not source.exists():

--- a/openclawbrain/labels.py
+++ b/openclawbrain/labels.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -129,6 +130,8 @@ def append_labels_jsonl(path: str | Path, records: list[LabelRecord]) -> None:
     with destination.open("a", encoding="utf-8") as handle:
         for record in records:
             handle.write(json.dumps(record.to_dict(), ensure_ascii=True, sort_keys=True) + "\n")
+        handle.flush()
+        os.fsync(handle.fileno())
 
 
 def read_labels_jsonl(path: str | Path) -> list[LabelRecord]:

--- a/openclawbrain/ops/async_route_pg.py
+++ b/openclawbrain/ops/async_route_pg.py
@@ -7,13 +7,14 @@ import json
 import os
 import random
 import time
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, replace
 from pathlib import Path
 from typing import Callable
 
 from ..graph import Edge, Graph
 from ..hasher import HashEmbedder
 from ..learn import apply_outcome_pg
+from ..labels import append_labels_jsonl, from_teacher_output
 from ..replay import default_keyword_seed_fn
 from ..reward import RewardSource, RewardWeights, scale_reward
 from ..storage import EventStore, JsonStateStore, JsonlEventStore, StateStore
@@ -419,9 +420,10 @@ def _flatten_traces(
     traces: list[RouteTrace],
     *,
     max_decision_points: int,
-) -> tuple[list[DecisionPoint], list[RouteDecisionPoint], bool]:
+) -> tuple[list[DecisionPoint], list[RouteDecisionPoint], list[tuple[str, int, float]], bool]:
     compat_points: list[DecisionPoint] = []
     route_points: list[RouteDecisionPoint] = []
+    point_refs: list[tuple[str, int, float]] = []
     cap_hit = False
 
     for trace in traces:
@@ -454,10 +456,11 @@ def _flatten_traces(
                 )
             )
             route_points.append(point)
+            point_refs.append((trace.query_id, idx, float(point.ts)))
         if cap_hit:
             break
 
-    return compat_points, route_points, cap_hit
+    return compat_points, route_points, point_refs, cap_hit
 
 
 def _normalize_labels(
@@ -470,6 +473,43 @@ def _normalize_labels(
     padded = list(labels_by_point)
     padded.extend({} for _ in range(expected_len - len(padded)))
     return padded
+
+
+def _apply_teacher_labels_to_traces(
+    traces: list[RouteTrace],
+    labels_by_point: list[dict[str, float]],
+    *,
+    max_decision_points: int,
+) -> list[RouteTrace]:
+    if not traces or not labels_by_point:
+        return traces
+    label_idx = 0
+    updated_traces: list[RouteTrace] = []
+    for trace in traces:
+        new_points: list[RouteDecisionPoint] = []
+        for point in trace.decision_points:
+            if label_idx >= max_decision_points or label_idx >= len(labels_by_point):
+                new_points.append(point)
+                continue
+            labels = labels_by_point[label_idx]
+            label_idx += 1
+            if not labels:
+                new_points.append(point)
+                continue
+            teacher_scores = {str(k): float(v) for k, v in labels.items()}
+            teacher_choose = list(point.teacher_choose)
+            if teacher_scores and not teacher_choose:
+                if all(float(value) >= 1.0 for value in teacher_scores.values()):
+                    teacher_choose = sorted(teacher_scores.keys())
+            new_points.append(
+                replace(
+                    point,
+                    teacher_scores=teacher_scores,
+                    teacher_choose=teacher_choose,
+                )
+            )
+        updated_traces.append(replace(trace, decision_points=new_points))
+    return updated_traces
 
 
 def _router_conf_multiplier(router_conf: float | None) -> float:
@@ -590,6 +630,7 @@ def run_async_route_pg(
     score_scale: float = 0.3,
     traces_out: str | None = None,
     traces_in: str | None = None,
+    labels_out: str | None = None,
     include_query_vector: bool = False,
     reward_source: RewardSource | str = RewardSource.TEACHER,
     reward_weights: RewardWeights | None = None,
@@ -623,10 +664,9 @@ def run_async_route_pg(
             event_store=resolved_event_store,
         )
 
-    if traces_out:
-        _write_traces_jsonl(traces_out, traces)
-
-    decision_points, route_points, flatten_cap_hit = _flatten_traces(traces, max_decision_points=max_decision_points)
+    decision_points, route_points, point_refs, flatten_cap_hit = _flatten_traces(
+        traces, max_decision_points=max_decision_points
+    )
     cap_hit = cap_hit or flatten_cap_hit
 
     teacher_available = False
@@ -666,6 +706,11 @@ def run_async_route_pg(
         errors.append("teacher disabled")
 
     labels_by_point = _normalize_labels(labels_by_point, expected_len=len(route_points))
+    traces_with_labels = _apply_teacher_labels_to_traces(
+        traces,
+        labels_by_point,
+        max_decision_points=max_decision_points,
+    )
 
     working_graph = graph if apply else copy.deepcopy(graph)
     decision_points_labeled = 0
@@ -728,6 +773,29 @@ def run_async_route_pg(
 
     if apply and teacher_available and updates_applied > 0:
         resolved_state_store.save(state_path, graph=working_graph, index=index, meta=meta)
+
+    if labels_out:
+        label_records = []
+        for (query_id, point_idx, ts), labels in zip(point_refs, labels_by_point):
+            if not labels:
+                continue
+            label_records.append(
+                from_teacher_output(
+                    query_id=query_id,
+                    decision_point_idx=point_idx,
+                    teacher_scores=labels,
+                    ts=ts,
+                    weight=1.0,
+                    metadata={
+                        "teacher_model": teacher_model,
+                        "teacher_requested": teacher,
+                    },
+                )
+            )
+        append_labels_jsonl(labels_out, label_records)
+
+    if traces_out:
+        _write_traces_jsonl(traces_out, traces_with_labels)
 
     return AsyncRoutePgSummary(
         teacher_requested=teacher,

--- a/tests/test_async_route_pg.py
+++ b/tests/test_async_route_pg.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from openclawbrain.graph import Edge, Graph, Node
 from openclawbrain.index import VectorIndex
+from openclawbrain.labels import LabelRecord, read_labels_jsonl, write_labels_jsonl
 from openclawbrain.ops.async_route_pg import parse_teacher_route_labels, run_async_route_pg
 from openclawbrain.reward import RewardSource
 from openclawbrain.store import load_state, save_state
@@ -198,3 +199,82 @@ def test_run_async_route_pg_modulates_updates_by_router_confidence(tmp_path: Pat
     weight_a = graph_after._edges["seed"]["target_a"].weight
     weight_b = graph_after._edges["seed"]["target_b"].weight
     assert (weight_a - 0.35) > (weight_b - 0.30)
+
+
+def test_async_route_pg_persists_teacher_labels_and_appends_labels_out(tmp_path: Path) -> None:
+    state_path = tmp_path / "state.json"
+    journal_path = tmp_path / "journal.jsonl"
+    traces_in = tmp_path / "route_traces_in.jsonl"
+    traces_out = tmp_path / "route_traces_out.jsonl"
+    labels_out = tmp_path / "labels.jsonl"
+    _write_state(state_path)
+    _write_journal(journal_path)
+
+    trace = RouteTrace(
+        query_id="trace-1",
+        ts=10.0,
+        query_text="alpha",
+        decision_points=[
+            RouteDecisionPoint(
+                query_text="alpha",
+                source_id="seed",
+                source_preview="seed",
+                chosen_target_id="target_a",
+                candidates=[RouteCandidate(target_id="target_a", edge_weight=0.35, edge_relevance=0.0)],
+                reward_source=RewardSource.TEACHER,
+                ts=10.0,
+            ),
+            RouteDecisionPoint(
+                query_text="alpha",
+                source_id="seed",
+                source_preview="seed",
+                chosen_target_id="target_b",
+                candidates=[RouteCandidate(target_id="target_b", edge_weight=0.30, edge_relevance=0.0)],
+                reward_source=RewardSource.TEACHER,
+                ts=11.0,
+            ),
+        ],
+    )
+    traces_in.write_text(route_trace_to_json(trace) + "\n", encoding="utf-8")
+
+    existing = LabelRecord(
+        query_id="existing",
+        decision_point_idx=0,
+        candidate_scores={"seed": 1.0},
+        reward_source=RewardSource.SELF,
+        weight=1.0,
+        ts=1.0,
+        metadata={"kind": "existing"},
+    )
+    write_labels_jsonl(labels_out, [existing])
+
+    def _teacher(points):
+        return [{"target_a": 1.0}, {"target_b": -0.5}], []
+
+    run_async_route_pg(
+        state_path=str(state_path),
+        journal_path=str(journal_path),
+        traces_in=str(traces_in),
+        traces_out=str(traces_out),
+        labels_out=str(labels_out),
+        teacher="none",
+        apply=False,
+        teacher_labeler=_teacher,
+    )
+
+    out_lines = [line for line in traces_out.read_text(encoding="utf-8").splitlines() if line.strip()]
+    assert out_lines
+    trace_payload = json.loads(out_lines[0])
+    point_payloads = trace_payload.get("decision_points", [])
+    assert point_payloads[0]["teacher_scores"] == {"target_a": 1.0}
+    assert point_payloads[1]["teacher_scores"] == {"target_b": -0.5}
+
+    labels = read_labels_jsonl(labels_out)
+    assert len(labels) == 3
+    teacher_labels = [label for label in labels if label.reward_source == RewardSource.TEACHER]
+    assert len(teacher_labels) == 2
+    assert {label.decision_point_idx for label in teacher_labels} == {0, 1}
+    for label in teacher_labels:
+        assert label.query_id == "trace-1"
+        assert label.metadata.get("teacher_model") == "gpt-5-mini"
+        assert label.metadata.get("teacher_requested") == "none"

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from openclawbrain.labels import (
     LabelRecord,
+    append_labels_jsonl,
     from_human_correction,
     from_self_learning_event,
     from_teacher_output,
@@ -29,6 +30,31 @@ def test_label_record_serialization_roundtrip(tmp_path: Path) -> None:
     loaded = read_labels_jsonl(path)
     assert len(loaded) == 1
     assert loaded[0] == record
+
+
+def test_append_labels_jsonl_appends_lines(tmp_path: Path) -> None:
+    path = tmp_path / "labels.jsonl"
+    record_a = LabelRecord(
+        query_id="q1",
+        decision_point_idx=0,
+        candidate_scores={"a": 1.0},
+        reward_source=RewardSource.HUMAN,
+        weight=1.0,
+        ts=1.0,
+    )
+    record_b = LabelRecord(
+        query_id="q2",
+        decision_point_idx=1,
+        candidate_scores={"b": -0.5},
+        reward_source=RewardSource.TEACHER,
+        weight=0.9,
+        ts=2.0,
+    )
+    write_labels_jsonl(path, [record_a])
+    append_labels_jsonl(path, [record_b])
+
+    loaded = read_labels_jsonl(path)
+    assert [item.query_id for item in loaded] == ["q1", "q2"]
 
 
 def test_label_conversions_human_self_teacher() -> None:


### PR DESCRIPTION
## Summary\n- persist teacher labels into route traces and append to labels JSONL\n- add labels-out plumbing for async-route-pg\n- add append helper + tests + README updates\n\n## Testing\n- python3 -m pytest tests/test_async_route_pg.py tests/test_labels.py