### PR TITLE
Document no-timeout guidance for long builds

### DIFF
--- a/docs/FULL_REBUILD.md
+++ b/docs/FULL_REBUILD.md
@@ -2,6 +2,8 @@
 
 A comprehensive brain rebuild that applies **all** learning mechanisms to historical conversation data.
 
+**Important (NO TIMEOUTS):** `init`, `build-all`, `async-route-pg`, and large local embedding runs can take 30-180+ minutes. If running under CI, cron, supervisor, or wrappers, do **not** use short timeouts; ensure the runner allows long execution. For unattended runs, prefer the `launchd` loop. For manual runs, use `nohup` or `tmux`.
+
 ## What This Does
 
 Most brain operations are incremental — they learn from new queries as they come in. A **full rebuild** replays your entire conversation history through the graph with every learning mechanism active:

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -12,6 +12,8 @@ Use packaged adapter CLIs for agent hooks (no `~/openclawbrain` clone required):
 - `python3 -m openclawbrain.openclaw_adapter.query_brain ...`
 - `python3 -m openclawbrain.openclaw_adapter.capture_feedback ...`
 
+**Important (NO TIMEOUTS):** `init`, `build-all`, `async-route-pg`, and large local embedding runs can take 30-180+ minutes. If running under CI, cron, supervisor, or wrappers, do **not** use short timeouts; ensure the runner allows long execution. For unattended runs, prefer the `launchd` loop. For manual runs, use `nohup` or `tmux`.
+
 ## 2) Turn brain ON
 Canonical run command:
 

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -8,6 +8,8 @@
 
 ## Step 1: Build your first brain
 
+**Important (NO TIMEOUTS):** `init`, `build-all`, `async-route-pg`, and large local embedding runs can take 30-180+ minutes. If running under CI, cron, supervisor, or wrappers, do **not** use short timeouts; ensure the runner allows long execution. For unattended runs, prefer the `launchd` loop. For manual runs, use `nohup` or `tmux`.
+
 ```bash
 openclawbrain init --workspace ./my-workspace --state ./brain/state.json
 openclawbrain doctor --state ./brain/state.json

--- a/openclawbrain/cli.py
+++ b/openclawbrain/cli.py
@@ -2898,6 +2898,16 @@ def _check_result(ok: bool, label: str, details: str = "") -> bool:
     return ok
 
 
+def _maybe_warn_long_running() -> None:
+    """warn about long-running commands when in an interactive session."""
+    if not sys.stderr.isatty():
+        return
+    print(
+        "Note: init/build-all may take a long time; do not run under a short timeout.",
+        file=sys.stderr,
+    )
+
+
 def _journal_entry_count(journal_path: str | None) -> int | None:
     """ journal entry count."""
     if journal_path is None:
@@ -2983,6 +2993,7 @@ def _query_text_output(result: TraversalResult, graph: Graph, max_context_chars:
 
 def cmd_init(args: argparse.Namespace) -> int:
     """cmd init."""
+    _maybe_warn_long_running()
     output_dir = Path(args.output).expanduser()
     if output_dir.suffix == ".json" and not output_dir.is_dir():
         output_dir = output_dir.parent
@@ -6392,6 +6403,7 @@ def cmd_train_route_model(args: argparse.Namespace) -> int:
 
 def cmd_build_all(args: argparse.Namespace) -> int:
     """Run unattended brain-building pipeline for all configured agents."""
+    _maybe_warn_long_running()
     agent_ids = _resolve_agent_ids(args)
     parallel = max(1, int(args.parallel_agents))
     ocb_bin = _resolve_openclawbrain_bin()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,6 +19,7 @@ from openclawbrain.cli import (
     _resolve_openclawbrain_bin,
     _filter_replay_interactions,
     _default_labels_path,
+    _maybe_warn_long_running,
 )
 from openclawbrain.graph import Graph, Node
 from openclawbrain.hasher import default_embed
@@ -97,6 +98,22 @@ def _write_state(
     if meta is None:
         meta = {"embedder_name": "hash-v1", "embedder_dim": 1024}
     path.write_text(json.dumps({"graph": graph_payload, "index": index_payload, "meta": meta}), encoding="utf-8")
+
+
+def test_long_running_warning_prints_when_interactive(monkeypatch, capsys) -> None:
+    """interactive sessions print a long-running warning."""
+    monkeypatch.setattr(sys.stderr, "isatty", lambda: True)
+    _maybe_warn_long_running()
+    err = capsys.readouterr().err
+    assert "Note: init/build-all may take a long time; do not run under a short timeout." in err
+
+
+def test_long_running_warning_suppressed_when_not_tty(monkeypatch, capsys) -> None:
+    """non-interactive sessions suppress the long-running warning."""
+    monkeypatch.setattr(sys.stderr, "isatty", lambda: False)
+    _maybe_warn_long_running()
+    err = capsys.readouterr().err
+    assert err == ""
 
 
 def test_init_command_creates_workspace_graph(tmp_path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- add NO TIMEOUTS guidance to setup, operator guide, and full rebuild docs
- warn interactively when running init/build-all
- add tests for long-running warning helper

## Testing
- not run (not requested)