### PR TITLE
Harden learned routing invariants and add audit tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ openclaw gateway restart
 
 - Operator quickstart (start here): [docs/operator-quickstart.md](docs/operator-quickstart.md)
 - Operator guide (deep dive): [docs/operator-guide.md](docs/operator-guide.md)
+- Learned routing audit (invariants + checklist): [docs/learned-routing-audit.md](docs/learned-routing-audit.md)
 - Default brain-building experience (macOS): [docs/default-experience.md](docs/default-experience.md)
 - Shadow routing architecture: [docs/shadow-routing-upg-architecture.md](docs/shadow-routing-upg-architecture.md)
 - Evaluation plan: [docs/evaluation-plan.md](docs/evaluation-plan.md)

--- a/docs/learned-routing-audit.md
+++ b/docs/learned-routing-audit.md
@@ -1,0 +1,128 @@
+# Learned Routing Audit
+
+Learned routing is the top invariant. This doc traces the lifecycle, surfaces configuration knobs, and provides a concrete operator checklist to verify that learned routing is active end-to-end.
+
+**Scope:** route_fn + route_model + labels/traces + training + loop + serve + hook + report/health.
+
+## Lifecycle Diagram
+
+```
+init/bootstrap
+  -> labels/traces (harvest + async-route-pg)
+    -> train-route-model (route_model.npz)
+      -> serve loads model
+        -> runtime uses learned route_fn
+          -> loop/dream retrains
+```
+
+## Configuration Knobs
+
+**Routing mode**
+- `--route-mode learned|edge|edge+sim|off` (daemon/serve/clients)
+- `OPENCLAWBRAIN_ROUTE_MODE` (profile env override)
+- `policy.route_mode` in profile JSON
+
+**Learned enforcement (high-trust operators)**
+- `--assert-learned` (daemon/serve/socket client)
+- `OPENCLAWBRAIN_ROUTE_ASSERT_LEARNED` (profile env override)
+- `policy.assert_learned` in profile JSON
+- Query param: `assert_learned=true` (socket client/query calls)
+
+**Stop action**
+- `--route-enable-stop true|false`
+- `--route-stop-margin <float>`
+- `OPENCLAWBRAIN_ROUTE_ENABLE_STOP`, `OPENCLAWBRAIN_ROUTE_STOP_MARGIN`
+- `policy.route_enable_stop`, `policy.route_stop_margin` in profile JSON
+
+**Route model path**
+- Default: `route_model.npz` next to `state.json`
+- Override: `--route-model /path/to/route_model.npz`
+
+## Failure Modes and Detection
+
+**Missing route model**
+- Symptom: learned configured, effective mode falls back to `edge+sim`.
+- Detection: daemon health shows `route_model_present=false`, `route_mode_effective=edge+sim`, `route_model_error=missing`.
+- Operator action: run `async-route-pg` and `train-route-model`, or rebuild via loop/build-all.
+
+**Route model load failure**
+- Symptom: route_model exists but cannot be loaded, fallback to `edge+sim`.
+- Detection: daemon health `route_model_error=load_failed: ...`, report warning, `route-audit` shows `route_model_loaded=false`.
+- Operator action: regenerate route_model from traces/labels, verify file permissions/format.
+
+**Embedding dimension mismatch**
+- Symptom: daemon query errors with embedding dimension mismatch.
+- Detection: query error: `expected <dim>, got <dim>`.
+- Operator action: rebuild embeddings or reembed to match state metadata.
+
+**Stale route model**
+- Symptom: labels/traces updated recently but route_model timestamp lags far behind.
+- Detection: `route-audit` shows `last_train_iso` older than recent labels file mtime.
+- Operator action: retrain route model (loop or `train-route-model`).
+
+**No labels**
+- Symptom: `labels.jsonl` empty or missing; training has no new supervision.
+- Detection: `route-audit` shows `labels_count=0` or file missing.
+- Operator action: ensure `harvest` or `async-route-pg` runs with labels output.
+
+**State lock contention**
+- Symptom: training/maintenance steps skip due to lock held.
+- Detection: build-all/loop logs show state lock timeout or skipped steps.
+- Operator action: stop conflicting writer or run with `--force` (expert use).
+
+**Teacher disabled/unavailable**
+- Symptom: `async-route-pg` reports `teacher_available=false`, no labels created.
+- Detection: `async-route-pg --json` output errors like `OPENAI_API_KEY not set` or `teacher disabled`.
+- Operator action: enable teacher, configure model/key, or rely on self/human labels.
+
+## Operator Checklist
+
+**1) Verify effective routing mode**
+```
+openclawbrain route-audit --state ~/.openclawbrain/main/state.json
+```
+Expected (healthy learned mode):
+- `route_mode_configured: learned`
+- `route_mode_effective: learned`
+- `route_model_present: True`
+- `route_model_loaded: True`
+
+**2) Check daemon health (includes routing fields)**
+```
+openclawbrain health --state ~/.openclawbrain/main/state.json
+```
+Expected: payload includes `route_model_present`, `route_mode_configured`, `route_mode_effective`.
+
+**3) Check report warnings**
+```
+openclawbrain report --state ~/.openclawbrain/main/state.json
+```
+Expected: no warnings about degraded learned routing.
+
+**4) Ensure labels are being written**
+```
+wc -l ~/.openclawbrain/main/labels.jsonl
+```
+Expected: non-zero once supervision has been collected.
+
+**5) Run teacher loop (optional but recommended)**
+```
+openclawbrain async-route-pg --state ~/.openclawbrain/main/state.json --apply --json
+```
+Expected: `decision_points_labeled > 0` when teacher is available and there is query history.
+
+**6) Train route model**
+```
+openclawbrain train-route-model \
+  --state ~/.openclawbrain/main/state.json \
+  --traces-in ~/.openclawbrain/main/route_traces.jsonl \
+  --labels-in ~/.openclawbrain/main/labels.jsonl \
+  --out ~/.openclawbrain/main/route_model.npz
+```
+Expected: non-zero `points_used` and a new `route_model.npz` mtime.
+
+**7) Enforce learned routing (high-trust)**
+```
+openclawbrain serve start --state ~/.openclawbrain/main/state.json --assert-learned
+```
+Expected: daemon refuses to start if effective mode is not `learned`.

--- a/openclawbrain/cli.py
+++ b/openclawbrain/cli.py
@@ -1256,6 +1256,18 @@ def _coalesce_route_enable_stop(
     return default
 
 
+def _coalesce_assert_learned(
+    cli_value: bool | None,
+    profile_value: bool | None,
+    default: bool,
+) -> bool:
+    if cli_value is not None:
+        return bool(cli_value)
+    if profile_value is not None:
+        return bool(profile_value)
+    return default
+
+
 @contextmanager
 def _command_state_write_lock(
     args: argparse.Namespace,
@@ -1427,6 +1439,12 @@ def _build_parser() -> argparse.ArgumentParser:
     d.add_argument("--route-use-relevance", choices=["true", "false"], default=None)
     d.add_argument("--route-enable-stop", choices=["true", "false"], default=None)
     d.add_argument("--route-stop-margin", type=float, default=None)
+    d.add_argument(
+        "--assert-learned",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Error if effective routing mode is not learned.",
+    )
     d.add_argument("--route-model", default=None)
     d.add_argument("--auto-save-interval", type=int, default=10)
 
@@ -1450,6 +1468,12 @@ def _build_parser() -> argparse.ArgumentParser:
     serve.add_argument("--route-use-relevance", choices=["true", "false"], default=None)
     serve.add_argument("--route-enable-stop", choices=["true", "false"], default=None)
     serve.add_argument("--route-stop-margin", type=float, default=None)
+    serve.add_argument(
+        "--assert-learned",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Error if effective routing mode is not learned.",
+    )
     serve.add_argument("--route-model", default=None)
     serve.add_argument(
         "--foreground",
@@ -1658,6 +1682,10 @@ def _build_parser() -> argparse.ArgumentParser:
 
     rep = sub.add_parser("report", help="Daily brain update summary")
     rep.add_argument("--state")
+
+    ra = sub.add_parser("route-audit", help="Learned routing audit snapshot")
+    ra.add_argument("--state")
+    ra.add_argument("--json", action="store_true")
 
     ar = sub.add_parser("async-route-pg")
     ar.add_argument("--state", required=True)
@@ -2323,6 +2351,7 @@ def _serve_start_arguments(
     route_use_relevance: bool,
     route_enable_stop: bool,
     route_stop_margin: float,
+    assert_learned: bool,
     route_model: str | None,
 ) -> list[str]:
     argv = ["--state", state_path]
@@ -2348,6 +2377,8 @@ def _serve_start_arguments(
         "--route-stop-margin",
         str(route_stop_margin),
     ])
+    if assert_learned:
+        argv.append("--assert-learned")
     if route_model:
         argv.extend(["--route-model", str(route_model)])
     return argv
@@ -4729,17 +4760,34 @@ def cmd_report(args: argparse.Namespace) -> int:
         lines.append(f"  warning: {health_warning}")
 
     route_model_present = None
+    route_mode_configured = None
     route_mode_effective = None
+    route_model_error = None
+    route_model_path = None
     if health_payload is not None:
         route_model_present = health_payload.get("route_model_present")
+        route_mode_configured = health_payload.get("route_mode_configured")
         route_mode_effective = health_payload.get("route_mode_effective")
+        route_model_error = health_payload.get("route_model_error")
+        route_model_path = health_payload.get("route_model_path")
     if route_model_present is None:
         route_model_present = (Path(resolved_state).expanduser().parent / "route_model.npz").exists()
+    if route_mode_configured is None:
+        route_mode_configured = "unknown"
     if route_mode_effective is None:
         route_mode_effective = "learned" if route_model_present else "edge+sim"
 
     lines.append(f"  route_model: {'present' if route_model_present else 'missing'}")
+    lines.append(f"  route_mode_configured: {route_mode_configured}")
     lines.append(f"  route_mode_effective: {route_mode_effective}")
+    if route_model_path:
+        lines.append(f"  route_model_path: {route_model_path}")
+    if route_model_error:
+        lines.append(f"  route_model_error: {route_model_error}")
+    if route_mode_configured == "learned" and route_mode_effective != "learned":
+        lines.append("  warning: learned routing configured but effective mode is degraded")
+    elif not route_model_present and route_mode_effective != "learned":
+        lines.append("  warning: route_model missing; learned routing will fall back to edge+sim")
 
     sync_totals = None
     sync_workspace_count = 0
@@ -4818,6 +4866,107 @@ def cmd_report(args: argparse.Namespace) -> int:
             journal_path=journal_path,
         )
 
+    return 0
+
+
+def cmd_route_audit(args: argparse.Namespace) -> int:
+    """Print learned routing audit snapshot."""
+    state_path = _resolve_state_path(args.state, allow_default=True)
+    if state_path is None:
+        raise SystemExit("--state is required for route-audit")
+    resolved_state = str(Path(state_path).expanduser())
+    state_dir = Path(resolved_state).expanduser().parent
+    route_model_path = state_dir / "route_model.npz"
+    labels_path = _default_labels_path(resolved_state)
+
+    model_present = route_model_path.exists()
+    model_loaded = False
+    model_error = None
+    if model_present:
+        try:
+            RouteModel.load_npz(route_model_path)
+            model_loaded = True
+        except Exception as exc:  # noqa: BLE001
+            model_error = str(exc)
+
+    labels_count = 0
+    if labels_path.exists():
+        labels_count = sum(1 for line in labels_path.read_text(encoding="utf-8").splitlines() if line.strip())
+
+    last_train_ts = None
+    last_train_iso = None
+    if model_present:
+        last_train_ts = route_model_path.stat().st_mtime
+        last_train_iso = datetime.fromtimestamp(last_train_ts, tz=timezone.utc).isoformat()
+
+    socket_path = _default_daemon_socket_path(resolved_state)
+    ping_ok, health_payload, health_error = _socket_health_status(socket_path)
+    route_mode_configured = None
+    route_mode_effective = None
+    route_model_present = None
+    route_enable_stop = None
+    route_stop_margin = None
+    route_model_error = None
+    if isinstance(health_payload, dict):
+        route_mode_configured = health_payload.get("route_mode_configured")
+        route_mode_effective = health_payload.get("route_mode_effective")
+        route_model_present = health_payload.get("route_model_present")
+        route_enable_stop = health_payload.get("route_enable_stop")
+        route_stop_margin = health_payload.get("route_stop_margin")
+        route_model_error = health_payload.get("route_model_error")
+
+    if route_mode_effective is None:
+        route_mode_effective = "learned" if model_present else "edge+sim"
+    if route_mode_configured is None:
+        route_mode_configured = "unknown"
+    if route_model_present is None:
+        route_model_present = model_present
+
+    payload = {
+        "state_path": resolved_state,
+        "daemon_running": bool(ping_ok),
+        "daemon_socket": socket_path,
+        "daemon_health_error": health_error,
+        "route_mode_configured": route_mode_configured,
+        "route_mode_effective": route_mode_effective,
+        "route_model_present": route_model_present,
+        "route_model_loaded": model_loaded if model_present else False,
+        "route_model_path": str(route_model_path),
+        "route_model_error": route_model_error or model_error,
+        "last_train_ts": last_train_ts,
+        "last_train_iso": last_train_iso,
+        "labels_path": str(labels_path),
+        "labels_count": labels_count,
+        "route_enable_stop": route_enable_stop,
+        "route_stop_margin": route_stop_margin,
+    }
+
+    if args.json:
+        print(json.dumps(payload, indent=2))
+        return 0
+
+    lines = [
+        "Route audit",
+        f"  state: {resolved_state}",
+        f"  daemon_running: {bool(ping_ok)}",
+        f"  route_mode_configured: {route_mode_configured}",
+        f"  route_mode_effective: {route_mode_effective}",
+        f"  route_model_present: {route_model_present}",
+        f"  route_model_loaded: {model_loaded if model_present else False}",
+        f"  route_model_path: {route_model_path}",
+        f"  last_train_iso: {last_train_iso or 'n/a'}",
+        f"  labels_count: {labels_count}",
+        f"  labels_path: {labels_path}",
+        f"  stop_enabled: {route_enable_stop if route_enable_stop is not None else 'unknown'}",
+        f"  stop_margin: {route_stop_margin if route_stop_margin is not None else 'unknown'}",
+    ]
+    if payload.get("route_model_error"):
+        lines.append(f"  route_model_error: {payload['route_model_error']}")
+    if not ping_ok and health_error:
+        lines.append(f"  warning: daemon health unavailable ({health_error})")
+    if route_mode_configured == "learned" and route_mode_effective != "learned":
+        lines.append("  warning: learned routing configured but effective mode is degraded")
+    print("\n".join(lines))
     return 0
 
 
@@ -4918,6 +5067,11 @@ def cmd_daemon(args: argparse.Namespace) -> int:
         profile.policy.route_stop_margin if profile is not None else None,
         0.1,
     )
+    assert_learned = _coalesce_assert_learned(
+        args.assert_learned,
+        profile.policy.assert_learned if profile is not None else None,
+        False,
+    )
     if route_stop_margin < 0.0:
         raise SystemExit("--route-stop-margin must be >= 0.0")
     route_model = args.route_model
@@ -4947,7 +5101,9 @@ def cmd_daemon(args: argparse.Namespace) -> int:
             str(route_stop_margin),
             "--auto-save-interval",
             str(args.auto_save_interval),
-        ] + (["--route-model", str(route_model)] if route_model else [])
+        ]
+        + (["--assert-learned"] if assert_learned else [])
+        + (["--route-model", str(route_model)] if route_model else [])
     )
 
 
@@ -4997,6 +5153,11 @@ def cmd_serve(args: argparse.Namespace) -> int:
         profile.policy.route_stop_margin if profile is not None else None,
         0.1,
     )
+    assert_learned = _coalesce_assert_learned(
+        args.assert_learned,
+        profile.policy.assert_learned if profile is not None else None,
+        False,
+    )
     if route_stop_margin < 0.0:
         raise SystemExit("--route-stop-margin must be >= 0.0")
     route_model = args.route_model
@@ -5019,6 +5180,7 @@ def cmd_serve(args: argparse.Namespace) -> int:
         route_use_relevance=route_use_relevance,
         route_enable_stop=route_enable_stop,
         route_stop_margin=route_stop_margin,
+        assert_learned=assert_learned,
         route_model=route_model,
     )
     launchd_program_arguments = _resolve_serve_launchd_program_arguments(start_argv)
@@ -6511,6 +6673,7 @@ def main(argv: list[str] | None = None) -> int:
         "harvest": cmd_harvest,
         "health": cmd_health,
         "report": cmd_report,
+        "route-audit": cmd_route_audit,
         "async-route-pg": cmd_async_route_pg,
         "dream": cmd_dream,
         "dreaming": cmd_dream,

--- a/openclawbrain/daemon.py
+++ b/openclawbrain/daemon.py
@@ -60,6 +60,12 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--route-use-relevance", choices=["true", "false"], default="true")
     parser.add_argument("--route-enable-stop", choices=["true", "false"], default="false")
     parser.add_argument("--route-stop-margin", type=float, default=0.1)
+    parser.add_argument(
+        "--assert-learned",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Error if effective routing mode is not learned.",
+    )
     parser.add_argument("--route-model", default=None)
     parser.add_argument("--auto-save-interval", type=int, default=10)
     parser.add_argument("--force", action="store_true", help="Bypass state lock (expert use)")
@@ -422,8 +428,18 @@ def _handle_query(
 
     traverse_start = time.perf_counter()
     seeds = index.search(query_vector, top_k=top_k)
+    route_mode_configured = query.route_mode
+    route_model_present = learned_model is not None
+    route_mode_effective = route_mode_configured
+    if route_mode_configured == "learned" and not route_model_present:
+        route_mode_effective = "edge+sim"
+    if query.assert_learned and route_mode_effective != "learned":
+        raise ValueError(
+            f"assert_learned requested but effective route_mode is {route_mode_effective} "
+            f"(configured={route_mode_configured}, model_present={route_model_present})"
+        )
     policy = RoutingPolicy(
-        route_mode="edge+sim" if query.route_mode == "learned" and learned_model is None else query.route_mode,
+        route_mode=route_mode_effective,
         top_k=query.route_top_k,
         alpha_sim=query.route_alpha_sim,
         use_relevance=query.route_use_relevance,
@@ -492,7 +508,15 @@ def _handle_query(
         query_text=query_text,
         fired_ids=result.fired,
         node_count=graph.node_count(),
-        metadata={"chat_id": query.chat_id, "max_fired_nodes": max_fired_nodes, **prompt_context_stats, **route_summary},
+        metadata={
+            "chat_id": query.chat_id,
+            "max_fired_nodes": max_fired_nodes,
+            "route_mode_configured": route_mode_configured,
+            "route_mode_effective": route_mode_effective,
+            "route_model_present": route_model_present,
+            **prompt_context_stats,
+            **route_summary,
+        },
     )
 
     return {
@@ -505,6 +529,9 @@ def _handle_query(
         "embed_query_ms": _ms(embed_start, embed_stop),
         "traverse_ms": _ms(traverse_start, traverse_stop),
         "total_ms": _ms(total_start, total_stop),
+        "route_mode_configured": route_mode_configured,
+        "route_mode_effective": route_mode_effective,
+        "route_model_present": route_model_present,
         **route_summary,
     }
 
@@ -1011,6 +1038,7 @@ class QueryDefaults:
     route_use_relevance: bool = True
     route_enable_stop: bool = False
     route_stop_margin: float = 0.1
+    assert_learned: bool = False
 
 
 def _with_query_defaults(params: dict[str, object], defaults: QueryDefaults) -> dict[str, object]:
@@ -1024,6 +1052,7 @@ def _with_query_defaults(params: dict[str, object], defaults: QueryDefaults) -> 
     merged.setdefault("route_use_relevance", defaults.route_use_relevance)
     merged.setdefault("route_enable_stop", defaults.route_enable_stop)
     merged.setdefault("route_stop_margin", defaults.route_stop_margin)
+    merged.setdefault("assert_learned", defaults.assert_learned)
     return merged
 
 
@@ -1045,11 +1074,13 @@ def main(argv: list[str] | None = None) -> int:
         route_mode_configured = parse_route_mode(args.route_mode)
         route_model: RouteModel | None = None
         target_projections: dict[str, object] = {}
+        route_model_error: str | None = None
         if route_model_path.exists():
             try:
                 route_model = RouteModel.load_npz(route_model_path)
                 target_projections = route_model.precompute_target_projections(index)
             except Exception as exc:  # noqa: BLE001
+                route_model_error = f"load_failed: {exc}"
                 print(
                     f"warning: failed to load route model at {route_model_path}: {exc}; falling back to edge+sim",
                     file=sys.stderr,
@@ -1057,6 +1088,7 @@ def main(argv: list[str] | None = None) -> int:
                 route_model = None
                 target_projections = {}
         elif route_mode_configured == "learned":
+            route_model_error = "missing"
             print(
                 f"warning: route_model.npz missing at {route_model_path}; falling back to edge+sim",
                 file=sys.stderr,
@@ -1065,10 +1097,23 @@ def main(argv: list[str] | None = None) -> int:
         route_mode_effective = route_mode_configured
         if route_mode_configured == "learned" and route_model is None:
             route_mode_effective = "edge+sim"
+        if args.assert_learned and route_mode_effective != "learned":
+            raise SystemExit(
+                "assert_learned enabled but effective route_mode is not learned "
+                f"(configured={route_mode_configured}, model_present={route_model_present})"
+            )
+        route_stop_margin = parse_float(args.route_stop_margin, "route_stop_margin", required=False, default=0.1)
+        if route_stop_margin < 0.0:
+            raise ValueError("route_stop_margin must be >= 0.0")
         route_status = {
             "route_model_present": route_model_present,
             "route_mode_configured": route_mode_configured,
             "route_mode_effective": route_mode_effective,
+            "route_model_path": str(route_model_path),
+            "route_model_error": route_model_error,
+            "route_enable_stop": str(args.route_enable_stop).strip().lower() == "true",
+            "route_stop_margin": route_stop_margin,
+            "route_assert_learned": bool(args.assert_learned),
         }
         daemon_state = _DaemonState(
             graph=graph,
@@ -1081,9 +1126,6 @@ def main(argv: list[str] | None = None) -> int:
             ),
         )
         embed_fn = _resolve_embed_fn(args.embed_model, meta)
-        route_stop_margin = parse_float(args.route_stop_margin, "route_stop_margin", required=False, default=0.1)
-        if route_stop_margin < 0.0:
-            raise ValueError("route_stop_margin must be >= 0.0")
         query_defaults = QueryDefaults(
             max_prompt_context_chars=parse_int(
                 args.max_prompt_context_chars,
@@ -1095,7 +1137,7 @@ def main(argv: list[str] | None = None) -> int:
                 "max_fired_nodes",
                 default=30,
             ),
-            route_mode=route_mode_effective,
+            route_mode=route_mode_configured,
             route_top_k=parse_int(
                 args.route_top_k,
                 "route_top_k",
@@ -1109,18 +1151,8 @@ def main(argv: list[str] | None = None) -> int:
             route_use_relevance=str(args.route_use_relevance).strip().lower() == "true",
             route_enable_stop=str(args.route_enable_stop).strip().lower() == "true",
             route_stop_margin=route_stop_margin,
+            assert_learned=bool(args.assert_learned),
         )
-        if query_defaults.route_mode == "learned" and route_model is None:
-            query_defaults = QueryDefaults(
-                max_prompt_context_chars=query_defaults.max_prompt_context_chars,
-                max_fired_nodes=query_defaults.max_fired_nodes,
-                route_mode="edge+sim",
-                route_top_k=query_defaults.route_top_k,
-                route_alpha_sim=query_defaults.route_alpha_sim,
-                route_use_relevance=query_defaults.route_use_relevance,
-                route_enable_stop=query_defaults.route_enable_stop,
-                route_stop_margin=query_defaults.route_stop_margin,
-            )
         auto_save_interval = max(1, args.auto_save_interval) if args.auto_save_interval > 0 else 0
 
         if hasattr(sys.stdout, "reconfigure"):

--- a/openclawbrain/ops/async_route_pg.py
+++ b/openclawbrain/ops/async_route_pg.py
@@ -14,7 +14,7 @@ from typing import Callable
 from ..graph import Edge, Graph
 from ..hasher import HashEmbedder
 from ..learn import apply_outcome_pg
-from ..labels import append_labels_jsonl, from_teacher_output
+from ..labels import append_labels_jsonl, from_teacher_output, write_labels_jsonl
 from ..replay import default_keyword_seed_fn
 from ..reward import RewardSource, RewardWeights, scale_reward
 from ..storage import EventStore, JsonStateStore, JsonlEventStore, StateStore
@@ -775,6 +775,9 @@ def run_async_route_pg(
         resolved_state_store.save(state_path, graph=working_graph, index=index, meta=meta)
 
     if labels_out:
+        labels_path = Path(labels_out).expanduser()
+        if not labels_path.exists():
+            write_labels_jsonl(labels_path, [])
         label_records = []
         for (query_id, point_idx, ts), labels in zip(point_refs, labels_by_point):
             if not labels:

--- a/openclawbrain/profile.py
+++ b/openclawbrain/profile.py
@@ -30,6 +30,7 @@ class ProfilePolicy:
     route_use_relevance: bool = True
     route_enable_stop: bool = False
     route_stop_margin: float = 0.1
+    assert_learned: bool = False
 
 
 @dataclass(frozen=True)
@@ -97,6 +98,7 @@ class BrainProfile:
                     "route_use_relevance",
                     "route_enable_stop",
                     "route_stop_margin",
+                    "assert_learned",
                 },
                 "policy",
             )
@@ -154,6 +156,11 @@ class BrainProfile:
             )
             if route_stop_margin < 0.0:
                 raise ValueError("policy.route_stop_margin must be >= 0.0")
+            assert_learned = parse_bool(
+                raw_policy.get("assert_learned"),
+                "policy.assert_learned",
+                default=False,
+            )
 
             reward_source = _parse_non_empty_str(raw_reward.get("source"), "reward.source", default="explicit")
             reward_weight_correction = parse_float(
@@ -193,6 +200,7 @@ class BrainProfile:
                     route_use_relevance=route_use_relevance,
                     route_enable_stop=route_enable_stop,
                     route_stop_margin=route_stop_margin,
+                    assert_learned=assert_learned,
                 ),
                 reward=ProfileReward(
                     source=reward_source,
@@ -222,6 +230,7 @@ class BrainProfile:
                 "route_use_relevance": self.policy.route_use_relevance,
                 "route_enable_stop": self.policy.route_enable_stop,
                 "route_stop_margin": self.policy.route_stop_margin,
+                "assert_learned": self.policy.assert_learned,
             },
             "reward": {
                 "source": self.reward.source,
@@ -252,6 +261,7 @@ def _env_overrides(*, env_prefix: str) -> dict[str, object]:
         "ROUTE_USE_RELEVANCE": (("policy", "route_use_relevance"), _parse_env_bool),
         "ROUTE_ENABLE_STOP": (("policy", "route_enable_stop"), _parse_env_bool),
         "ROUTE_STOP_MARGIN": (("policy", "route_stop_margin"), float),
+        "ROUTE_ASSERT_LEARNED": (("policy", "assert_learned"), _parse_env_bool),
         "REWARD_SOURCE": (("reward", "source"), str),
         "REWARD_WEIGHT_CORRECTION": (("reward", "weight_correction"), float),
         "REWARD_WEIGHT_TEACHING": (("reward", "weight_teaching"), float),

--- a/openclawbrain/protocol.py
+++ b/openclawbrain/protocol.py
@@ -118,6 +118,7 @@ class QueryParams:
     route_use_relevance: bool = True
     route_enable_stop: bool = False
     route_stop_margin: float = 0.1
+    assert_learned: bool = False
     debug_allow_confidence_override: bool = False
     router_conf_override: float | None = None
     relevance_conf_override: float | None = None
@@ -156,6 +157,7 @@ class QueryParams:
             route_use_relevance=parse_bool(params.get("route_use_relevance"), "route_use_relevance", default=True),
             route_enable_stop=parse_bool(params.get("route_enable_stop"), "route_enable_stop", default=False),
             route_stop_margin=_parse_stop_margin(params.get("route_stop_margin")),
+            assert_learned=parse_bool(params.get("assert_learned"), "assert_learned", default=False),
             debug_allow_confidence_override=parse_bool(
                 params.get("debug_allow_confidence_override"),
                 "debug_allow_confidence_override",
@@ -196,6 +198,7 @@ class QueryParams:
             "route_use_relevance": self.route_use_relevance,
             "route_enable_stop": self.route_enable_stop,
             "route_stop_margin": self.route_stop_margin,
+            "assert_learned": self.assert_learned,
             "debug_allow_confidence_override": self.debug_allow_confidence_override,
             "router_conf_override": self.router_conf_override,
             "relevance_conf_override": self.relevance_conf_override,

--- a/openclawbrain/socket_client.py
+++ b/openclawbrain/socket_client.py
@@ -69,6 +69,7 @@ class OCBClient:
         route_use_relevance: bool = True,
         route_enable_stop: bool = False,
         route_stop_margin: float = 0.1,
+        assert_learned: bool = False,
     ) -> dict[str, Any]:
         params = {
             "query": query,
@@ -79,6 +80,7 @@ class OCBClient:
             "route_use_relevance": route_use_relevance,
             "route_enable_stop": route_enable_stop,
             "route_stop_margin": route_stop_margin,
+            "assert_learned": assert_learned,
         }
         if chat_id is not None:
             params["chat_id"] = chat_id
@@ -222,6 +224,12 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         dest="route_use_relevance",
         action="store_false",
     )
+    parser.add_argument(
+        "--assert-learned",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Error if effective routing mode is not learned.",
+    )
     return parser.parse_args(argv)
 
 
@@ -238,6 +246,7 @@ def _main(argv: list[str] | None = None) -> int:
         params["route_top_k"] = args.route_top_k
         params["route_alpha_sim"] = args.route_alpha_sim
         params["route_use_relevance"] = args.route_use_relevance
+        params["assert_learned"] = bool(args.assert_learned)
 
     with OCBClient(socket_path=args.socket, timeout=args.timeout) as client:
         result = client.request(args.method, params)

--- a/openclawbrain/socket_server.py
+++ b/openclawbrain/socket_server.py
@@ -30,6 +30,12 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--route-model", default=None)
     parser.add_argument("--route-enable-stop", choices=["true", "false"], default="false")
     parser.add_argument("--route-stop-margin", type=float, default=0.1)
+    parser.add_argument(
+        "--assert-learned",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Error if effective routing mode is not learned.",
+    )
     parser.add_argument("--auto-save-interval", type=int, default=10)
     parser.add_argument("--force", action="store_true", help="Bypass state lock (expert use)")
     parser.add_argument("--verbose", action="store_true", help="Enable verbose logging")
@@ -67,6 +73,7 @@ class SocketDaemonServer:
         route_model: str | None,
         route_enable_stop: str,
         route_stop_margin: float,
+        assert_learned: bool,
         auto_save_interval: int,
         force: bool,
         verbose: bool,
@@ -87,6 +94,7 @@ class SocketDaemonServer:
         self.route_model = route_model
         self.route_enable_stop = route_enable_stop
         self.route_stop_margin = route_stop_margin
+        self.assert_learned = bool(assert_learned)
         self.auto_save_interval = auto_save_interval
         self.force = force
         self.pid_path = Path(_default_pid_path(str(self.socket_path)))
@@ -164,6 +172,8 @@ class SocketDaemonServer:
             "--auto-save-interval",
             str(self.auto_save_interval),
         ]
+        if self.assert_learned:
+            cmd.append("--assert-learned")
         if self.force:
             cmd.append("--force")
         if self.route_model:
@@ -394,6 +404,7 @@ def main(argv: list[str] | None = None) -> int:
         route_model=args.route_model,
         route_enable_stop=args.route_enable_stop,
         route_stop_margin=args.route_stop_margin,
+        assert_learned=args.assert_learned,
         auto_save_interval=args.auto_save_interval,
         force=args.force,
         verbose=args.verbose,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1371,7 +1371,7 @@ def test_openclaw_install_runs_expected_commands(monkeypatch, tmp_path) -> None:
     assert calls[3][:4] == [sys.executable, "-m", "openclawbrain.cli", "loop"]
     assert calls[4][:4] == [sys.executable, "-m", "openclawbrain.cli", "harvest"]
     assert calls[5][:4] == [sys.executable, "-m", "openclawbrain.cli", "async-route-pg"]
-    assert calls[6][:3] == ["openclaw", "gateway", "restart"]
+    assert calls[-1][:3] == ["openclaw", "gateway", "restart"]
 
 
 def test_serve_status_payload_reports_ping_failure(monkeypatch, tmp_path) -> None:
@@ -1431,7 +1431,6 @@ def test_report_handles_missing_daemon_health(monkeypatch, tmp_path, capsys) -> 
     state_dir.mkdir()
     state_path = state_dir / "state.json"
     _write_state(state_path)
-
     socket_path = Path(cli_module._default_daemon_socket_path(str(state_path)))
     socket_path.parent.mkdir(parents=True, exist_ok=True)
     socket_path.write_text("", encoding="utf-8")
@@ -1443,6 +1442,44 @@ def test_report_handles_missing_daemon_health(monkeypatch, tmp_path, capsys) -> 
     out = capsys.readouterr().out
     assert "warning: health unavailable (daemon timeout)" in out
     assert "orphans:" in out
+
+
+def test_report_surfaces_route_model_health_fields(monkeypatch, tmp_path, capsys) -> None:
+    from openclawbrain import cli as cli_module
+
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+    state_dir = tmp_path / "main"
+    state_dir.mkdir()
+    state_path = state_dir / "state.json"
+    _write_state(state_path)
+    socket_path = Path(cli_module._default_daemon_socket_path(str(state_path)))
+    socket_path.parent.mkdir(parents=True, exist_ok=True)
+    socket_path.write_text("", encoding="utf-8")
+
+    monkeypatch.setattr(
+        cli_module,
+        "_socket_health_status",
+        lambda _path: (
+            True,
+            {
+                "route_model_present": False,
+                "route_mode_configured": "learned",
+                "route_mode_effective": "edge+sim",
+                "route_model_error": "load_failed: bad zip",
+                "route_model_path": str(state_dir / "route_model.npz"),
+            },
+            None,
+        ),
+    )
+
+    code = main(["report", "--state", str(state_path)])
+    assert code == 0
+    out = capsys.readouterr().out
+    assert "route_model_error: load_failed: bad zip" in out
+    assert "warning: learned routing configured but effective mode is degraded" in out
 
 
 def test_serve_stop_subcommand_sends_shutdown(monkeypatch, capsys) -> None:

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import importlib
 
 import numpy as np
+import pytest
 from openclawbrain import Edge, Graph, HashEmbedder, Node, VectorIndex, save_state
 from openclawbrain.route_model import RouteModel
 from openclawbrain.traverse import TraversalResult
@@ -49,6 +50,27 @@ def _start_daemon(state_path: Path, auto_save_interval: int = 10) -> subprocess.
             str(state_path),
             "--auto-save-interval",
             str(auto_save_interval),
+        ],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        text=True,
+        bufsize=1,
+        env=env,
+    )
+
+
+def _start_daemon_with_args(state_path: Path, extra_args: list[str]) -> subprocess.Popen:
+    env = os.environ.copy()
+    env.pop("OPENAI_API_KEY", None)
+    return subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "openclawbrain",
+            "daemon",
+            "--state",
+            str(state_path),
+            *extra_args,
         ],
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
@@ -137,6 +159,9 @@ def test_daemon_responds_to_health(tmp_path: Path) -> None:
         assert "dormant_pct" in response["result"]
         assert "nodes" in response["result"]
         assert response["result"]["nodes"] == 2
+        assert response["result"]["route_mode_configured"] == "learned"
+        assert response["result"]["route_mode_effective"] in {"learned", "edge+sim"}
+        assert "route_model_present" in response["result"]
     finally:
         _shutdown_daemon(proc)
 
@@ -341,6 +366,51 @@ def test_daemon_query_route_mode_learned_falls_back_to_edge_sim_without_model(tm
     assert "seed" in response["fired_nodes"]
     assert "good" in response["fired_nodes"]
     assert "bad" not in response["fired_nodes"]
+
+
+def test_handle_query_assert_learned_errors_when_model_missing(tmp_path: Path) -> None:
+    graph = Graph()
+    graph.add_node(Node("seed", "seed content", metadata={"file": "seed.md"}))
+    graph.add_node(Node("good", "good answer", metadata={"file": "good.md"}))
+    graph.add_edge(Edge("seed", "good", weight=0.4, metadata={"relevance": 0.0}))
+
+    index = VectorIndex()
+    index.upsert("seed", [1.0, 0.0])
+    index.upsert("good", [1.0, 0.0])
+    meta = {"embedder_name": "hash-v1", "embedder_dim": 2}
+
+    with pytest.raises(ValueError, match="assert_learned"):
+        daemon_module._handle_query(
+            graph=graph,
+            index=index,
+            meta=meta,
+            embed_fn=lambda _q: [1.0, 0.0],
+            params={
+                "query": "assert learned",
+                "top_k": 1,
+                "route_mode": "learned",
+                "assert_learned": True,
+            },
+            state_path=str(tmp_path / "state.json"),
+            learned_model=None,
+        )
+
+
+def test_daemon_health_reports_route_model_load_error(tmp_path: Path) -> None:
+    state_path = tmp_path / "state.json"
+    _write_state(state_path)
+    bad_model = tmp_path / "route_model.npz"
+    bad_model.write_text("not a zip", encoding="utf-8")
+
+    proc = _start_daemon_with_args(state_path, ["--route-model", str(bad_model)])
+    try:
+        response = _call(proc, "health", req_id="health-bad-model")
+        result = response["result"]
+        assert result["route_model_present"] is False
+        assert result["route_model_error"].startswith("load_failed")
+        assert result["route_mode_effective"] in {"learned", "edge+sim"}
+    finally:
+        _shutdown_daemon(proc)
 
 
 def test_daemon_query_ranked_prompt_context_uses_authority_and_scores(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -24,6 +24,7 @@ def test_brain_profile_loads_from_json(tmp_path: Path) -> None:
                     "route_top_k": 9,
                     "route_alpha_sim": 0.7,
                     "route_use_relevance": False,
+                    "assert_learned": True,
                 },
                 "reward": {
                     "source": "explicit",
@@ -47,6 +48,7 @@ def test_brain_profile_loads_from_json(tmp_path: Path) -> None:
     assert profile.policy.route_top_k == 9
     assert profile.policy.route_alpha_sim == 0.7
     assert profile.policy.route_use_relevance is False
+    assert profile.policy.assert_learned is True
     assert profile.reward.source == "explicit"
     assert profile.reward.weight_correction == -0.9
     assert profile.reward.weight_teaching == 0.3
@@ -70,10 +72,12 @@ def test_brain_profile_env_overrides(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setenv("OPENCLAWBRAIN_ROUTE_MODE", "edge")
     monkeypatch.setenv("OPENCLAWBRAIN_MAX_FIRED_NODES", "88")
     monkeypatch.setenv("OPENCLAWBRAIN_EMBED_MODEL", "hash")
+    monkeypatch.setenv("OPENCLAWBRAIN_ROUTE_ASSERT_LEARNED", "true")
 
     profile = BrainProfile.load(str(profile_path))
     assert profile.policy.route_mode == "edge"
     assert profile.policy.max_fired_nodes == 88
+    assert profile.policy.assert_learned is True
     assert profile.embedder.embed_model == "hash"
 
 

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -36,6 +36,7 @@ def test_query_params_defaults_follow_daemon_behavior() -> None:
     assert params.route_use_relevance is True
     assert params.route_enable_stop is False
     assert params.route_stop_margin == 0.1
+    assert params.assert_learned is False
     assert params.debug_allow_confidence_override is False
     assert params.router_conf_override is None
     assert params.relevance_conf_override is None

--- a/tests/test_socket_client_cli.py
+++ b/tests/test_socket_client_cli.py
@@ -52,6 +52,7 @@ def test_socket_client_query_method_includes_route_params(monkeypatch) -> None:
         "route_top_k": 8,
         "route_alpha_sim": 0.2,
         "route_use_relevance": False,
+        "assert_learned": False,
     }
 
 


### PR DESCRIPTION
## Summary
- add learned routing audit doc and CLI snapshot (route-audit)
- add assert-learned guardrails across profile/daemon/serve/socket client
- expose route_mode/model status in query/health/report outputs
- ensure async-route-pg always materializes labels file

## Testing
- pytest tests/test_protocol.py tests/test_profile.py tests/test_socket_client_cli.py tests/test_daemon.py tests/test_cli.py