### PR TITLE
Harden labels store, init routing, and fastembed cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -581,6 +581,7 @@ from openclawbrain import (
 - **Optional OpenAI:** install `openclawbrain[openai]` and use `--embedder openai` (or OpenAI teacher labeling via `async-route-pg`) when you want API-backed labels/embeddings.
 - **Batch init:** `openclawbrain init` embeds all workspace files in one batch call. Subsequent queries reuse cached vectors.
 - **Explicit control:** use `--embedder local` / `--embedder openai` to force a specific embedder. Use `--embed-model BAAI/bge-small-en-v1.5` to choose a smaller local model, or pass a bespoke fastembed model string. Use `--llm none` to skip LLM-assisted splitting.
+- **fastembed cache:** stored at `~/.cache/fastembed` by default. Override with `FASTEMBED_CACHE_PATH`.
 
 Example: switching an existing state to a different local model
 

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -15,6 +15,7 @@ openclawbrain info --state ./brain/state.json
 ```
 
 By default, `init` uses local embeddings (`--embedder auto` resolves to local) and does not require OpenAI. Use `--embedder openai` if you explicitly want OpenAI embeddings.
+fastembed cache lives at `~/.cache/fastembed` by default; override with `FASTEMBED_CACHE_PATH` if you want a different persistent location.
 
 Daemon query embedder default is `--embed-model auto`:
 - `local:*` states use local query embeddings.

--- a/openclawbrain/cli.py
+++ b/openclawbrain/cli.py
@@ -77,7 +77,14 @@ from .full_learning import (
 from ._util import _tokenize
 from .maintain import run_maintenance
 from .reward import RewardSource, RewardWeights
-from .labels import LabelRecord, from_self_learning_event, from_teacher_output, write_labels_jsonl
+from .labels import (
+    LabelRecord,
+    append_labels_jsonl,
+    from_self_learning_event,
+    from_teacher_output,
+    read_labels_jsonl,
+    write_labels_jsonl,
+)
 from .trace import RouteTrace, route_trace_to_json
 from .state_lock import StateLockError, lock_path_for_state, state_write_lock
 from .store import load_state, save_state, resolve_default_state_path
@@ -96,6 +103,10 @@ LOOP_CHECKPOINT_FILENAME = "loop.checkpoint.json"
 LOOP_MANIFEST_FILENAME = "loop.manifest.json"
 LOOP_STDOUT_FILENAME = "loop.stdout.log"
 LOOP_STDERR_FILENAME = "loop.stderr.log"
+INIT_ROUTE_SINCE_HOURS = 100000
+INIT_ROUTE_MAX_QUERIES = 100000
+INIT_ROUTE_SAMPLE_RATE = 1.0
+INIT_ROUTE_TRACES_FILENAME = "init.route_traces.jsonl"
 REPLAY_HELP_EPILOG = (
     "Replay modes and rough cost profile:\n"
     "  edges-only    Fastest/cheapest. No LLM calls, no harvest.\n"
@@ -196,6 +207,7 @@ def _build_all_root_manifest_payload(
             "replay_priority": str(args.replay_priority),
             "advance_offsets_on_skip": bool(args.advance_offsets_on_skip),
             "enable_async_teacher": bool(args.enable_async_teacher),
+            "skip_init_route_model": bool(args.skip_init_route_model),
             "events_jsonl": str(events_jsonl),
         },
         "agents": agents or [],
@@ -719,13 +731,19 @@ def _build_all_agent_pipeline(
     maintain_path = scratch / f"{prefix}.maintain.json"
     async_route_path = scratch / f"{prefix}.async-route-pg.json"
     train_route_path = scratch / f"{prefix}.train-route-model.json"
+    init_harvest_path = scratch / f"{prefix}.init.harvest.json"
     traces_out_path = scratch / f"{prefix}.route_traces.jsonl"
     route_model_out_path = scratch / f"{prefix}.route_model.npz"
+    init_async_route_path = scratch / f"{prefix}.init.async-route-pg.json"
+    init_train_route_path = scratch / f"{prefix}.init.train-route-model.json"
+    init_traces_path = scratch / INIT_ROUTE_TRACES_FILENAME
+    init_route_model_out_path = agent_root / "route_model.npz"
     agent_manifest_path = scratch / f"{prefix}.manifest.json"
 
     state_path = agent_root / "state.json"
     sessions_path = Path.home() / ".openclaw" / "agents" / agent_id / "sessions"
     checkpoint_path = agent_root / REPLAY_CHECKPOINT_FILENAME
+    labels_path = _default_labels_path(str(state_path))
 
     steps: list[dict[str, object]] = []
     exit_code = 0
@@ -985,6 +1003,87 @@ def _build_all_agent_pipeline(
     else:
         emit_skipped("maintain", reason=last_error, code=exit_code, stdout_path=maintain_path)
 
+    if exit_code == 0 and not args.skip_init_route_model:
+        preserved = [record for record in read_labels_jsonl(labels_path) if record.reward_source != RewardSource.HARVESTER]
+        harvest_cmd = [
+            ocb_bin,
+            "harvest",
+            "--state",
+            str(state_path),
+            "--dry-run",
+            "--labels-out",
+            str(labels_path),
+            "--json",
+        ]
+        exit_code = run_step("init_harvest_labels", harvest_cmd, stdout_path=init_harvest_path)
+        if exit_code == 0 and preserved:
+            append_labels_jsonl(labels_path, preserved)
+        if exit_code == 0:
+            init_async_cmd = [
+                ocb_bin,
+                "async-route-pg",
+                "--state",
+                str(state_path),
+                "--teacher",
+                str(args.teacher),
+                "--teacher-model",
+                str(args.teacher_model),
+                "--since-hours",
+                str(INIT_ROUTE_SINCE_HOURS),
+                "--max-queries",
+                str(INIT_ROUTE_MAX_QUERIES),
+                "--sample-rate",
+                str(INIT_ROUTE_SAMPLE_RATE),
+                "--max-candidates-per-node",
+                str(args.max_candidates_per_node),
+                "--max-decision-points",
+                str(args.max_decision_points),
+                "--score-scale",
+                str(args.score_scale),
+                "--reward-source",
+                str(args.reward_source),
+                "--labels-out",
+                str(labels_path),
+                "--traces-out",
+                str(init_traces_path),
+                "--include-query-vector",
+                "--apply",
+                "--json",
+            ]
+            if args.reward_weights:
+                init_async_cmd.extend(["--reward-weights", str(args.reward_weights)])
+            if args.write_relevance_metadata:
+                init_async_cmd.append("--write-relevance-metadata")
+            else:
+                init_async_cmd.append("--no-write-relevance-metadata")
+
+            exit_code = run_step("init_async_route_pg", init_async_cmd, stdout_path=init_async_route_path)
+            if exit_code == 0 and init_traces_path.exists() and init_traces_path.stat().st_size > 0:
+                init_train_cmd = [
+                    ocb_bin,
+                    "train-route-model",
+                    "--state",
+                    str(state_path),
+                    "--traces-in",
+                    str(init_traces_path),
+                    "--labels-in",
+                    str(labels_path),
+                    "--out",
+                    str(init_route_model_out_path),
+                    "--json",
+                ]
+                exit_code = run_step("init_train_route_model", init_train_cmd, stdout_path=init_train_route_path)
+            else:
+                skip_reason = "missing traces" if exit_code == 0 else "init async route failed"
+                emit_skipped("init_train_route_model", reason=skip_reason, code=exit_code, stdout_path=init_train_route_path)
+        else:
+            emit_skipped("init_async_route_pg", reason="init harvest failed", code=exit_code, stdout_path=init_async_route_path)
+            emit_skipped("init_train_route_model", reason="init harvest failed", code=exit_code, stdout_path=init_train_route_path)
+    elif exit_code == 0:
+        emit_skipped("init_harvest_labels", reason="disabled", code=0, stdout_path=init_harvest_path)
+        emit_skipped("init_async_route_pg", reason="disabled", code=0, stdout_path=init_async_route_path)
+        emit_skipped("init_train_route_model", reason="disabled", code=0, stdout_path=init_train_route_path)
+
     if exit_code == 0 and args.enable_async_teacher:
         async_cmd = [
             ocb_bin,
@@ -1009,6 +1108,8 @@ def _build_all_agent_pipeline(
             str(args.score_scale),
             "--reward-source",
             str(args.reward_source),
+            "--labels-out",
+            str(labels_path),
             "--traces-out",
             str(traces_out_path),
             "--apply",
@@ -1030,6 +1131,8 @@ def _build_all_agent_pipeline(
                 str(state_path),
                 "--traces-in",
                 str(traces_out_path),
+                "--labels-in",
+                str(labels_path),
                 "--out",
                 str(route_model_out_path),
                 "--json",
@@ -1598,6 +1701,7 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     dream.add_argument("--reward-weights", default=None, help="Comma-separated weights: human=1.0,self=0.6,harvester=0.3,teacher=0.1")
     dream.add_argument("--traces-dir", default=None)
+    dream.add_argument("--labels-out", default=None)
     dream.add_argument("--json", action="store_true")
 
     loop = sub.add_parser(
@@ -1686,6 +1790,7 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     dreaming.add_argument("--reward-weights", default=None, help="Comma-separated weights: human=1.0,self=0.6,harvester=0.3,teacher=0.1")
     dreaming.add_argument("--traces-dir", default=None)
+    dreaming.add_argument("--labels-out", default=None)
     dreaming.add_argument("--json", action="store_true")
 
     tr = sub.add_parser("train-route-model")
@@ -1788,6 +1893,11 @@ def _build_parser() -> argparse.ArgumentParser:
     build_all.add_argument("--reward-weights", default=None)
     build_all.add_argument("--write-relevance-metadata", action=argparse.BooleanOptionalAction, default=True)
     build_all.add_argument(
+        "--skip-init-route-model",
+        action="store_true",
+        help="Skip one-shot route model init (harvest + async-route-pg + train-route-model).",
+    )
+    build_all.add_argument(
         "--events-jsonl",
         default=None,
         help="Optional path for build-all JSONL event stream. Defaults to ~/.openclawbrain/scratch/build-all.<ts>.events.jsonl",
@@ -1806,6 +1916,11 @@ def _build_parser() -> argparse.ArgumentParser:
     openclaw.add_argument("--state", help="Explicit state.json path (overrides --agent)")
     openclaw.add_argument("--hooks-path", help="Path to openclawbrain-context-injector hook directory")
     openclaw.add_argument("--env-file", help="Optional .env file to pass into launchd service plists")
+    openclaw.add_argument(
+        "--skip-init-route-model",
+        action="store_true",
+        help="Skip one-shot route model init (harvest + async-route-pg + train-route-model).",
+    )
     openclaw.add_argument("--yes", action="store_true", help="Skip confirmation prompts")
     return parser
 
@@ -2463,6 +2578,22 @@ def _default_dream_traces_dir(state_path: str) -> Path:
     resolved_state = Path(state_path).expanduser()
     agent = resolved_state.parent.name or "default"
     return Path.home() / ".openclawbrain" / agent / "scratch"
+
+
+def _default_labels_path(state_path: str) -> Path:
+    """Resolve default labels.jsonl path for a state file."""
+    return Path(state_path).expanduser().parent / "labels.jsonl"
+
+
+def _refresh_labels_from_harvest(labels_path: Path, harvest_output_path: Path) -> None:
+    """Replace labels file with harvest output, preserving non-harvester labels."""
+    preserved = [
+        record for record in read_labels_jsonl(labels_path)
+        if record.reward_source != RewardSource.HARVESTER
+    ]
+    if preserved:
+        append_labels_jsonl(harvest_output_path, preserved)
+    harvest_output_path.replace(labels_path)
 
 
 def _load_session_query_records(session_paths: str | Iterable[str], since_ts: float | None = None) -> list[tuple[str, float | None]]:
@@ -4958,6 +5089,7 @@ def cmd_async_route_pg(args: argparse.Namespace) -> int:
         parsed_weights = RewardWeights.from_string(args.reward_weights) if args.reward_weights else RewardWeights.from_env()
     except ValueError as exc:
         raise SystemExit(str(exc)) from exc
+    labels_out = str(Path(args.labels_out).expanduser()) if args.labels_out else str(_default_labels_path(state_path))
     summary = run_async_route_pg(
         state_path=state_path,
         journal_path=journal_path,
@@ -4973,7 +5105,7 @@ def cmd_async_route_pg(args: argparse.Namespace) -> int:
         score_scale=float(args.score_scale),
         traces_out=str(args.traces_out) if args.traces_out else None,
         traces_in=str(args.traces_in) if args.traces_in else None,
-        labels_out=str(args.labels_out) if args.labels_out else None,
+        labels_out=labels_out,
         include_query_vector=bool(args.include_query_vector),
         reward_source=RewardSource.parse(args.reward_source),
         reward_weights=parsed_weights,
@@ -5013,6 +5145,7 @@ def cmd_dream(args: argparse.Namespace) -> int:
         raise SystemExit(str(exc)) from exc
 
     traces_dir = Path(args.traces_dir).expanduser() if args.traces_dir else _default_dream_traces_dir(state_path)
+    labels_out = str(Path(args.labels_out).expanduser()) if args.labels_out else str(_default_labels_path(state_path))
     interval_seconds = max(1, int(args.interval_seconds))
     cycle = 0
 
@@ -5051,6 +5184,7 @@ def cmd_dream(args: argparse.Namespace) -> int:
                         score_scale=float(args.score_scale),
                         traces_out=str(traces_out),
                         traces_in=None,
+                        labels_out=labels_out,
                         include_query_vector=False,
                         reward_source=RewardSource.parse(args.reward_source),
                         reward_weights=parsed_weights,
@@ -5080,6 +5214,7 @@ def cmd_dream(args: argparse.Namespace) -> int:
                 score_scale=float(args.score_scale),
                 traces_out=str(traces_out),
                 traces_in=None,
+                labels_out=labels_out,
                 include_query_vector=False,
                 reward_source=RewardSource.parse(args.reward_source),
                 reward_weights=parsed_weights,
@@ -5127,6 +5262,7 @@ def cmd_loop(args: argparse.Namespace) -> int:
     if state_path is None:
         raise SystemExit("--state or --agent is required for loop")
     state_path = str(Path(state_path).expanduser())
+    labels_path = _default_labels_path(state_path)
 
     agent_root = _loop_state_root(state_path)
     agent_id = agent_root.name or "main"
@@ -5533,6 +5669,31 @@ def cmd_loop(args: argparse.Namespace) -> int:
         emit_event({"type": "step_end", "job": job, "step": "harvest", "exit_code": code})
         return code
 
+    def run_harvest_labels(*, job: str) -> int:
+        temp_path = labels_path.with_suffix(".harvest.tmp")
+        harvest_cmd = [
+            *ocb_prefix,
+            "harvest",
+            "--state",
+            state_path,
+            "--dry-run",
+            "--labels-out",
+            str(temp_path),
+            "--json",
+        ]
+        write_checkpoint(status="running", job=job, step="harvest_labels")
+        emit_event({"type": "step_start", "job": job, "step": "harvest_labels"})
+        code = _run_logged_command(harvest_cmd, log_path=log_path, step_name=f"{job}.harvest_labels")
+        emit_event({"type": "step_end", "job": job, "step": "harvest_labels", "exit_code": code})
+        if code != 0:
+            return code
+        try:
+            _refresh_labels_from_harvest(labels_path, temp_path)
+        except OSError as exc:
+            log_line(f"{job}: harvest labels refresh failed to replace labels file: {exc}")
+            return 1
+        return 0
+
     def run_maintain(*, job: str) -> int:
         maintain_cmd = [
             *ocb_prefix,
@@ -5583,6 +5744,8 @@ def cmd_loop(args: argparse.Namespace) -> int:
             str(args.reward_source),
             "--apply",
             "--json",
+            "--labels-out",
+            str(labels_path),
         ]
         if args.reward_weights:
             async_cmd.extend(["--reward-weights", str(args.reward_weights)])
@@ -5612,6 +5775,8 @@ def cmd_loop(args: argparse.Namespace) -> int:
             state_path,
             "--traces-in",
             str(traces_in),
+            "--labels-in",
+            str(labels_path),
             "--out",
             str(out_path),
             "--json",
@@ -5745,6 +5910,9 @@ def cmd_loop(args: argparse.Namespace) -> int:
 
                 traces_out: Path | None = None
                 if include_teacher:
+                    labels_refresh_code = run_harvest_labels(job=job)
+                    if labels_refresh_code != 0:
+                        log_line(f"{job}: harvest labels refresh failed exit={labels_refresh_code}")
                     traces_root = _loop_state_root(state_path) / "scratch"
                     traces_root.mkdir(parents=True, exist_ok=True)
                     if args.enable_train_route_model:
@@ -6107,6 +6275,10 @@ def cmd_openclaw(args: argparse.Namespace) -> int:
             print("Aborted.")
             return 1
         hooks_path = _resolve_hooks_path(args.hooks_path)
+        labels_path = _default_labels_path(state_path)
+        scratch_dir = Path(state_path).expanduser().parent / "scratch"
+        scratch_dir.mkdir(parents=True, exist_ok=True)
+        traces_out = scratch_dir / INIT_ROUTE_TRACES_FILENAME
         codes = []
         serve_cmd = [*ocb_prefix, "serve", "install", "--state", state_path]
         if args.env_file:
@@ -6118,6 +6290,56 @@ def cmd_openclaw(args: argparse.Namespace) -> int:
         if args.env_file:
             loop_cmd.extend(["--env-file", str(Path(args.env_file).expanduser())])
         codes.append(run_step("loop install", loop_cmd))
+        if not args.skip_init_route_model:
+            preserved = [record for record in read_labels_jsonl(labels_path) if record.reward_source != RewardSource.HARVESTER]
+            harvest_cmd = [
+                *ocb_prefix,
+                "harvest",
+                "--state",
+                state_path,
+                "--dry-run",
+                "--labels-out",
+                str(labels_path),
+            ]
+            harvest_code = run_step("init harvest labels", harvest_cmd)
+            codes.append(harvest_code)
+            if harvest_code == 0 and preserved:
+                append_labels_jsonl(labels_path, preserved)
+            if harvest_code == 0:
+                async_cmd = [
+                    *ocb_prefix,
+                    "async-route-pg",
+                    "--state",
+                    state_path,
+                    "--since-hours",
+                    str(INIT_ROUTE_SINCE_HOURS),
+                    "--max-queries",
+                    str(INIT_ROUTE_MAX_QUERIES),
+                    "--sample-rate",
+                    str(INIT_ROUTE_SAMPLE_RATE),
+                    "--labels-out",
+                    str(labels_path),
+                    "--traces-out",
+                    str(traces_out),
+                    "--include-query-vector",
+                    "--apply",
+                ]
+                async_code = run_step("init async-route-pg", async_cmd)
+                codes.append(async_code)
+                if async_code == 0 and traces_out.exists() and traces_out.stat().st_size > 0:
+                    train_cmd = [
+                        *ocb_prefix,
+                        "train-route-model",
+                        "--state",
+                        state_path,
+                        "--traces-in",
+                        str(traces_out),
+                        "--labels-in",
+                        str(labels_path),
+                        "--out",
+                        str(Path(state_path).expanduser().parent / "route_model.npz"),
+                    ]
+                    codes.append(run_step("init train-route-model", train_cmd))
         codes.append(run_step("gateway restart", ["openclaw", "gateway", "restart"]))
         return 0 if all(code == 0 for code in codes) else 1
 

--- a/openclawbrain/local_embedder.py
+++ b/openclawbrain/local_embedder.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import os
+from pathlib import Path
 
 import numpy as np
 
@@ -15,7 +16,20 @@ _LOCAL_MODEL_TAG_MAP = {
     "bge-small-en-v1.5": "BAAI/bge-small-en-v1.5",
 }
 
-_MODEL_CACHE: dict[str, object] = {}
+FASTEMBED_CACHE_ENV = "FASTEMBED_CACHE_PATH"
+DEFAULT_FASTEMBED_CACHE_DIR = Path.home() / ".cache" / "fastembed"
+
+_MODEL_CACHE: dict[tuple[str, str | None], object] = {}
+
+
+def resolve_fastembed_cache_dir(cache_dir: str | None = None) -> str | None:
+    """Resolve fastembed cache dir with env override."""
+    if cache_dir and str(cache_dir).strip():
+        return str(Path(cache_dir).expanduser())
+    env_value = os.environ.get(FASTEMBED_CACHE_ENV)
+    if env_value and env_value.strip():
+        return str(Path(env_value).expanduser())
+    return str(DEFAULT_FASTEMBED_CACHE_DIR)
 
 
 def _stub_dim_for_model(model_name: str) -> int:
@@ -97,6 +111,7 @@ class LocalEmbedder:
     """Fast local embedder powered by `fastembed`."""
 
     model_name: str = DEFAULT_LOCAL_MODEL
+    cache_dir: str | None = None
     _dim: int | None = None
 
     @property
@@ -110,7 +125,9 @@ class LocalEmbedder:
         return self._dim
 
     def _model(self):
-        cached = _MODEL_CACHE.get(self.model_name)
+        cache_dir = resolve_fastembed_cache_dir(self.cache_dir)
+        cache_key = (self.model_name, cache_dir)
+        cached = _MODEL_CACHE.get(cache_key)
         if cached is not None:
             return cached
         try:
@@ -118,11 +135,11 @@ class LocalEmbedder:
         except ImportError as exc:
             if os.environ.get("OPENCLAWBRAIN_FASTEMBED_STUB"):
                 model = _StubTextEmbedding(self.model_name)
-                _MODEL_CACHE[self.model_name] = model
+                _MODEL_CACHE[cache_key] = model
                 return model
             raise ImportError("fastembed is required for local embeddings") from exc
-        model = TextEmbedding(model_name=self.model_name)
-        _MODEL_CACHE[self.model_name] = model
+        model = TextEmbedding(model_name=self.model_name, cache_dir=cache_dir)
+        _MODEL_CACHE[cache_key] = model
         return model
 
     def embed(self, text: str) -> list[float]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,7 +13,13 @@ import pytest
 
 from datetime import datetime, timezone
 
-from openclawbrain.cli import main, _read_replay_checkpoint_progress, _resolve_openclawbrain_bin, _filter_replay_interactions
+from openclawbrain.cli import (
+    main,
+    _read_replay_checkpoint_progress,
+    _resolve_openclawbrain_bin,
+    _filter_replay_interactions,
+    _default_labels_path,
+)
 from openclawbrain.graph import Graph, Node
 from openclawbrain.hasher import default_embed
 from openclawbrain.journal import read_journal
@@ -189,6 +195,12 @@ def test_resolve_openclawbrain_bin_prefers_sys_argv(tmp_path, monkeypatch) -> No
     monkeypatch.setattr("openclawbrain.cli.shutil.which", lambda _: "/opt/homebrew/bin/openclawbrain")
 
     assert _resolve_openclawbrain_bin() == str(bin_path)
+
+
+def test_default_labels_path_resolves_from_state_path(tmp_path) -> None:
+    state_path = tmp_path / "brain" / "state.json"
+    expected = state_path.parent / "labels.jsonl"
+    assert _default_labels_path(str(state_path)) == expected
 
 
 def test_query_command_returns_json_with_fired_nodes(tmp_path, capsys, monkeypatch) -> None:

--- a/tests/test_local_embedder.py
+++ b/tests/test_local_embedder.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 import importlib
 import math
+from pathlib import Path
 import sys
 import types
 
 
 def test_local_embedder_embed_is_normalized_and_sets_dim(monkeypatch) -> None:
     class FakeTextEmbedding:
-        def __init__(self, model_name: str) -> None:
+        def __init__(self, model_name: str, cache_dir: str | None = None) -> None:
             self.model_name = model_name
 
         def embed(self, texts: list[str]):
@@ -34,7 +35,7 @@ def test_local_embedder_embed_is_normalized_and_sets_dim(monkeypatch) -> None:
 
 def test_local_embedder_embed_batch_is_normalized(monkeypatch) -> None:
     class FakeTextEmbedding:
-        def __init__(self, model_name: str) -> None:
+        def __init__(self, model_name: str, cache_dir: str | None = None) -> None:
             self.model_name = model_name
 
         def embed(self, texts: list[str]):
@@ -56,3 +57,38 @@ def test_local_embedder_embed_batch_is_normalized(monkeypatch) -> None:
     assert embedder.dim == 3
     assert math.isclose(sum(v * v for v in vectors["a"]), 1.0, rel_tol=1e-6)
     assert math.isclose(sum(v * v for v in vectors["b"]), 1.0, rel_tol=1e-6)
+
+
+def test_local_embedder_uses_persistent_cache_dir(monkeypatch, tmp_path) -> None:
+    seen: dict[str, str | None] = {}
+
+    class FakeTextEmbedding:
+        def __init__(self, model_name: str, cache_dir: str | None = None) -> None:
+            seen["model_name"] = model_name
+            seen["cache_dir"] = cache_dir
+
+        def embed(self, texts: list[str]):
+            for _text in texts:
+                yield [1.0, 0.0, 0.0]
+
+    fake_fastembed = types.ModuleType("fastembed")
+    fake_fastembed.TextEmbedding = FakeTextEmbedding
+    monkeypatch.setitem(sys.modules, "fastembed", fake_fastembed)
+
+    module_name = "openclawbrain.local_embedder"
+    sys.modules.pop(module_name, None)
+    module = importlib.import_module(module_name)
+    module._MODEL_CACHE.clear()
+
+    monkeypatch.delenv("FASTEMBED_CACHE_PATH", raising=False)
+    embedder = module.LocalEmbedder()
+    embedder.embed("hello")
+    assert seen["cache_dir"] == str(Path.home() / ".cache" / "fastembed")
+
+    custom_dir = tmp_path / "fastembed-cache"
+    monkeypatch.setenv("FASTEMBED_CACHE_PATH", str(custom_dir))
+    module._MODEL_CACHE.clear()
+    seen.clear()
+    embedder = module.LocalEmbedder()
+    embedder.embed("hello again")
+    assert seen["cache_dir"] == str(custom_dir)


### PR DESCRIPTION
## Summary
- default fastembed cache dir with FASTEMBED_CACHE_PATH override
- add canonical labels.jsonl path usage and refresh flow in loop/dream/async-route
- add init route-model bootstrap in openclaw install and build-all (skippable)

## Testing
- pytest tests/test_local_embedder.py tests/test_cli.py::test_default_labels_path_resolves_from_state_path