### PR TITLE
Fix loop multi-sessions + install UX + OpenAI optional guard (fixes #137)

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ openclawbrain query "incident runbook for deploy failures" --state /tmp/brain/st
 
 If you want API-backed embeddings/teacher labeling, use:
 
+- OpenAI is an optional dependency. It is required for `--llm openai` / `--llm openrouter` and `--teacher openai`.
 - **Embeddings:** `text-embedding-3-small` (1536-dim)
 - **LLM routing/scoring:** `gpt-5-mini`
 - **Offline/testing default:** local fastembed embeddings (no API key required).

--- a/docs/openclaw-integration.md
+++ b/docs/openclaw-integration.md
@@ -87,6 +87,8 @@ Hook Python resolution:
 openclawbrain loop install --state ~/.openclawbrain/main/state.json
 ```
 
+Loop now supports multiple sessions; pass `--sessions /path/to/sessions1 /path/to/sessions2` to aggregate multiple agents.
+
 Loop Python resolution (launchd/systemd templates):
 - `OPENCLAWBRAIN_LOOP_PYTHON` or `OPENCLAWBRAIN_PYTHON`, then `~/.openclaw/venvs/openclawbrain/bin/python`, then the current `sys.executable`.
 

--- a/openclawbrain/cli.py
+++ b/openclawbrain/cli.py
@@ -3217,9 +3217,14 @@ def _parse_env_file(env_path: str) -> dict[str, str]:
 
 
 def _run_launchctl(argv: list[str], *, ignore_errors: bool = False) -> None:
-    result = subprocess.run(argv, check=not ignore_errors)
-    if ignore_errors and result.returncode != 0:
+    if ignore_errors:
+        result = subprocess.run(argv, check=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        if result.returncode != 0:
+            if len(argv) > 1 and argv[1] == "bootout":
+                print("bootout: ignored (service not loaded)")
+            return
         return
+    subprocess.run(argv, check=True)
 
 
 def _run_launchctl_returncode(argv: list[str]) -> int:
@@ -3744,6 +3749,15 @@ def _resolve_llm(args: argparse.Namespace) -> tuple[Callable[[str, str], str] | 
     if llm in (None, "none"):
         return None, None
     if llm in {"openai", "openrouter"}:
+        try:
+            import openai  # noqa: F401
+        except ModuleNotFoundError as exc:
+            raise SystemExit(
+                "LLM provider="
+                f"{llm} but Python package openai is not installed in this environment "
+                f"(sys.executable={sys.executable}). Install: pip install \"openclawbrain[openai]\" "
+                "(or pip install openai), or set OPENCLAWBRAIN_DEFAULT_LLM=ollama / pass --llm ollama."
+            ) from exc
         from .openai_llm import openai_llm_batch_fn, openai_llm_fn
 
         return openai_llm_fn, openai_llm_batch_fn
@@ -5950,6 +5964,7 @@ def cmd_route_audit(args: argparse.Namespace) -> int:
     route_model_path = state_dir / "route_model.npz"
     labels_path = _default_labels_path(resolved_state)
 
+    labels_present = labels_path.exists()
     model_present = route_model_path.exists()
     model_loaded = False
     model_error = None
@@ -5961,7 +5976,7 @@ def cmd_route_audit(args: argparse.Namespace) -> int:
             model_error = str(exc)
 
     labels_count = 0
-    if labels_path.exists():
+    if labels_present:
         labels_count = sum(1 for line in labels_path.read_text(encoding="utf-8").splitlines() if line.strip())
 
     last_train_ts = None
@@ -6007,6 +6022,7 @@ def cmd_route_audit(args: argparse.Namespace) -> int:
         "last_train_ts": last_train_ts,
         "last_train_iso": last_train_iso,
         "labels_path": str(labels_path),
+        "labels_present": labels_present,
         "labels_count": labels_count,
         "route_enable_stop": route_enable_stop,
         "route_stop_margin": route_stop_margin,
@@ -6026,11 +6042,14 @@ def cmd_route_audit(args: argparse.Namespace) -> int:
         f"  route_model_loaded: {model_loaded if model_present else False}",
         f"  route_model_path: {route_model_path}",
         f"  last_train_iso: {last_train_iso or 'n/a'}",
+        f"  labels_present: {labels_present}",
         f"  labels_count: {labels_count}",
         f"  labels_path: {labels_path}",
         f"  stop_enabled: {route_enable_stop if route_enable_stop is not None else 'unknown'}",
         f"  stop_margin: {route_stop_margin if route_stop_margin is not None else 'unknown'}",
     ]
+    if not labels_present:
+        lines.append("  labels_note: labels file not created yet (will appear after first harvest/teacher run)")
     if payload.get("route_model_error"):
         lines.append(f"  route_model_error: {payload['route_model_error']}")
     if not ping_ok and health_error:

--- a/openclawbrain/cli.py
+++ b/openclawbrain/cli.py
@@ -2612,7 +2612,7 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     loop.add_argument("--agent", help="Agent id (defaults to main; overrides --state)")
     loop.add_argument("--state", help="Path to state.json (defaults to main profile)")
-    loop.add_argument("--sessions", help="Path to OpenClaw sessions directory")
+    loop.add_argument("--sessions", nargs="+", help="Path(s) to OpenClaw sessions directory")
     loop.add_argument("--mode", choices=REPLAY_MODES, default="full")
     loop.add_argument("--llm", choices=["none", "openai", "ollama", "auto"], default="auto")
     loop.add_argument("--llm-model")
@@ -3384,9 +3384,10 @@ def _render_systemd_unit(*, state_path: str, socket_path: str) -> str:
 def _render_loop_systemd_templates(
     *,
     state_path: str,
-    sessions_path: str,
+    sessions_paths: list[str],
     loop_cmd: str,
 ) -> str:
+    sessions_display = ", ".join(sessions_paths)
     return "\n".join(
         [
             "# /etc/systemd/system/openclawbrain-loop.service",
@@ -3408,7 +3409,7 @@ def _render_loop_systemd_templates(
             "#   sudo systemctl enable --now openclawbrain-loop.service",
             "# Logs:",
             "#   journalctl -u openclawbrain-loop.service -n 200 --no-pager",
-            f"# Sessions path assumed: {sessions_path}",
+            f"# Sessions paths assumed: {sessions_display}",
         ]
     )
 
@@ -6642,14 +6643,18 @@ def cmd_loop(args: argparse.Namespace) -> int:
     stdout_path = _loop_stdout_path(state_path)
     stderr_path = _loop_stderr_path(state_path)
 
-    sessions_path = (
-        Path(args.sessions).expanduser()
-        if args.sessions
-        else Path.home() / ".openclaw" / "agents" / agent_id / "sessions"
-    )
+    if args.sessions:
+        sessions_paths = [Path(path).expanduser() for path in args.sessions]
+    else:
+        sessions_paths = [Path.home() / ".openclaw" / "agents" / agent_id / "sessions"]
 
     ocb_prefix = [_resolve_loop_python(), "-m", "openclawbrain.cli"]
     ocb_subprocess_prefix = _resolve_subprocess_prefix()
+
+    sessions_paths_serialized = [str(path) for path in sessions_paths]
+
+    def _format_sessions_paths(paths: list[Path]) -> str:
+        return ", ".join(str(path) for path in paths)
 
     def _loop_run_program_arguments() -> list[str]:
         argv = ocb_prefix + [
@@ -6658,7 +6663,7 @@ def cmd_loop(args: argparse.Namespace) -> int:
             "--state",
             state_path,
             "--sessions",
-            str(sessions_path),
+            *[str(path) for path in sessions_paths],
             "--mode",
             str(args.mode),
             "--llm",
@@ -6785,7 +6790,7 @@ def cmd_loop(args: argparse.Namespace) -> int:
         print(
             _render_loop_systemd_templates(
                 state_path=state_path,
-                sessions_path=str(sessions_path),
+                sessions_paths=sessions_paths_serialized,
                 loop_cmd=" ".join(shlex.quote(part) for part in _loop_run_program_arguments()),
             )
         )
@@ -6881,7 +6886,12 @@ def cmd_loop(args: argparse.Namespace) -> int:
         plist_path = _derive_launchd_plist_path(label)
         print("OpenClawBrain loop status")
         print(f"State: {state_path}")
-        print(f"Sessions: {sessions_path}")
+        if len(sessions_paths) == 1:
+            print(f"Sessions: {sessions_paths[0]}")
+        else:
+            print("Sessions:")
+            for path in sessions_paths:
+                print(f"  {path}")
         print(f"Log: {log_path}")
         print(f"Stdout: {stdout_path}")
         print(f"Stderr: {stderr_path}")
@@ -6935,7 +6945,8 @@ def cmd_loop(args: argparse.Namespace) -> int:
             "ts": datetime.now(timezone.utc).isoformat(),
             "agent_id": agent_id,
             "state_path": state_path,
-            "sessions_path": str(sessions_path),
+            "sessions_path": _format_sessions_paths(sessions_paths),
+            "sessions_paths": sessions_paths_serialized,
             **event,
         }
         _append_jsonl(events_path, payload)
@@ -6954,7 +6965,8 @@ def cmd_loop(args: argparse.Namespace) -> int:
             {
                 "agent_id": agent_id,
                 "state_path": state_path,
-                "sessions_path": str(sessions_path),
+                "sessions_path": _format_sessions_paths(sessions_paths),
+                "sessions_paths": sessions_paths_serialized,
                 "log_path": str(log_path),
                 "events_path": str(events_path),
                 "checkpoint_path": str(checkpoint_path),
@@ -6983,7 +6995,8 @@ def cmd_loop(args: argparse.Namespace) -> int:
             "job": job,
             "step": step,
             "state_path": state_path,
-            "sessions_path": str(sessions_path),
+            "sessions_path": _format_sessions_paths(sessions_paths),
+            "sessions_paths": sessions_paths_serialized,
             "mode": str(args.mode),
             "maintain_tasks": str(args.maintain_tasks),
             "teacher_enabled": bool(args.enable_teacher),
@@ -7003,8 +7016,10 @@ def cmd_loop(args: argparse.Namespace) -> int:
         log_line(f"missing state: {state_path}")
         write_checkpoint(status="failed", job="preflight", step="preflight", exit_code=2, reason="missing_state")
         return 2
-    if not sessions_path.exists():
-        log_line(f"missing sessions: {sessions_path}")
+    missing_sessions = [path for path in sessions_paths if not path.exists()]
+    if missing_sessions:
+        missing_display = _format_sessions_paths(missing_sessions)
+        log_line(f"missing sessions: {missing_display}")
         write_checkpoint(status="failed", job="preflight", step="preflight", exit_code=2, reason="missing_sessions")
         return 2
 
@@ -7024,7 +7039,7 @@ def cmd_loop(args: argparse.Namespace) -> int:
             "--state",
             state_path,
             "--sessions",
-            str(sessions_path),
+            *sessions_paths_serialized,
             "--mode",
             str(mode),
             "--llm",
@@ -7302,7 +7317,7 @@ def cmd_loop(args: argparse.Namespace) -> int:
             write_checkpoint(status="running", job=job, step="preflight", started_at=started_at)
             write_manifest(job, {"last_status": "running", "last_started_at": started_at})
             emit_event({"type": "job_start", "job": job, "started_at": started_at})
-            log_line(f"{job}: run start mode={mode} llm={llm} sessions={sessions_path}")
+            log_line(f"{job}: run start mode={mode} llm={llm} sessions={_format_sessions_paths(sessions_paths)}")
 
             replay_code = run_replay(job=job, mode=mode, llm=llm)
             if replay_code != 0:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1094,6 +1094,41 @@ def test_loop_install_dry_run_prints_launchd_plist(monkeypatch, tmp_path, capsys
     assert str(state_path) in program_arguments
 
 
+def test_loop_install_dry_run_supports_multiple_sessions(monkeypatch, tmp_path, capsys) -> None:
+    """loop install --dry-run should emit multiple --sessions args including relative paths."""
+    state_path = tmp_path / "main" / "state.json"
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(json.dumps({"nodes": []}), encoding="utf-8")
+
+    extra_sessions = tmp_path / "extra_sessions"
+    extra_sessions.mkdir(parents=True, exist_ok=True)
+
+    import openclawbrain.cli as cli_module
+
+    monkeypatch.setattr(cli_module.sys, "platform", "darwin")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("OPENCLAWBRAIN_LOOP_PYTHON", raising=False)
+    monkeypatch.delenv("OPENCLAWBRAIN_PYTHON", raising=False)
+
+    code = main([
+        "loop",
+        "install",
+        "--state",
+        str(state_path),
+        "--sessions",
+        ".",
+        str(extra_sessions),
+        "--dry-run",
+    ])
+    assert code == 0
+
+    payload = _extract_plist_from_output(capsys.readouterr().out)
+    program_arguments = payload["ProgramArguments"]
+    sessions_index = program_arguments.index("--sessions")
+    assert program_arguments[sessions_index + 1] == "."
+    assert program_arguments[sessions_index + 2] == str(extra_sessions)
+
+
 def test_loop_install_dry_run_prefers_openclaw_venv_python(monkeypatch, tmp_path, capsys) -> None:
     """loop install --dry-run should prefer the OpenClaw venv python when present."""
     state_path = tmp_path / "main" / "state.json"

--- a/tests/test_openai_embeddings.py
+++ b/tests/test_openai_embeddings.py
@@ -8,6 +8,7 @@ import json
 import threading
 import sys
 import types
+import builtins
 
 import pytest
 
@@ -247,6 +248,27 @@ def test_resolve_llm_openai_returns_callbacks(monkeypatch) -> None:
 
     assert llm_fn is not None
     assert llm_batch_fn is not None
+
+
+def test_resolve_llm_openai_missing_dependency(monkeypatch) -> None:
+    """missing openai dependency yields actionable SystemExit."""
+    sys.modules.pop("openai", None)
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "openai":
+            raise ModuleNotFoundError("No module named 'openai'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    with pytest.raises(SystemExit) as excinfo:
+        _resolve_llm(argparse.Namespace(llm="openai"))
+
+    message = str(excinfo.value)
+    assert "LLM provider=openai" in message
+    assert "openai is not installed" in message
+    assert "pip install \"openclawbrain[openai]\"" in message
+    assert f"sys.executable={sys.executable}" in message
 
 
 def test_resolve_llm_ollama_returns_callbacks(monkeypatch) -> None:


### PR DESCRIPTION
Fixes #137.

Changes:
- loop: --sessions now accepts multiple session dirs and plumbs through to replay subprocess + launchd/systemd templates.
- install UX: suppress noisy launchctl bootout stderr when bootout is best-effort; print a soft info line instead.
- optional deps: if --llm openai/openrouter is selected but the Python package "openai" is missing, fail fast with a clean actionable SystemExit (no confusing stacktrace).
- route-audit: report labels_present + note when labels file hasn’t been created yet.
- docs: mention multi-session loop usage + OpenAI optional dependency note.

Tests:
- pytest (528 passed)
