### PR TITLE
Handle missing daemon health in report

### DIFF
--- a/openclawbrain/cli.py
+++ b/openclawbrain/cli.py
@@ -118,6 +118,19 @@ REPLAY_HELP_EPILOG = (
     "  --checkpoint chooses the checkpoint file path."
 )
 
+_DEFAULT_DAEMON_HEALTH_TIMEOUT = 30.0
+
+
+def _daemon_health_timeout() -> float:
+    """Resolve daemon health timeout with env override."""
+    raw = os.getenv("OCB_DAEMON_HEALTH_TIMEOUT")
+    if raw is None:
+        return _DEFAULT_DAEMON_HEALTH_TIMEOUT
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return _DEFAULT_DAEMON_HEALTH_TIMEOUT
+
 
 def _write_json_atomic(path: Path, payload: object) -> None:
     """Write JSON payload via a temporary file and atomic rename."""
@@ -2070,7 +2083,7 @@ def _daemon_socket_status(state_path: str) -> tuple[bool, str]:
 def _socket_health_status(
     socket_path: str,
     *,
-    timeout: float = 5.0,
+    timeout: float | None = None,
 ) -> tuple[bool, dict[str, object] | None, str | None]:
     """Check socket existence + daemon health call via socket protocol."""
     resolved_socket = str(Path(socket_path).expanduser())
@@ -2079,6 +2092,8 @@ def _socket_health_status(
 
     from .socket_client import OCBClient
 
+    if timeout is None:
+        timeout = _daemon_health_timeout()
     try:
         with OCBClient(resolved_socket, timeout=timeout) as client:
             health = client.health()
@@ -4528,7 +4543,7 @@ def cmd_report(args: argparse.Namespace) -> int:
         raise SystemExit("--state is required for report")
     resolved_state = str(Path(state_path).expanduser())
     graph, _, _ = load_state(resolved_state)
-    health = measure_health(graph)
+    local_health = measure_health(graph)
 
     socket_path = _default_daemon_socket_path(resolved_state)
     socket_exists = Path(socket_path).exists()
@@ -4539,10 +4554,13 @@ def cmd_report(args: argparse.Namespace) -> int:
         if raw_pid.isdigit():
             pid = int(raw_pid)
     health_payload = None
+    health_warning = None
     if socket_exists:
-        ping_ok, health, _error = _socket_health_status(socket_path, timeout=2.0)
-        if ping_ok and isinstance(health, dict):
-            health_payload = health
+        ping_ok, daemon_health, _error = _socket_health_status(socket_path)
+        if ping_ok and isinstance(daemon_health, dict):
+            health_payload = daemon_health
+        else:
+            health_warning = "health unavailable (daemon timeout)"
 
     sync_payload = _read_json_optional(_sync_report_path(resolved_state))
     maintain_payload = _read_json_optional(_maintain_report_path(resolved_state))
@@ -4624,9 +4642,11 @@ def cmd_report(args: argparse.Namespace) -> int:
         "Daily brain update summary",
         f"  state: {resolved_state}",
         f"  daemon.sock: {'present' if socket_exists else 'missing'}" + (f" (pid {pid})" if pid is not None else ""),
-        f"  nodes: {graph.node_count()}  edges: {graph.edge_count()}  orphans: {health.orphan_nodes}",
-        f"  reflex: {health.reflex_pct:.1%}  habitual: {health.habitual_pct:.1%}  dormant: {health.dormant_pct:.1%}",
+        f"  nodes: {graph.node_count()}  edges: {graph.edge_count()}  orphans: {local_health.orphan_nodes}",
+        f"  reflex: {local_health.reflex_pct:.1%}  habitual: {local_health.habitual_pct:.1%}  dormant: {local_health.dormant_pct:.1%}",
     ]
+    if health_warning is not None:
+        lines.append(f"  warning: {health_warning}")
 
     route_model_present = None
     route_mode_effective = None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1407,6 +1407,32 @@ def test_serve_status_subcommand_uses_health_ping(monkeypatch, capsys) -> None:
     assert "edges=3" in out
 
 
+def test_report_handles_missing_daemon_health(monkeypatch, tmp_path, capsys) -> None:
+    """report should keep local stats and warn when daemon health is unavailable."""
+    from openclawbrain import cli as cli_module
+
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+    state_dir = tmp_path / "main"
+    state_dir.mkdir()
+    state_path = state_dir / "state.json"
+    _write_state(state_path)
+
+    socket_path = Path(cli_module._default_daemon_socket_path(str(state_path)))
+    socket_path.parent.mkdir(parents=True, exist_ok=True)
+    socket_path.write_text("", encoding="utf-8")
+
+    monkeypatch.setattr(cli_module, "_socket_health_status", lambda _path: (False, None, "timeout"))
+
+    code = main(["report", "--state", str(state_path)])
+    assert code == 0
+    out = capsys.readouterr().out
+    assert "warning: health unavailable (daemon timeout)" in out
+    assert "orphans:" in out
+
+
 def test_serve_stop_subcommand_sends_shutdown(monkeypatch, capsys) -> None:
     """`serve stop` should send daemon shutdown request over socket when reachable."""
     from openclawbrain import cli as cli_module


### PR DESCRIPTION
## Summary
- avoid overwriting local report health when daemon health ping fails
- add warning when daemon health is unavailable
- make daemon health timeout configurable with a safer default
- add regression test for report output when health is unavailable

## Testing
- python3 -m pytest tests/test_cli.py -k "report_handles_missing_daemon_health or socket_health_status"