### PR TITLE
Make sync multi-workspace aware

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,19 @@ See `examples/openai_embedder/` for a complete example.
 
 State writes are atomic (`temp` + `fsync` + `rename`) with `.bak` backup. Crash-safe.
 
+## Multi-workspace sync
+
+You can sync multiple workspaces into a single brain state without cross-deleting nodes:
+
+```bash
+openclawbrain sync --state ~/.openclawbrain/main/state.json \
+  --workspace ~/workspace-pelican \
+  --workspace ~/workspace-ops
+```
+
+`workspace_id` defaults to the workspace directory basename (with `workspace-` stripped). Use `--workspaces` for a comma-separated list if you prefer.
+Node ids are prefixed with `workspace_id` (for example: `pelican/docs/foo.md::0`).
+
 ## Low-Level Worker (`openclawbrain daemon`)
 
 For production use, prefer `openclawbrain serve`, which manages the daemon worker and socket lifecycle.

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -265,10 +265,12 @@ openclawbrain info --state ./brain/state.json
 openclawbrain sync --state ~/.openclawbrain/main/state.json --workspace ./my-workspace --embedder openai
 ```
 
+Multi-workspace sync is supported; repeat `--workspace` (or use `--workspaces` with a comma-separated list) to keep multiple workspaces in one brain state without cross-deletes.
+
 ## Step 8: Set constitutional anchors
 
 ```bash
-openclawbrain anchor --state ~/.openclawbrain/main/state.json --node-id "SOUL.md::0" --authority constitutional
+openclawbrain anchor --state ~/.openclawbrain/main/state.json --node-id "my-workspace/SOUL.md::0" --authority constitutional
 openclawbrain anchor --state ~/.openclawbrain/main/state.json --list
 ```
 

--- a/openclawbrain/cli.py
+++ b/openclawbrain/cli.py
@@ -55,10 +55,10 @@ from .replay import (
     replay_queries,
     replay_queries_parallel,
 )
-from .split import split_workspace
+from .split import split_workspace, _resolve_workspace_id
 from .hasher import HashEmbedder
 from .traverse import TraversalConfig, TraversalResult, traverse
-from .sync import DEFAULT_AUTHORITY_MAP, sync_workspace
+from .sync import DEFAULT_AUTHORITY_MAP, SyncReport, sync_workspace
 from .local_embedder import LocalEmbedder, resolve_local_model
 from .route_model import RouteModel
 from .full_learning import (
@@ -1839,7 +1839,8 @@ def _build_parser() -> argparse.ArgumentParser:
 
     sync = sub.add_parser("sync")
     sync.add_argument("--state")
-    sync.add_argument("--workspace", required=True)
+    sync.add_argument("--workspace", action="append")
+    sync.add_argument("--workspaces", help="Comma-separated workspace roots")
     sync.add_argument("--embedder", choices=["openai", "local"], default=None)
     sync.add_argument(
         "--authority-map",
@@ -4435,11 +4436,51 @@ def _parse_authority_map(raw: str | None) -> dict[str, str]:
     return parsed
 
 
+def _sum_sync_reports(reports: dict[str, SyncReport]) -> SyncReport:
+    """Aggregate per-workspace sync reports."""
+    totals = SyncReport(
+        nodes_added=0,
+        nodes_updated=0,
+        nodes_removed=0,
+        nodes_unchanged=0,
+        nodes_metadata_updated=0,
+        embeddings_computed=0,
+        authority_set={},
+    )
+    for report in reports.values():
+        totals.nodes_added += report.nodes_added
+        totals.nodes_updated += report.nodes_updated
+        totals.nodes_removed += report.nodes_removed
+        totals.nodes_unchanged += report.nodes_unchanged
+        totals.nodes_metadata_updated += report.nodes_metadata_updated
+        totals.embeddings_computed += report.embeddings_computed
+        for key, value in report.authority_set.items():
+            totals.authority_set[key] = totals.authority_set.get(key, 0) + value
+    return totals
+
+
 def cmd_sync(args: argparse.Namespace) -> int:
     """cmd sync."""
     state_path = _resolve_state_path(args.state, allow_default=True)
     if state_path is None:
         raise SystemExit("--state is required for sync")
+    raw_workspaces: list[str] = []
+    if args.workspace:
+        raw_workspaces.extend(args.workspace)
+    if args.workspaces:
+        raw_workspaces.extend([item.strip() for item in args.workspaces.split(",") if item.strip()])
+    if not raw_workspaces:
+        raise SystemExit("--workspace or --workspaces is required for sync")
+
+    workspaces: list[str] = []
+    seen: set[str] = set()
+    for item in raw_workspaces:
+        resolved = str(Path(item).expanduser())
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        workspaces.append(resolved)
+
     authority_map = _parse_authority_map(getattr(args, "authority_map", None))
     graph, index, meta = _resolve_graph_index(args, allow_default_state=True)
 
@@ -4449,22 +4490,42 @@ def cmd_sync(args: argparse.Namespace) -> int:
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_state = Path(tmp_dir) / "state.json"
             shutil.copy2(state_path, tmp_state)
-            report = sync_workspace(
-                state_path=str(tmp_state),
-                workspace_dir=args.workspace,
-                embed_fn=embed_fn,
-                embed_batch_fn=embed_batch_fn,
-                journal_path=None,
-                authority_map=authority_map,
-            )
-            if args.json:
-                print(json.dumps(asdict(report), indent=2))
-            else:
-                print(
-                    f"sync report: +{report.nodes_added}/~{report.nodes_updated} "
-                    f"-{report.nodes_removed} ={report.nodes_unchanged} unchanged | "
-                    f"{report.embeddings_computed} embeddings"
+            reports: dict[str, SyncReport] = {}
+            for workspace in workspaces:
+                workspace_id = _resolve_workspace_id(workspace)
+                reports[workspace_id] = sync_workspace(
+                    state_path=str(tmp_state),
+                    workspace_dir=workspace,
+                    workspace_id=workspace_id,
+                    embed_fn=embed_fn,
+                    embed_batch_fn=embed_batch_fn,
+                    journal_path=None,
+                    authority_map=authority_map,
                 )
+            if args.json:
+                payload = {"workspaces": {key: asdict(value) for key, value in reports.items()}}
+                print(json.dumps(payload, indent=2))
+            else:
+                if len(reports) == 1:
+                    report = next(iter(reports.values()))
+                    print(
+                        f"sync report: +{report.nodes_added}/~{report.nodes_updated} "
+                        f"-{report.nodes_removed} ={report.nodes_unchanged} unchanged | "
+                        f"{report.embeddings_computed} embeddings"
+                    )
+                else:
+                    for workspace_id, report in reports.items():
+                        print(
+                            f"sync[{workspace_id}]: +{report.nodes_added}/~{report.nodes_updated} "
+                            f"-{report.nodes_removed} ={report.nodes_unchanged} unchanged | "
+                            f"{report.embeddings_computed} embeddings"
+                        )
+                    totals = _sum_sync_reports(reports)
+                    print(
+                        f"sync total: +{totals.nodes_added}/~{totals.nodes_updated} "
+                        f"-{totals.nodes_removed} ={totals.nodes_unchanged} unchanged | "
+                        f"{totals.embeddings_computed} embeddings"
+                    )
                 graph, _, _ = load_state(str(tmp_state))
                 health = measure_health(graph)
                 print(
@@ -4474,19 +4535,23 @@ def cmd_sync(args: argparse.Namespace) -> int:
                 )
             return 0
 
-    report = sync_workspace(
-        state_path=state_path,
-        workspace_dir=args.workspace,
-        embed_fn=embed_fn,
-        embed_batch_fn=embed_batch_fn,
-        journal_path=_resolve_journal_path(args, allow_default_state=True),
-        authority_map=authority_map,
-    )
+    reports = {}
+    for workspace in workspaces:
+        workspace_id = _resolve_workspace_id(workspace)
+        reports[workspace_id] = sync_workspace(
+            state_path=state_path,
+            workspace_dir=workspace,
+            workspace_id=workspace_id,
+            embed_fn=embed_fn,
+            embed_batch_fn=embed_batch_fn,
+            journal_path=_resolve_journal_path(args, allow_default_state=True),
+            authority_map=authority_map,
+        )
 
     _write_json_atomic(
         _sync_report_path(state_path),
         {
-            **asdict(report),
+            "workspaces": {key: asdict(value) for key, value in reports.items()},
             "state_path": str(Path(state_path).expanduser()),
             "ts": time.time(),
             "iso": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
@@ -4494,13 +4559,28 @@ def cmd_sync(args: argparse.Namespace) -> int:
     )
 
     if args.json:
-        print(json.dumps(asdict(report), indent=2))
+        print(json.dumps({"workspaces": {key: asdict(value) for key, value in reports.items()}}, indent=2))
     else:
-        print(
-            f"sync report: +{report.nodes_added}/~{report.nodes_updated} "
-            f"-{report.nodes_removed} ={report.nodes_unchanged} unchanged | "
-            f"{report.embeddings_computed} embeddings"
-        )
+        if len(reports) == 1:
+            report = next(iter(reports.values()))
+            print(
+                f"sync report: +{report.nodes_added}/~{report.nodes_updated} "
+                f"-{report.nodes_removed} ={report.nodes_unchanged} unchanged | "
+                f"{report.embeddings_computed} embeddings"
+            )
+        else:
+            for workspace_id, report in reports.items():
+                print(
+                    f"sync[{workspace_id}]: +{report.nodes_added}/~{report.nodes_updated} "
+                    f"-{report.nodes_removed} ={report.nodes_unchanged} unchanged | "
+                    f"{report.embeddings_computed} embeddings"
+                )
+            totals = _sum_sync_reports(reports)
+            print(
+                f"sync total: +{totals.nodes_added}/~{totals.nodes_updated} "
+                f"-{totals.nodes_removed} ={totals.nodes_unchanged} unchanged | "
+                f"{totals.embeddings_computed} embeddings"
+            )
         graph, _, _ = load_state(state_path)
         health = measure_health(graph)
         print(
@@ -4661,12 +4741,36 @@ def cmd_report(args: argparse.Namespace) -> int:
     lines.append(f"  route_model: {'present' if route_model_present else 'missing'}")
     lines.append(f"  route_mode_effective: {route_mode_effective}")
 
-    if sync_payload:
+    sync_totals = None
+    sync_workspace_count = 0
+    if isinstance(sync_payload, dict) and isinstance(sync_payload.get("workspaces"), dict):
+        workspaces_payload = sync_payload["workspaces"]
+        if workspaces_payload:
+            sync_workspace_count = len(workspaces_payload)
+            sync_totals = {
+                "nodes_added": 0,
+                "nodes_updated": 0,
+                "nodes_removed": 0,
+                "nodes_unchanged": 0,
+                "embeddings_computed": 0,
+            }
+            for report in workspaces_payload.values():
+                if not isinstance(report, dict):
+                    continue
+                for key in sync_totals:
+                    sync_totals[key] += _get_int(report, key)
+    elif sync_payload:
+        sync_totals = sync_payload
+
+    if sync_totals:
+        suffix = ""
+        if sync_workspace_count > 1:
+            suffix = f" ({sync_workspace_count} workspaces)"
         lines.append(
             "  last sync: "
-            f"+{_get_int(sync_payload, 'nodes_added')}/~{_get_int(sync_payload, 'nodes_updated')} "
-            f"-{_get_int(sync_payload, 'nodes_removed')} ={_get_int(sync_payload, 'nodes_unchanged')} unchanged | "
-            f"{_get_int(sync_payload, 'embeddings_computed')} embeddings"
+            f"+{_get_int(sync_totals, 'nodes_added')}/~{_get_int(sync_totals, 'nodes_updated')} "
+            f"-{_get_int(sync_totals, 'nodes_removed')} ={_get_int(sync_totals, 'nodes_unchanged')} unchanged | "
+            f"{_get_int(sync_totals, 'embeddings_computed')} embeddings{suffix}"
         )
     else:
         lines.append("  last sync: (none)")

--- a/openclawbrain/split.py
+++ b/openclawbrain/split.py
@@ -339,6 +339,17 @@ def _load_gitignore_patterns(workspace: Path) -> list[str]:
     return [line.strip().replace("\\", "/") for line in raw_lines if line.strip() and not line.strip().startswith("#")]
 
 
+def _resolve_workspace_id(workspace_dir: str | Path, workspace_id: str | None = None) -> str:
+    """Resolve a stable workspace id (default: basename with workspace- stripped)."""
+    if workspace_id is not None and workspace_id.strip():
+        return workspace_id.strip()
+    base = Path(workspace_dir).expanduser().name
+    if base.startswith("workspace-"):
+        base = base[len("workspace-") :]
+    base = base.strip()
+    return base or "workspace"
+
+
 def _match_gitignore(path_posix: str, patterns: list[str]) -> bool:
     """ match gitignore."""
     for pattern in patterns:
@@ -420,6 +431,7 @@ def _should_skip_path(relative_path: str, excludes: set[str], gitignore_patterns
 def split_workspace(
     workspace_dir: str | Path,
     *,
+    workspace_id: str | None = None,
     max_depth: int = 3,
     exclude: Iterable[str] | None = None,
     llm_fn: Callable[[str, str], str] | None = None,
@@ -433,6 +445,7 @@ def split_workspace(
 
     Args:
         workspace_dir: Directory containing source files.
+        workspace_id: Optional stable workspace identifier (default: basename with ``workspace-`` stripped).
 
     Returns:
         ``(graph, texts)`` where each ``texts[node_id]`` is the chunk content for
@@ -450,6 +463,9 @@ def split_workspace(
 
     if llm_parallelism <= 0:
         raise ValueError("llm_parallelism must be >= 1")
+
+    resolved_workspace_id = _resolve_workspace_id(workspace_dir, workspace_id)
+    workspace_prefix = f"{resolved_workspace_id}/"
 
     graph = Graph()
     texts: dict[str, str] = {}
@@ -575,13 +591,19 @@ def split_workspace(
         for chunk_index, chunk in enumerate(chunks):
             if not chunk.strip():
                 continue
-            node_id = f"{rel}::{chunk_index}"
+            file_path = f"{workspace_prefix}{rel}"
+            node_id = f"{file_path}::{chunk_index}"
             summary = chunk.splitlines()[0] if chunk.splitlines() else ""
             node = Node(
                 id=node_id,
                 content=chunk,
                 summary=summary,
-                metadata={"file": rel, "chunk": chunk_index, "kind": "markdown"},
+                metadata={
+                    "file": file_path,
+                    "chunk": chunk_index,
+                    "kind": "markdown",
+                    "workspace_id": resolved_workspace_id,
+                },
             )
             graph.add_node(node)
             texts[node_id] = chunk

--- a/openclawbrain/sync.py
+++ b/openclawbrain/sync.py
@@ -14,7 +14,7 @@ from .graph import Edge, Graph, Node
 from .hasher import default_embed, default_embed_batch
 from .journal import log_event
 from ._util import _first_line
-from .split import split_workspace, _sibling_weight
+from .split import split_workspace, _sibling_weight, _resolve_workspace_id
 from .store import load_state, save_state
 
 
@@ -76,6 +76,16 @@ def _is_workspace_node(node: Node) -> bool:
     return isinstance(node.metadata, dict) and file_name == node.metadata.get("file")
 
 
+def _workspace_id_for_node(node: Node) -> str | None:
+    """Return workspace id from metadata if present."""
+    if not isinstance(node.metadata, dict):
+        return None
+    workspace_id = node.metadata.get("workspace_id")
+    if isinstance(workspace_id, str) and workspace_id.strip():
+        return workspace_id.strip()
+    return None
+
+
 def _is_protected(authority: str | None) -> bool:
     """Check if this node should be preserved even if removed from the workspace."""
     return isinstance(authority, str) and authority.lower() in PROTECTED_AUTHORITIES
@@ -128,6 +138,7 @@ def sync_workspace(
     state_path: str,
     workspace_dir: str,
     *,
+    workspace_id: str | None = None,
     embed_fn: Callable[[str], list[float]] | None = None,
     embed_batch_fn: Callable[[list[tuple[str, str]]], dict[str, list[float]]] | None = None,
     journal_path: str | None = None,
@@ -136,7 +147,8 @@ def sync_workspace(
     """Sync workspace chunks against persisted state and re-embed changed/new nodes."""
     state_path_obj = Path(state_path).expanduser()
     graph, index, meta = load_state(str(state_path_obj))
-    _, current_texts = split_workspace(workspace_dir)
+    resolved_workspace_id = _resolve_workspace_id(workspace_dir, workspace_id)
+    _, current_texts = split_workspace(workspace_dir, workspace_id=resolved_workspace_id)
 
     if embed_fn is None and embed_batch_fn is None:
         embed_fn = default_embed
@@ -146,6 +158,49 @@ def sync_workspace(
     existing_hashes: dict[str, str] = {node_id: _hash_content(node.content) for node_id, node in existing_nodes.items()}
     current_ids = set(current_texts.keys())
     existing_ids = set(existing_nodes.keys())
+
+    workspace_prefix = f"{resolved_workspace_id}/"
+    rel_files = set()
+    for node_id in current_ids:
+        file_name, _ = _split_node_id(node_id)
+        if file_name and file_name.startswith(workspace_prefix):
+            rel_files.add(file_name[len(workspace_prefix) :])
+
+    has_current_workspace_nodes = False
+    has_any_workspace_nodes = False
+    has_any_workspace_ids = False
+    legacy_workspace_match = False
+    for node in graph.nodes():
+        if not _is_workspace_node(node):
+            continue
+        has_any_workspace_nodes = True
+        node_workspace_id = _workspace_id_for_node(node)
+        if node_workspace_id is not None:
+            has_any_workspace_ids = True
+        if node_workspace_id == resolved_workspace_id:
+            has_current_workspace_nodes = True
+            break
+        if node_workspace_id is None:
+            file_name = _node_file(node)
+            if file_name in rel_files:
+                legacy_workspace_match = True
+
+    legacy_mode = (
+        (not has_current_workspace_nodes)
+        and has_any_workspace_nodes
+        and (legacy_workspace_match or not has_any_workspace_ids)
+    )
+    if legacy_mode:
+        legacy_texts: dict[str, str] = {}
+        for node_id, content in current_texts.items():
+            file_name, chunk_idx = _split_node_id(node_id)
+            if file_name is None or chunk_idx is None:
+                continue
+            if file_name.startswith(workspace_prefix):
+                file_name = file_name[len(workspace_prefix) :]
+            legacy_texts[f"{file_name}::{chunk_idx}"] = content
+        current_texts = legacy_texts
+        current_ids = set(current_texts.keys())
 
     added_ids = sorted(current_ids - existing_ids)
     unchanged_ids: list[str] = []
@@ -171,6 +226,10 @@ def sync_workspace(
     for node_id, node in workspace_nodes:
         if node_id in current_ids:
             continue
+        node_workspace_id = _workspace_id_for_node(node)
+        if node_workspace_id != resolved_workspace_id:
+            if not (legacy_mode and node_workspace_id is None):
+                continue
         authority = node.metadata.get("authority") if isinstance(node.metadata, dict) else None
         if _is_protected(authority):
             continue
@@ -210,6 +269,7 @@ def sync_workspace(
         metadata["file"] = file_name
         metadata["chunk"] = chunk_idx
         metadata["kind"] = metadata.get("kind", "markdown")
+        metadata["workspace_id"] = resolved_workspace_id
         authority = _resolve_authority(file_name, authority_map)
         previous_authority = metadata.get("authority")
         if authority is not None and previous_authority != authority:
@@ -236,6 +296,9 @@ def sync_workspace(
         node = graph.get_node(node_id)
         if node is None:
             continue
+        if node.metadata.get("workspace_id") != resolved_workspace_id:
+            node.metadata["workspace_id"] = resolved_workspace_id
+            nodes_metadata_updated += 1
         file_name = _node_file(node)
         if file_name is None:
             continue
@@ -273,6 +336,7 @@ def sync_workspace(
                 "type": "sync",
                 "state_path": str(state_path_obj),
                 "workspace_dir": str(Path(workspace_dir).expanduser()),
+                "workspace_id": resolved_workspace_id,
                 "nodes_added": report.nodes_added,
                 "nodes_updated": report.nodes_updated,
                 "nodes_removed": report.nodes_removed,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -171,12 +171,14 @@ def test_init_sets_authority_metadata_for_mapped_files(tmp_path, monkeypatch) ->
 
     state_data = json.loads((output / "state.json").read_text(encoding="utf-8"))
     nodes = state_data["graph"]["nodes"]
+    workspace_prefix = f"{workspace.name}/"
 
     def authorities_for(file_name: str) -> set[str]:
+        expected_file = f"{workspace_prefix}{file_name}"
         return {
             str(node.get("metadata", {}).get("authority"))
             for node in nodes
-            if node.get("metadata", {}).get("file") == file_name
+            if node.get("metadata", {}).get("file") == expected_file
         }
 
     assert "constitutional" in authorities_for("SOUL.md")
@@ -870,6 +872,10 @@ def test_serve_command_prints_banner_and_calls_socket_server(monkeypatch, capsys
         "0.5",
         "--route-use-relevance",
         "true",
+        "--route-enable-stop",
+        "false",
+        "--route-stop-margin",
+        "0.1",
     ]]
 
     err = capsys.readouterr().err
@@ -1285,6 +1291,10 @@ def test_serve_command_passes_explicit_socket_path(monkeypatch) -> None:
         "0.5",
         "--route-use-relevance",
         "true",
+        "--route-enable-stop",
+        "false",
+        "--route-stop-margin",
+        "0.1",
     ]]
 
 
@@ -1359,7 +1369,9 @@ def test_openclaw_install_runs_expected_commands(monkeypatch, tmp_path) -> None:
     assert calls[1][:3] == ["openclaw", "hooks", "install"]
     assert calls[2][:3] == ["openclaw", "hooks", "enable"]
     assert calls[3][:4] == [sys.executable, "-m", "openclawbrain.cli", "loop"]
-    assert calls[4][:3] == ["openclaw", "gateway", "restart"]
+    assert calls[4][:4] == [sys.executable, "-m", "openclawbrain.cli", "harvest"]
+    assert calls[5][:4] == [sys.executable, "-m", "openclawbrain.cli", "async-route-pg"]
+    assert calls[6][:3] == ["openclaw", "gateway", "restart"]
 
 
 def test_serve_status_payload_reports_ping_failure(monkeypatch, tmp_path) -> None:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -48,8 +48,8 @@ def test_full_cycle_init_query_learn_query(tmp_path, capsys, monkeypatch) -> Non
     index_path.write_text(
         json.dumps(
             {
-                "note.md::0": [1.0, 0.0],
-                "note.md::1": [0.0, 1.0],
+                "docs/note.md::0": [1.0, 0.0],
+                "docs/note.md::1": [0.0, 1.0],
             },
         )
     )
@@ -102,7 +102,7 @@ def test_full_cycle_init_query_learn_query(tmp_path, capsys, monkeypatch) -> Non
     )
     assert code == 0
     second = json.loads(capsys.readouterr().out.strip())
-    assert second["fired"][0] == "note.md::0"
+    assert second["fired"][0] == "docs/note.md::0"
 
 
 def test_edge_damping_simulation_converges() -> None:

--- a/tests/test_llm_features.py
+++ b/tests/test_llm_features.py
@@ -125,6 +125,7 @@ def test_split_workspace_with_llm_fn_signature_matches_contract(tmp_path: Path) 
     """test split workspace with llm fn signature matches contract."""
     workspace = tmp_path / "split_workspace"
     workspace.mkdir()
+    workspace_id = workspace.name
     (workspace / "note.md").write_text("## One\nA\n\n## Two\nB")
 
     graph, texts = split_workspace(
@@ -134,5 +135,5 @@ def test_split_workspace_with_llm_fn_signature_matches_contract(tmp_path: Path) 
     )
 
     assert graph.node_count() == 2
-    assert texts["note.md::0"] == "One section"
-    assert texts["note.md::1"] == "Two section"
+    assert texts[f"{workspace_id}/note.md::0"] == "One section"
+    assert texts[f"{workspace_id}/note.md::1"] == "Two section"

--- a/tests/test_openai_embeddings.py
+++ b/tests/test_openai_embeddings.py
@@ -29,7 +29,7 @@ def _install_fake_openai(monkeypatch, vector_fn):
             self.data = [FakeEmbedding(vector) for vector in vectors]
 
     class FakeEmbeddings:
-        def create(self, model: str, input: str | list[str]) -> FakeResponse:
+        def create(self, model: str, input: str | list[str], **_kwargs: object) -> FakeResponse:
             calls.append((model, input))
             values = [input] if isinstance(input, str) else input
             vectors = [vector_fn(value) for value in values]

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -10,6 +10,7 @@ def test_split_by_headers_creates_chunked_nodes(tmp_path: Path) -> None:
     """test split by headers creates chunked nodes."""
     workspace = tmp_path / "split_headers"
     workspace.mkdir()
+    workspace_id = workspace.name
     (workspace / "a.md").write_text(
         "## Intro\nThis is intro.\n\n## Body\nThis is body.",
         encoding="utf-8",
@@ -20,8 +21,8 @@ def test_split_by_headers_creates_chunked_nodes(tmp_path: Path) -> None:
     assert len(nodes) == 2
     assert any(node_id.endswith("::0") for node_id in nodes)
     assert any(node_id.endswith("::1") for node_id in nodes)
-    assert graph.outgoing("a.md::0")[0][1].kind == "sibling"
-    assert texts["a.md::0"].startswith("## Intro")
+    assert graph.outgoing(f"{workspace_id}/a.md::0")[0][1].kind == "sibling"
+    assert texts[f"{workspace_id}/a.md::0"].startswith("## Intro")
 
 
 def test_split_by_blank_lines_when_no_headers(tmp_path: Path) -> None:
@@ -43,18 +44,20 @@ def test_split_single_file_with_no_sections_is_one_node(tmp_path: Path) -> None:
     """test split single file with no sections is one node."""
     workspace = tmp_path / "split_single"
     workspace.mkdir()
+    workspace_id = workspace.name
     (workspace / "single.md").write_text("Just one paragraph only.", encoding="utf-8")
 
     graph, texts = split_workspace(str(workspace))
     assert graph.node_count() == 1
     assert graph.edge_count() == 0
-    assert "single.md::0" in texts
+    assert f"{workspace_id}/single.md::0" in texts
 
 
 def test_split_multiple_files_with_cross_references(tmp_path: Path) -> None:
     """test split multiple files with cross references."""
     workspace = tmp_path / "split_multi"
     workspace.mkdir()
+    workspace_id = workspace.name
     (workspace / "one.md").write_text(
         "## Alpha\nSee [file two](two.md).\n\n## Beta\n", encoding="utf-8"
     )
@@ -65,8 +68,8 @@ def test_split_multiple_files_with_cross_references(tmp_path: Path) -> None:
     graph, texts = split_workspace(str(workspace))
     node_ids = {node.id for node in graph.nodes()}
     assert len(node_ids) == 3
-    assert "one.md::0" in node_ids
-    assert "two.md::0" in node_ids
+    assert f"{workspace_id}/one.md::0" in node_ids
+    assert f"{workspace_id}/two.md::0" in node_ids
     assert any("file two" in text for text in texts.values())
     assert any("one.md" in text for text in texts.values())
 
@@ -85,18 +88,20 @@ def test_split_ignores_binary_files(tmp_path: Path) -> None:
     """test split ignores binary files."""
     workspace = tmp_path / "split_binary"
     workspace.mkdir()
+    workspace_id = workspace.name
     (workspace / "note.png").write_bytes(b"\x89PNG\r\n\x1a\n")
     (workspace / "text.md").write_text("## Section\nBody", encoding="utf-8")
 
     graph, texts = split_workspace(str(workspace))
     assert graph.node_count() == 1
     assert len(graph.nodes()) == 1
-    assert list(texts.keys()) == ["text.md::0"]
+    assert list(texts.keys()) == [f"{workspace_id}/text.md::0"]
 
 
 def test_split_nested_directories_preserved(tmp_path: Path) -> None:
     """test split nested directories preserved."""
     workspace = tmp_path / "split_nested"
+    workspace_id = workspace.name
     nested = workspace / "a" / "b"
     nested.mkdir(parents=True)
     (workspace / "root.md").write_text("## R\nroot", encoding="utf-8")
@@ -104,8 +109,8 @@ def test_split_nested_directories_preserved(tmp_path: Path) -> None:
 
     graph, _ = split_workspace(str(workspace))
     ids = {node.id for node in graph.nodes()}
-    assert "root.md::0" in ids
-    assert "a/b/nested.md::0" in ids
+    assert f"{workspace_id}/root.md::0" in ids
+    assert f"{workspace_id}/a/b/nested.md::0" in ids
 
 
 def test_split_long_file_splits_into_multiple_nodes(tmp_path: Path) -> None:
@@ -142,12 +147,13 @@ def test_split_file_with_title_only(tmp_path: Path) -> None:
     """test split file with title only."""
     workspace = tmp_path / "split_title"
     workspace.mkdir()
+    workspace_id = workspace.name
     (workspace / "title.md").write_text("# Just a title", encoding="utf-8")
 
     graph, texts = split_workspace(str(workspace))
     assert graph.node_count() == 1
-    assert graph.incoming("title.md::0") == []
-    assert texts["title.md::0"] == "# Just a title"
+    assert graph.incoming(f"{workspace_id}/title.md::0") == []
+    assert texts[f"{workspace_id}/title.md::0"] == "# Just a title"
 
 
 def test_split_with_llm_json_sections(tmp_path: Path) -> None:
@@ -181,11 +187,12 @@ def test_split_without_llm(tmp_path: Path) -> None:
     """test split without llm."""
     workspace = tmp_path / "split_no_llm"
     workspace.mkdir()
+    workspace_id = workspace.name
     (workspace / "note.md").write_text("## Intro\nFirst\n\n## Body\nSecond")
 
     graph, texts = split_workspace(str(workspace))
     assert len(graph.nodes()) == 2
-    assert texts["note.md::0"].startswith("## Intro")
+    assert texts[f"{workspace_id}/note.md::0"].startswith("## Intro")
 
 
 def test_split_with_llm_parse_fallback_to_headers(tmp_path: Path) -> None:
@@ -209,6 +216,7 @@ def test_split_with_llm_default_off_for_small_file(tmp_path: Path) -> None:
     """test LLM split is off by default for small files."""
     workspace = tmp_path / "split_llm_small"
     workspace.mkdir()
+    workspace_id = workspace.name
     (workspace / "note.md").write_text("Short paragraph for quick splitting.", encoding="utf-8")
 
     calls: list[tuple[str, str]] = []
@@ -222,7 +230,7 @@ def test_split_with_llm_default_off_for_small_file(tmp_path: Path) -> None:
 
     assert len(graph.nodes()) == 1
     assert not calls
-    assert texts["note.md::0"] == "Short paragraph for quick splitting."
+    assert texts[f"{workspace_id}/note.md::0"] == "Short paragraph for quick splitting."
 
 
 def test_split_json_file_with_long_payload_handles_supported_extension(tmp_path: Path) -> None:
@@ -270,6 +278,7 @@ def test_split_always_includes_bootstrap_and_memory_when_gitignored(tmp_path: Pa
     workspace = tmp_path / "split_always_include"
     memory_dir = workspace / "memory"
     memory_dir.mkdir(parents=True)
+    workspace_id = workspace.name
     (workspace / ".gitignore").write_text("SOUL.md\nmemory/\n", encoding="utf-8")
     (workspace / "SOUL.md").write_text("# Soul\nFoundational rules.", encoding="utf-8")
     (memory_dir / "daily.md").write_text("## Log\nEntry", encoding="utf-8")
@@ -277,7 +286,7 @@ def test_split_always_includes_bootstrap_and_memory_when_gitignored(tmp_path: Pa
     graph, texts = split_workspace(str(workspace))
     node_ids = {node.id for node in graph.nodes()}
 
-    assert "SOUL.md::0" in node_ids
-    assert "memory/daily.md::0" in node_ids
-    assert "SOUL.md::0" in texts
-    assert "memory/daily.md::0" in texts
+    assert f"{workspace_id}/SOUL.md::0" in node_ids
+    assert f"{workspace_id}/memory/daily.md::0" in node_ids
+    assert f"{workspace_id}/SOUL.md::0" in texts
+    assert f"{workspace_id}/memory/daily.md::0" in texts

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -52,8 +52,8 @@ def test_sync_detects_new_files(tmp_path: Path) -> None:
     assert report.embeddings_computed == 1
 
     graph, index, _ = load_state(str(state_path))
-    assert graph.get_node("SOUL.md::0") is not None
-    assert index._vectors["SOUL.md::0"] == default_embed("# Soul\nKeep these rules.")
+    assert graph.get_node("workspace/SOUL.md::0") is not None
+    assert index._vectors["workspace/SOUL.md::0"] == default_embed("# Soul\nKeep these rules.")
 
 
 def test_sync_detects_changed_content(tmp_path: Path) -> None:
@@ -74,7 +74,7 @@ def test_sync_detects_changed_content(tmp_path: Path) -> None:
     assert report.embeddings_computed == 1
 
     graph, _, _ = load_state(str(state_path))
-    assert graph.get_node("AGENTS.md::0").content == "# Agents\nRevised"
+    assert graph.get_node("workspace/AGENTS.md::0").content == "# Agents\nRevised"
 
 
 def test_sync_preserves_unchanged_nodes(tmp_path: Path) -> None:
@@ -115,7 +115,7 @@ def test_sync_sets_authority_from_map(tmp_path: Path) -> None:
     assert report.authority_set["canonical"] == 1
 
     graph, _, _ = load_state(str(state_path))
-    node = graph.get_node("USER.md::0")
+    node = graph.get_node("workspace/USER.md::0")
     assert node is not None
     assert node.metadata["authority"] == "canonical"
 
@@ -130,7 +130,7 @@ def test_sync_sets_authority_for_unchanged_nodes_without_reembedding(tmp_path: P
     _state_from_workspace(workspace, state_path)
 
     graph, index, _ = load_state(str(state_path))
-    node = graph.get_node("SOUL.md::0")
+    node = graph.get_node("workspace/SOUL.md::0")
     assert node is not None
     node.metadata.pop("authority", None)
     _write_state(state_path, graph=graph, index=index)
@@ -198,4 +198,51 @@ def test_sync_dry_run_doesnt_modify(tmp_path: Path) -> None:
     assert before == after
 
     graph, _, _ = load_state(str(state_path))
-    assert graph.get_node("IDENTITY.md::0").content == "# Identity\nA"
+    assert graph.get_node("workspace/IDENTITY.md::0").content == "# Identity\nA"
+
+
+def test_sync_multiple_workspaces_no_cross_delete(tmp_path: Path) -> None:
+    """syncing workspace A then B does not delete A nodes."""
+    workspace_a = tmp_path / "workspace-alpha"
+    workspace_b = tmp_path / "workspace-beta"
+    workspace_a.mkdir()
+    workspace_b.mkdir()
+    (workspace_a / "A.md").write_text("# A\nAlpha", encoding="utf-8")
+    (workspace_b / "B.md").write_text("# B\nBeta", encoding="utf-8")
+
+    state_path = tmp_path / "state.json"
+    _write_state(state_path, graph=Graph(), index=VectorIndex())
+
+    sync_workspace(state_path=str(state_path), workspace_dir=str(workspace_a), embed_fn=default_embed)
+    sync_workspace(state_path=str(state_path), workspace_dir=str(workspace_b), embed_fn=default_embed)
+
+    graph, _, _ = load_state(str(state_path))
+    assert graph.get_node("alpha/A.md::0") is not None
+    assert graph.get_node("beta/B.md::0") is not None
+
+
+def test_sync_scoped_deletion_within_workspace(tmp_path: Path) -> None:
+    """syncing workspace A twice deletes removed nodes only within A."""
+    workspace_a = tmp_path / "workspace-alpha"
+    workspace_b = tmp_path / "workspace-beta"
+    workspace_a.mkdir()
+    workspace_b.mkdir()
+    (workspace_a / "keep.md").write_text("# Keep\nAlpha", encoding="utf-8")
+    remove_path = workspace_a / "remove.md"
+    remove_path.write_text("# Remove\nAlpha", encoding="utf-8")
+    (workspace_b / "other.md").write_text("# Other\nBeta", encoding="utf-8")
+
+    state_path = tmp_path / "state.json"
+    _write_state(state_path, graph=Graph(), index=VectorIndex())
+
+    sync_workspace(state_path=str(state_path), workspace_dir=str(workspace_a), embed_fn=default_embed)
+    sync_workspace(state_path=str(state_path), workspace_dir=str(workspace_b), embed_fn=default_embed)
+
+    remove_path.unlink()
+    report = sync_workspace(state_path=str(state_path), workspace_dir=str(workspace_a), embed_fn=default_embed)
+    assert report.nodes_removed == 1
+
+    graph, _, _ = load_state(str(state_path))
+    assert graph.get_node("alpha/keep.md::0") is not None
+    assert graph.get_node("alpha/remove.md::0") is None
+    assert graph.get_node("beta/other.md::0") is not None


### PR DESCRIPTION
## Summary
- namespace workspace nodes with workspace_id prefixes and metadata
- scope sync deletions to the current workspace and preserve legacy nodes
- add multi-workspace CLI support and update sync report aggregation/docs/tests

## Testing
- python3 -m pytest tests/test_sync.py
- python3 -m pytest tests/test_sync.py tests/test_split.py tests/test_llm_features.py tests/test_integration.py