### PR TITLE
Add single-brain state path overrides

### DIFF
--- a/integrations/openclaw/hooks/openclawbrain-context-injector/HOOK.md
+++ b/integrations/openclaw/hooks/openclawbrain-context-injector/HOOK.md
@@ -31,7 +31,8 @@ On each `message:preprocessed` event, the hook does:
    - match `event.context.workspaceDir` against `event.context.cfg.agents.list[].workspace`.
    - fallback: `main`.
 4. Compute state path:
-   - `~/.openclawbrain/<agentId>/state.json`.
+   - `OPENCLAWBRAIN_STATE_PATH` when set (non-empty).
+   - Otherwise `~/.openclawbrain/<agentId>/state.json` (agentId can be forced with `OPENCLAWBRAIN_AGENT_ID`).
 5. Compute `chatId`:
    - `${channelId}:${conversationId}` when both exist.
 6. Budget:
@@ -62,3 +63,11 @@ Keep bootstrap exclusions and redaction enabled:
 - `--redact`
 
 The emitted prompt block is a `[BRAIN_CONTEXT ...]` section and is marked as data-only context.
+
+## Single brain mode
+
+To share one brain state across all agents on a machine, set a fixed state path:
+
+```bash
+export OPENCLAWBRAIN_STATE_PATH=~/.openclawbrain/main/state.json
+```

--- a/integrations/openclaw/hooks/openclawbrain-context-injector/handler.ts
+++ b/integrations/openclaw/hooks/openclawbrain-context-injector/handler.ts
@@ -4,6 +4,7 @@ import { homedir } from "node:os";
 import * as path from "node:path";
 import { createHash } from "node:crypto";
 import { promisify } from "node:util";
+import { resolveStatePath } from "./state-path.js";
 
 const execFileAsync = promisify(execFile);
 const HOOK_VENV_PYTHON = path.join(
@@ -225,7 +226,7 @@ export default async function handler(event: any): Promise<any> {
   }
 
   const agentId = resolveAgentId(context);
-  const statePath = path.join(homedir(), ".openclawbrain", agentId, "state.json");
+  const statePath = resolveStatePath(agentId);
   const budget = keywordIncreasedBudget(message) ? 80000 : 20000;
   const chatId =
     normalizeText(context?.channelId) && normalizeText(context?.conversationId)

--- a/integrations/openclaw/hooks/openclawbrain-context-injector/state-path.js
+++ b/integrations/openclaw/hooks/openclawbrain-context-injector/state-path.js
@@ -1,0 +1,16 @@
+import { homedir } from "node:os";
+import * as path from "node:path";
+
+function normalizeText(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+export function resolveStatePath(agentId, env = process.env) {
+  const override = normalizeText(env?.OPENCLAWBRAIN_STATE_PATH);
+  if (override) {
+    return override;
+  }
+  const forcedAgentId = normalizeText(env?.OPENCLAWBRAIN_AGENT_ID);
+  const resolvedAgentId = forcedAgentId || normalizeText(agentId) || "main";
+  return path.join(homedir(), ".openclawbrain", resolvedAgentId, "state.json");
+}

--- a/integrations/openclaw/hooks/openclawbrain-context-injector/state-path.test.js
+++ b/integrations/openclaw/hooks/openclawbrain-context-injector/state-path.test.js
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import { homedir } from "node:os";
+import * as path from "node:path";
+import { resolveStatePath } from "./state-path.js";
+
+const home = homedir();
+
+assert.equal(
+  resolveStatePath("agent-a", {
+    OPENCLAWBRAIN_STATE_PATH: "/tmp/openclawbrain/state.json",
+    OPENCLAWBRAIN_AGENT_ID: "forced",
+  }),
+  "/tmp/openclawbrain/state.json",
+);
+
+assert.equal(
+  resolveStatePath("agent-a", {
+    OPENCLAWBRAIN_AGENT_ID: "forced",
+  }),
+  path.join(home, ".openclawbrain", "forced", "state.json"),
+);
+
+assert.equal(
+  resolveStatePath("agent-a", {
+    OPENCLAWBRAIN_STATE_PATH: "  ",
+  }),
+  path.join(home, ".openclawbrain", "agent-a", "state.json"),
+);


### PR DESCRIPTION
## Summary
- add OPENCLAWBRAIN_STATE_PATH and OPENCLAWBRAIN_AGENT_ID overrides for state path resolution
- document single brain mode in the hook docs
- add a lightweight node assert test for state path resolution

## Testing
- not run (not requested)
