### PR TITLE
Include query vectors in loop async-route traces

### DIFF
--- a/README.md
+++ b/README.md
@@ -619,6 +619,12 @@ If you have prior conversation logs, replay them. By default, `replay` runs
 openclawbrain replay --state /tmp/brain/state.json --sessions ./sessions/
 ```
 
+`--sessions` now accepts more than plain OpenClaw JSONL files:
+- OpenClaw session directories with rotated `*.jsonl*` files
+- `sessions.json` session indices
+- nested Codex rollout trees such as `~/.codex/sessions`
+- direct Codex state sqlite files such as `~/.codex/state_5.sqlite`
+
 OpenClaw media uploads are usually logged as user text stubs like
 `[media attached: ...]`. Those stubs alone have little semantic value, so they
 often do not improve memory quality by themselves. The useful text typically
@@ -827,9 +833,11 @@ openclawbrain daemon \
   --route-model /tmp/brain/route_model.npz
 ```
 
-Replay/harvest now optionally emit route traces + labels:
-- `openclawbrain replay --traces-out ... --labels-out ...`
-- `openclawbrain harvest --traces-out ... --labels-out ...`
+Important training guardrails:
+- trainable route traces come from `async-route-pg --traces-out`, not `replay` or `harvest`
+- `harvest --labels-out` remains valid for harvested feedback labels
+- `replay --traces-out`, `replay --labels-out`, and `harvest --traces-out` are rejected because they previously produced placeholder/non-trainable exports
+- `train-route-model` now fails fast with a detailed readiness summary when traces are missing required fields such as `query_vector` or indexed candidate targets
 
 ## Design Tenets
 

--- a/docs/FULL_REBUILD.md
+++ b/docs/FULL_REBUILD.md
@@ -47,15 +47,13 @@ openclawbrain init \
 Collect all session files:
 
 ```bash
-# For main agent
-SESSIONS=$(find ~/.openclaw/agents/main/sessions \
-  -maxdepth 1 \( -name "*.jsonl" -o -name "*.jsonl.reset.*" -o -name "*.jsonl.deleted.*" \) \
-  | grep -v ".lock$" | grep -v "sessions.json" | sort)
-
-# For cross-agent context (e.g., bountiful in main sessions)
-BOUNTIFUL_MAIN=$(grep -rl "5151316478" ~/.openclaw/agents/main/sessions/ | grep -v ".lock$")
-BOUNTIFUL_OWN=$(find ~/.openclaw/agents/bountiful/sessions -maxdepth 1 -name "*.jsonl*" | grep -v ".lock$")
-SESSIONS="$BOUNTIFUL_MAIN $BOUNTIFUL_OWN"
+# These can now be plain session dirs, sessions.json indices, Codex rollout dirs,
+# or Codex sqlite state files. Replay resolves them to the underlying logs.
+SESSIONS=(
+  ~/.openclaw/agents/main/sessions
+  ~/.openclaw/agents/codex/sessions/sessions.json
+  ~/.codex/sessions
+)
 ```
 
 Clear the replay checkpoint:
@@ -74,7 +72,7 @@ Replay:
 ```bash
 openclawbrain replay \
   --state ~/.openclawbrain/main/state.json \
-  --sessions $SESSIONS \
+  --sessions "${SESSIONS[@]}" \
   --json
 ```
 

--- a/docs/findings/2026-03-06-history-ingestion-runtime-policy.md
+++ b/docs/findings/2026-03-06-history-ingestion-runtime-policy.md
@@ -1,0 +1,47 @@
+# Findings — history ingestion + runtime-policy training
+
+Date: 2026-03-06
+Repo: `openclawbrain`
+
+## What was actually wrong
+
+1. History ingestion only treated session directories as top-level `*.jsonl` files, so it missed:
+   - `sessions.json` session indices
+   - nested Codex rollout trees such as `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`
+   - direct Codex sqlite state databases whose `threads.rollout_path` values point at rollout logs
+2. Codex rollout JSONL lines were not replayable because `replay.py` only understood OpenClaw-style message envelopes, not Codex `response_item` messages and function-call records.
+3. Runtime-policy training had dishonest export paths:
+   - `replay --traces-out` wrote placeholder traces without decision points or query vectors
+   - `replay --labels-out` wrote no labels
+   - `harvest --traces-out` wrote placeholder traces
+4. `train-route-model` failed late with a generic message instead of telling operators which required fields were missing.
+
+## Fix implemented
+
+- Added shared session-source resolution in `openclawbrain/session_sources.py`.
+- Extended replay/session ingestion to resolve `sessions.json`, nested Codex rollouts, and direct Codex sqlite state files.
+- Extended replay parsing to understand Codex `response_item` message/function-call/function-call-output records.
+- Replaced fake runtime-policy export paths with explicit CLI rejections for:
+  - `replay --traces-out`
+  - `replay --labels-out`
+  - `harvest --traces-out`
+- Kept `harvest --labels-out` as the valid harvested-label path.
+- Made `train-route-model` fail fast with a detailed readiness summary that reports missing `query_vector`, missing decision points/candidates, and insufficient indexed candidates.
+
+## Remaining constraints
+
+- `sessions.json` entries that only point to ACP/Codex metadata are resolved through the local Codex stores (`CODEX_HOME`, `~/.codex/sessions`, `state_*.sqlite`). If those local Codex artifacts are gone, replay still cannot reconstruct deleted histories.
+- This change does not make `replay` or `harvest` synthesize route traces; the supported trainable trace producer remains `async-route-pg`.
+
+## Validation plan executed
+
+- Added regression coverage for nested Codex rollouts.
+- Added regression coverage for `sessions.json` expansion and sqlite-backed rollout discovery.
+- Added regression coverage for Codex rollout parsing of messages + function-call records.
+- Added regression coverage for new CLI export rejections.
+- Added regression coverage for `train-route-model` readiness errors.
+
+## Deployment / prod
+
+- No production deployment performed.
+- No production state or live agent session stores were modified by this repo change.

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -318,6 +318,8 @@ When enabled in OpenClaw config, it will set `ctx.Transcript` and/or append extr
 
 If you rely on toolResult-only transcripts/OCR, keep `openclawbrain replay --include-tool-results` enabled (default).
 
+Replay session sources can also be `sessions.json` indices, nested Codex rollout directories like `~/.codex/sessions`, or direct Codex sqlite state files such as `~/.codex/state_5.sqlite`.
+
 ## 15) Correction wiring: what exists vs what you still need
 OpenClawBrain supports `correction(chat_id, lookback=N)` (it remembers recent fired paths per `chat_id`). To get *automatic* corrections in live chat, OpenClaw must:
 1) pass a stable `chat_id` into each brain query
@@ -499,6 +501,7 @@ openclawbrain daemon \
   --route-model ~/.openclawbrain/main/route_model.npz
 ```
 
-Optional exports during replay/harvest:
-- `openclawbrain replay --traces-out ... --labels-out ...`
-- `openclawbrain harvest --traces-out ... --labels-out ...`
+Training/export notes:
+- `async-route-pg --traces-out` is the supported source of trainable route traces.
+- `harvest --labels-out` remains supported for harvested feedback labels.
+- `replay --traces-out`, `replay --labels-out`, and `harvest --traces-out` are intentionally rejected because they were placeholder exports and not suitable for runtime-policy training.

--- a/openclawbrain/cli.py
+++ b/openclawbrain/cli.py
@@ -7176,7 +7176,7 @@ def cmd_loop(args: argparse.Namespace) -> int:
         else:
             async_cmd.append("--no-write-relevance-metadata")
         if traces_out is not None:
-            async_cmd.extend(["--traces-out", str(traces_out)])
+            async_cmd.extend(["--traces-out", str(traces_out), "--include-query-vector"])
 
         write_checkpoint(status="running", job=job, step="async_route_pg")
         emit_event({"type": "step_start", "job": job, "step": "async_route_pg"})

--- a/openclawbrain/cli.py
+++ b/openclawbrain/cli.py
@@ -49,9 +49,7 @@ from .replay import (
     DEFAULT_TOOL_RESULT_MAX_CHARS,
     extract_interactions,
     extract_query_records,
-    extract_query_records_from_dir,
     extract_queries,
-    extract_queries_from_dir,
     replay_queries,
     replay_queries_parallel,
 )
@@ -3493,13 +3491,8 @@ def _load_session_queries(
         session_paths = [session_paths]
     queries: list[str] = []
     for session_path in session_paths:
-        path = Path(session_path).expanduser()
-        if path.is_dir():
-            queries.extend(extract_queries_from_dir(path, since_ts=since_ts))
-        elif path.is_file():
-            queries.extend(extract_queries(path, since_ts=since_ts))
-        else:
-            raise SystemExit(f"invalid sessions path: {path}")
+        for session_file in collect_session_files(session_path):
+            queries.extend(extract_queries(session_file, since_ts=since_ts))
     return queries
 
 
@@ -3546,13 +3539,8 @@ def _load_session_query_records(session_paths: str | Iterable[str], since_ts: fl
         session_paths = [session_paths]
     records: list[tuple[str, float | None]] = []
     for session_path in session_paths:
-        path = Path(session_path).expanduser()
-        if path.is_dir():
-            records.extend(extract_query_records_from_dir(path, since_ts=since_ts))
-        elif path.is_file():
-            records.extend(extract_query_records(path, since_ts=since_ts))
-        else:
-            raise SystemExit(f"invalid sessions path: {path}")
+        for session_file in collect_session_files(session_path):
+            records.extend(extract_query_records(session_file, since_ts=since_ts))
     return records
 
 
@@ -3562,6 +3550,19 @@ def _write_route_traces_jsonl(path: str, traces: list[RouteTrace]) -> None:
     with destination.open("w", encoding="utf-8") as handle:
         for trace in traces:
             handle.write(route_trace_to_json(trace) + "\n")
+
+
+def _reject_placeholder_route_exports(command_name: str, *, traces_out: object = None, labels_out: object = None) -> None:
+    if traces_out:
+        raise SystemExit(
+            f"{command_name} --traces-out was removed because it only produced placeholder, non-trainable route traces. "
+            "Use async-route-pg --traces-out [--include-query-vector] for trainable route traces."
+        )
+    if command_name == "replay" and labels_out:
+        raise SystemExit(
+            "replay --labels-out was removed because replay does not generate route-training labels. "
+            "Use harvest --labels-out for harvested feedback labels or async-route-pg --labels-out for teacher labels."
+        )
 
 
 def _load_session_interactions(
@@ -4747,6 +4748,8 @@ def _build_checkpoint_status_payload(
 
 def cmd_replay(args: argparse.Namespace) -> int:
     """cmd replay."""
+    _reject_placeholder_route_exports("replay", traces_out=args.traces_out, labels_out=args.labels_out)
+
     state_path = _resolve_state_path(args.state, allow_default=True)
     mode, mode_defaulted = _resolve_replay_mode(args)
     run_fast = mode in {"fast-learning", "full"}
@@ -5186,28 +5189,6 @@ def cmd_replay(args: argparse.Namespace) -> int:
         journal_path=_resolve_journal_path(args, allow_default_state=True),
     )
 
-    if args.traces_out:
-        replay_traces = [
-            RouteTrace(
-                query_id=f"replay:{idx}",
-                ts=float(item.get("ts", 0.0) or 0.0),
-                query_text=str(item.get("query", "") or ""),
-                chat_id=str(item["chat_id"]) if isinstance(item.get("chat_id"), str) else None,
-                seeds=[],
-                fired_nodes=[],
-                traversal_config={},
-                route_policy={"route_mode": "off"},
-                query_vector=None,
-                decision_points=[],
-            )
-            for idx, item in enumerate(interactions)
-            if isinstance(item, dict)
-        ]
-        _write_route_traces_jsonl(str(args.traces_out), replay_traces)
-
-    if args.labels_out:
-        write_labels_jsonl(str(args.labels_out), [])
-
     output: dict[str, object] = dict(stats)
     if fast_stats is not None:
         output["fast_learning"] = fast_stats
@@ -5243,6 +5224,8 @@ def cmd_harvest(args: argparse.Namespace) -> int:
     if state_path is None:
         raise SystemExit("--state is required for harvest")
 
+    _reject_placeholder_route_exports("harvest", traces_out=args.traces_out)
+
     requested_tasks = [task.strip() for task in args.tasks.split(",") if task.strip()]
     report = run_harvest(
         state_path=state_path,
@@ -5255,24 +5238,6 @@ def cmd_harvest(args: argparse.Namespace) -> int:
     )
 
     events = event_log_entries(Path(report["learning_events_path"]))
-    if args.traces_out:
-        harvest_traces = [
-            RouteTrace(
-                query_id=f"harvest:{idx}",
-                ts=float(event.get("ts", 0.0) or 0.0),
-                query_text=str(event.get("content", "") or ""),
-                chat_id=None,
-                seeds=[],
-                fired_nodes=[],
-                traversal_config={},
-                route_policy={"route_mode": "off"},
-                query_vector=None,
-                decision_points=[],
-            )
-            for idx, event in enumerate(events)
-            if isinstance(event, dict)
-        ]
-        _write_route_traces_jsonl(str(args.traces_out), harvest_traces)
 
     if args.labels_out:
         labels: list[LabelRecord] = []

--- a/openclawbrain/full_learning.py
+++ b/openclawbrain/full_learning.py
@@ -20,6 +20,7 @@ from ._util import _extract_json
 from .inject import inject_batch
 from .provenance import attach_tool_evidence_provenance
 from .maintain import run_maintenance
+from .session_sources import collect_session_files as _collect_session_source_files
 try:
     from .openai_embeddings import OpenAIEmbedder
 except Exception:
@@ -218,28 +219,7 @@ def collect_session_files(session_paths: str | Path | list[str] | list[Path]) ->
     files remain after filtering, the function exits with a helpful
     message.
     """
-    paths: list[Path] = []
-    skipped: list[Path] = []
-    if isinstance(session_paths, (str, Path)):
-        session_paths = [session_paths]
-    for item in session_paths:
-        src = Path(item).expanduser()
-        if src.is_dir():
-            patterns = ("*.jsonl", "*.jsonl.reset.*", "*.jsonl.deleted.*")
-            collected = sorted((match for pattern in patterns for match in src.glob(pattern)))
-            paths.extend(collected)
-            continue
-        if src.is_file():
-            paths.append(src)
-            continue
-        # Missing or broken symlink — warn and skip.
-        print(f"warning: skipping missing session path: {src}", file=sys.stderr)
-        skipped.append(src)
-    if not paths and skipped:
-        raise SystemExit(
-            f"no valid session files found ({len(skipped)} missing/broken path(s) skipped)"
-        )
-    return paths
+    return _collect_session_source_files(session_paths)
 
 
 def _collect_turns(

--- a/openclawbrain/replay.py
+++ b/openclawbrain/replay.py
@@ -13,6 +13,7 @@ from .graph import Graph
 from .learn import LearningConfig, apply_outcome
 from .traverse import TraversalConfig, traverse
 from .provenance import ToolProvenanceConfig, build_tool_provenance
+from .session_sources import collect_session_files
 from ._util import _tokenize
 
 DEFAULT_TOOL_RESULT_ALLOWLIST = frozenset(
@@ -64,6 +65,11 @@ def _extract_message_payload(payload: dict) -> dict | None:
         message = payload.get("message")
         return message if isinstance(message, dict) else None
 
+    if payload.get("type") == "response_item":
+        response_item = payload.get("payload")
+        if isinstance(response_item, dict) and response_item.get("type") == "message":
+            return response_item
+
     role = payload.get("role")
     if isinstance(role, str) and role.strip().lower() in {"user", "assistant", "toolresult", "tool_result"}:
         return payload
@@ -114,10 +120,16 @@ def _extract_tool_result_record(message: dict) -> dict[str, object] | None:
     """Extract tool result record with call id + content when available."""
     if not isinstance(message, dict):
         return None
-    tool_call_id = message.get("toolCallId") or message.get("tool_call_id")
+    tool_call_id = message.get("toolCallId") or message.get("tool_call_id") or message.get("call_id")
     if not isinstance(tool_call_id, str) or not tool_call_id.strip():
         tool_call_id = None
     tool_name, text = _extract_tool_result(message)
+    if text is None and isinstance(message.get("output"), str):
+        output = str(message.get("output")).strip()
+        text = output or None
+    if tool_name is None and isinstance(message.get("name"), str):
+        normalized_name = str(message.get("name")).strip().lower()
+        tool_name = normalized_name or None
     record: dict[str, object] = {}
     if tool_call_id is not None:
         record["tool_call_id"] = tool_call_id
@@ -175,7 +187,7 @@ def _extract_tool_call(payload: dict) -> dict[str, object] | None:
     call: dict[str, object] = {}
     if isinstance(payload.get("id"), str):
         call["id"] = payload["id"]
-    tool_call_id = payload.get("toolCallId") or payload.get("tool_call_id")
+    tool_call_id = payload.get("toolCallId") or payload.get("tool_call_id") or payload.get("call_id")
     if isinstance(tool_call_id, str) and tool_call_id.strip():
         call["id"] = tool_call_id
     if isinstance(name, str) and name.strip():
@@ -327,6 +339,34 @@ def extract_interactions(
         if not isinstance(payload, dict):
             continue
 
+        if payload.get("type") == "response_item" and isinstance(payload.get("payload"), dict):
+            response_item = payload["payload"]
+            response_type = str(response_item.get("type", "")).strip().lower()
+            record_ts = _extract_query_timestamp(payload)
+            if response_type in {"function_call", "custom_tool_call"}:
+                if last_user_index is not None:
+                    tool_call = _extract_tool_call(response_item)
+                    if tool_call is not None:
+                        interactions[last_user_index].setdefault("tool_calls", [])
+                        if isinstance(interactions[last_user_index]["tool_calls"], list):
+                            interactions[last_user_index]["tool_calls"].append(tool_call)
+                        interactions[last_user_index]["line_no_end"] = line_no
+                continue
+            if response_type in {"function_call_output", "custom_tool_call_output"}:
+                if last_user_index is not None:
+                    record = _extract_tool_result_record(response_item)
+                    if record is not None:
+                        record["line_no"] = line_no
+                        record["session"] = session_name
+                        record["source"] = str(path)
+                        interactions[last_user_index].setdefault("tool_results", [])
+                        if isinstance(interactions[last_user_index]["tool_results"], list):
+                            interactions[last_user_index]["tool_results"].append(record)
+                        interactions[last_user_index]["line_no_end"] = line_no
+                        if record_ts is not None:
+                            interactions[last_user_index]["ts"] = record_ts
+                continue
+
         message = _extract_message_payload(payload)
         if message is None:
             continue
@@ -420,11 +460,16 @@ def extract_interactions(
             if interactions[last_user_index]["query"] is not None and (
                 since_ts is None or record_ts is None or record_ts > since_ts
             ):
+                existing_tool_calls = interactions[last_user_index].get("tool_calls")
+                existing_tool_results = interactions[last_user_index].get("tool_results")
                 interactions[last_user_index]["response"] = response
-                interactions[last_user_index]["tool_calls"] = tool_calls
+                interactions[last_user_index]["tool_calls"] = (
+                    tool_calls if tool_calls else existing_tool_calls if isinstance(existing_tool_calls, list) else []
+                )
                 interactions[last_user_index]["line_no_end"] = line_no
-                if "tool_results" not in interactions[last_user_index]:
-                    interactions[last_user_index]["tool_results"] = []
+                interactions[last_user_index]["tool_results"] = (
+                    existing_tool_results if isinstance(existing_tool_results, list) else []
+                )
                 if record_ts is not None:
                     interactions[last_user_index]["ts"] = record_ts
             else:
@@ -513,7 +558,7 @@ def extract_queries_from_dir(sessions_dir: str | Path, since_ts: float | None = 
         raise SystemExit(f"not a directory: {path}")
 
     queries: list[str] = []
-    for session_file in sorted(path.glob("*.jsonl")):
+    for session_file in collect_session_files([path]):
         queries.extend(extract_queries(session_file, since_ts=since_ts))
     return queries
 
@@ -530,7 +575,7 @@ def extract_query_records_from_dir(
         raise SystemExit(f"not a directory: {path}")
 
     records: list[tuple[str, float | None]] = []
-    for session_file in sorted(path.glob("*.jsonl")):
+    for session_file in collect_session_files([path]):
         records.extend(extract_query_records(session_file, since_ts=since_ts))
     return records
 

--- a/openclawbrain/session_sources.py
+++ b/openclawbrain/session_sources.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import sys
+from collections.abc import Iterable
+from pathlib import Path
+
+
+SESSION_FILE_PATTERNS = ("*.jsonl", "*.jsonl.reset.*", "*.jsonl.deleted.*")
+CODEX_ROLLOUT_GLOB = "**/rollout-*.jsonl"
+
+
+def _dedupe_paths(paths: Iterable[Path]) -> list[Path]:
+    ordered: list[Path] = []
+    seen: set[str] = set()
+    for path in paths:
+        resolved = str(path.expanduser())
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        ordered.append(path)
+    return ordered
+
+
+def _default_codex_home() -> Path:
+    raw = os.environ.get("CODEX_HOME")
+    if raw:
+        return Path(raw).expanduser()
+    return Path.home() / ".codex"
+
+
+def _resolve_codex_rollouts_from_sqlite(db_path: Path) -> list[Path]:
+    if not db_path.exists() or not db_path.is_file():
+        return []
+
+    query = "SELECT rollout_path FROM threads WHERE rollout_path IS NOT NULL AND rollout_path != '' ORDER BY updated_at, id"
+    try:
+        with sqlite3.connect(str(db_path)) as conn:
+            rows = conn.execute(query).fetchall()
+    except sqlite3.Error:
+        return []
+
+    rollouts: list[Path] = []
+    for (raw_path,) in rows:
+        if not isinstance(raw_path, str) or not raw_path.strip():
+            continue
+        path = Path(raw_path).expanduser()
+        if path.exists() and path.is_file():
+            rollouts.append(path)
+    return _dedupe_paths(rollouts)
+
+
+def _resolve_codex_rollouts(codex_home: Path | None = None) -> list[Path]:
+    home = (codex_home or _default_codex_home()).expanduser()
+    if not home.exists() or not home.is_dir():
+        return []
+
+    rollouts: list[Path] = []
+    for db_path in sorted(home.glob("state_*.sqlite")):
+        rollouts.extend(_resolve_codex_rollouts_from_sqlite(db_path))
+
+    if rollouts:
+        return _dedupe_paths(rollouts)
+
+    sessions_root = home / "sessions"
+    if not sessions_root.exists() or not sessions_root.is_dir():
+        return []
+    return _dedupe_paths(path for path in sorted(sessions_root.glob(CODEX_ROLLOUT_GLOB)) if path.is_file())
+
+
+def _sessions_index_requires_codex_rollouts(path: Path, payload: dict[str, object]) -> bool:
+    if path.parent.name == "sessions" and path.parent.parent.name == "codex":
+        return True
+
+    for entry in payload.values():
+        if not isinstance(entry, dict):
+            continue
+        acp = entry.get("acp")
+        if not isinstance(acp, dict):
+            continue
+        backend = str(acp.get("backend", "")).strip().lower()
+        agent = str(acp.get("agent", "")).strip().lower()
+        if backend in {"acpx", "acp"} or agent == "codex":
+            return True
+    return False
+
+
+def _resolve_sessions_index(path: Path) -> list[Path]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return []
+    if not isinstance(payload, dict):
+        return []
+
+    resolved: list[Path] = []
+    for entry in payload.values():
+        if not isinstance(entry, dict):
+            continue
+        for key in ("sessionFile", "session_file", "rollout_path"):
+            raw = entry.get(key)
+            if not isinstance(raw, str) or not raw.strip():
+                continue
+            candidate = Path(raw).expanduser()
+            if candidate.exists() and candidate.is_file():
+                resolved.append(candidate)
+                break
+
+    if _sessions_index_requires_codex_rollouts(path, payload):
+        resolved.extend(_resolve_codex_rollouts())
+
+    return _dedupe_paths(resolved)
+
+
+def _collect_from_directory(path: Path) -> list[Path]:
+    resolved: list[Path] = []
+    for pattern in SESSION_FILE_PATTERNS:
+        resolved.extend(match for match in sorted(path.glob(pattern)) if match.is_file())
+
+    sessions_index = path / "sessions.json"
+    if sessions_index.exists() and sessions_index.is_file():
+        resolved.extend(_resolve_sessions_index(sessions_index))
+
+    nested_rollouts = [match for match in sorted(path.glob(CODEX_ROLLOUT_GLOB)) if match.is_file()]
+    resolved.extend(nested_rollouts)
+    return _dedupe_paths(resolved)
+
+
+def collect_session_files(session_paths: str | Path | Iterable[str | Path]) -> list[Path]:
+    """Resolve session paths into replayable files.
+
+    Supports plain OpenClaw session JSONL files, rotated JSONL sidecars,
+    `sessions.json` indices, Codex rollout directories, and direct Codex state
+    sqlite databases whose `threads.rollout_path` columns reference session logs.
+    Missing paths are skipped with a warning; if no files remain, the caller gets
+    a helpful `SystemExit`.
+    """
+
+    if isinstance(session_paths, (str, Path)):
+        session_paths = [session_paths]
+
+    collected: list[Path] = []
+    skipped: list[Path] = []
+    for item in session_paths:
+        src = Path(item).expanduser()
+        if src.is_dir():
+            collected.extend(_collect_from_directory(src))
+            continue
+        if src.is_file():
+            if src.name == "sessions.json":
+                collected.extend(_resolve_sessions_index(src))
+                continue
+            if src.suffix == ".sqlite":
+                rollouts = _resolve_codex_rollouts_from_sqlite(src)
+                if rollouts:
+                    collected.extend(rollouts)
+                    continue
+            collected.append(src)
+            continue
+        print(f"warning: skipping missing session path: {src}", file=sys.stderr)
+        skipped.append(src)
+
+    deduped = _dedupe_paths(collected)
+    if not deduped and skipped:
+        raise SystemExit(f"no valid session files found ({len(skipped)} missing/broken path(s) skipped)")
+    if not deduped and not skipped:
+        raise SystemExit("no valid session files found")
+    return deduped

--- a/openclawbrain/train_route_model.py
+++ b/openclawbrain/train_route_model.py
@@ -58,6 +58,48 @@ def _read_traces(path: str) -> list[RouteTrace]:
     return traces
 
 
+def _describe_trace_readiness(
+    traces: list[RouteTrace],
+    index_vectors: dict[str, list[float]],
+) -> str:
+    missing_query_vector = 0
+    traces_without_points = 0
+    points_total = 0
+    points_without_candidates = 0
+    points_without_supervision = 0
+    points_with_lt2_indexed_candidates = 0
+
+    for trace in traces:
+        if trace.query_vector is None:
+            missing_query_vector += 1
+        if not trace.decision_points:
+            traces_without_points += 1
+        for point in trace.decision_points:
+            points_total += 1
+            indexed_candidates = 0
+            if not point.candidates:
+                points_without_candidates += 1
+            for candidate in point.sorted_candidates():
+                target_vector = index_vectors.get(candidate.target_id)
+                if target_vector is None:
+                    continue
+                target_arr = np.asarray(target_vector, dtype=float)
+                if target_arr.ndim == 1:
+                    indexed_candidates += 1
+            if indexed_candidates < 2:
+                points_with_lt2_indexed_candidates += 1
+            if not point.teacher_scores and not point.teacher_choose and not point.chosen_target_id:
+                points_without_supervision += 1
+
+    return (
+        f"traces={len(traces)} missing_query_vector={missing_query_vector} "
+        f"traces_without_decision_points={traces_without_points} decision_points={points_total} "
+        f"points_without_candidates={points_without_candidates} "
+        f"points_with_lt2_indexed_candidates={points_with_lt2_indexed_candidates} "
+        f"points_without_supervision={points_without_supervision}"
+    )
+
+
 def _softmax(logits: np.ndarray) -> np.ndarray:
     stable = logits - np.max(logits)
     exp = np.exp(stable)
@@ -210,7 +252,12 @@ def train_route_model(
     parsed_weights = reward_weights or RewardWeights.from_env()
     points_total, points = _collect_points(traces, index._vectors)
     if not points:
-        raise ValueError("no trainable decision points found (need query_vector + >=2 candidates with target vectors)")
+        detail = _describe_trace_readiness(traces, index._vectors)
+        raise ValueError(
+            "no trainable decision points found; required fields are "
+            "trace.query_vector plus decision points with >=2 candidate target_ids that exist in the state index. "
+            f"observed: {detail}"
+        )
 
     dq = int(points[0][3].shape[0])
     dt = int(points[0][4][0].shape[0])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2273,6 +2273,54 @@ def test_cli_replay_filters_parse() -> None:
     assert args.advance_offsets_on_skip is True
 
 
+def test_cli_replay_rejects_placeholder_route_exports(tmp_path: Path) -> None:
+    session = tmp_path / "session.jsonl"
+    session.write_text('{"role":"user","content":"hi"}\n', encoding="utf-8")
+
+    with pytest.raises(SystemExit, match="replay --traces-out was removed"):
+        main(
+            [
+                "replay",
+                "--state",
+                str(tmp_path / "state.json"),
+                "--sessions",
+                str(session),
+                "--traces-out",
+                str(tmp_path / "route_traces.jsonl"),
+            ]
+        )
+
+    with pytest.raises(SystemExit, match="replay --labels-out was removed"):
+        main(
+            [
+                "replay",
+                "--state",
+                str(tmp_path / "state.json"),
+                "--sessions",
+                str(session),
+                "--labels-out",
+                str(tmp_path / "labels.jsonl"),
+            ]
+        )
+
+
+def test_cli_harvest_rejects_placeholder_trace_exports(tmp_path: Path) -> None:
+    graph = Graph()
+    graph.add_node(Node("seed", "seed"))
+    save_state(graph=graph, index=VectorIndex(), path=str(tmp_path / "state.json"), meta={"embedder_name": "hash-v1", "embedder_dim": 1})
+
+    with pytest.raises(SystemExit, match="harvest --traces-out was removed"):
+        main(
+            [
+                "harvest",
+                "--state",
+                str(tmp_path / "state.json"),
+                "--traces-out",
+                str(tmp_path / "route_traces.jsonl"),
+            ]
+        )
+
+
 def test_cli_replay_fresh_aliases_parse() -> None:
     """--fresh/--no-checkpoint set fresh-start semantics."""
     from openclawbrain.cli import _build_parser

--- a/tests/test_full_learning.py
+++ b/tests/test_full_learning.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 from pathlib import Path
 
 import openclawbrain.full_learning as full_learning_module
@@ -314,6 +315,73 @@ def test_collect_session_files_broken_symlink_skipped(tmp_path: Path) -> None:
     link.symlink_to(target)
     result = collect_session_files([str(valid), str(link)])
     assert result == [valid]
+
+
+def test_collect_session_files_resolves_sessions_json_with_direct_session_file(tmp_path: Path) -> None:
+    sessions_dir = tmp_path / "agent" / "main" / "sessions"
+    sessions_dir.mkdir(parents=True)
+    session_file = sessions_dir / "abc.jsonl"
+    session_file.write_text('{"role":"user","content":"hi"}\n', encoding="utf-8")
+    (sessions_dir / "sessions.json").write_text(
+        json.dumps({"agent:main:main": {"sessionFile": str(session_file)}}),
+        encoding="utf-8",
+    )
+
+    assert collect_session_files([sessions_dir / "sessions.json"]) == [session_file]
+
+
+def test_collect_session_files_resolves_codex_rollouts_from_sessions_index(tmp_path: Path, monkeypatch) -> None:
+    codex_home = tmp_path / ".codex"
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    rollout_dir = codex_home / "sessions" / "2026" / "03" / "05"
+    rollout_dir.mkdir(parents=True)
+    rollout_path = rollout_dir / "rollout-2026-03-05T14-31-25-thread.jsonl"
+    rollout_path.write_text('{"role":"user","content":"codex query"}\n', encoding="utf-8")
+
+    db_path = codex_home / "state_5.sqlite"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "CREATE TABLE threads (id TEXT PRIMARY KEY, rollout_path TEXT NOT NULL, updated_at INTEGER NOT NULL)"
+        )
+        conn.execute(
+            "INSERT INTO threads (id, rollout_path, updated_at) VALUES (?, ?, ?)",
+            ("thread-1", str(rollout_path), 1772750548),
+        )
+        conn.commit()
+
+    sessions_dir = tmp_path / "agent" / "codex" / "sessions"
+    sessions_dir.mkdir(parents=True)
+    (sessions_dir / "sessions.json").write_text(
+        json.dumps(
+            {
+                "agent:codex:acp:1": {
+                    "sessionId": "session-1",
+                    "updatedAt": 1772750548000,
+                    "acp": {"backend": "acpx", "agent": "codex"},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert collect_session_files([sessions_dir / "sessions.json"]) == [rollout_path]
+
+
+def test_collect_session_files_resolves_direct_codex_sqlite(tmp_path: Path) -> None:
+    rollout_path = tmp_path / "rollout.jsonl"
+    rollout_path.write_text('{"role":"user","content":"codex query"}\n', encoding="utf-8")
+    db_path = tmp_path / "state_5.sqlite"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "CREATE TABLE threads (id TEXT PRIMARY KEY, rollout_path TEXT NOT NULL, updated_at INTEGER NOT NULL)"
+        )
+        conn.execute(
+            "INSERT INTO threads (id, rollout_path, updated_at) VALUES (?, ?, ?)",
+            ("thread-1", str(rollout_path), 1772750548),
+        )
+        conn.commit()
+
+    assert collect_session_files([db_path]) == [rollout_path]
 
 
 def test_collect_turns_includes_allowlisted_tool_result_for_media_stub(tmp_path: Path) -> None:

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -100,6 +100,43 @@ def test_extract_queries_from_directory(tmp_path: Path) -> None:
     assert extract_queries_from_dir(sessions) == ["one", "two", "three"]
 
 
+def test_extract_queries_from_directory_supports_nested_codex_rollouts(tmp_path: Path) -> None:
+    sessions = tmp_path / "sessions"
+    rollout_dir = sessions / "2026" / "03" / "05"
+    rollout_dir.mkdir(parents=True)
+    (rollout_dir / "rollout-2026-03-05T14-31-25-thread.jsonl").write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "timestamp": "2026-03-05T22:31:25.111Z",
+                        "type": "response_item",
+                        "payload": {
+                            "type": "message",
+                            "role": "user",
+                            "content": [{"type": "input_text", "text": "fix the router"}],
+                        },
+                    }
+                ),
+                json.dumps(
+                    {
+                        "timestamp": "2026-03-05T22:31:26.111Z",
+                        "type": "response_item",
+                        "payload": {
+                            "type": "message",
+                            "role": "assistant",
+                            "content": [{"type": "output_text", "text": "working on it"}],
+                        },
+                    }
+                ),
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    assert extract_queries_from_dir(sessions) == ["fix the router"]
+
+
 def test_extract_interactions_parses_user_and_assistant_messages(tmp_path: Path) -> None:
     """test extract interactions parses user and assistant messages."""
     path = tmp_path / "session.jsonl"
@@ -194,6 +231,77 @@ def test_extract_interactions_pairs_camelcase_toolcall_and_toolresult(tmp_path: 
     assert tool_results[0]["tool_call_id"] == "tc-1"
     assert tool_results[0]["tool_name"] == "web_search"
     assert tool_results[0]["content"] == "result text"
+
+
+def test_extract_interactions_parses_codex_rollout_messages_and_tools(tmp_path: Path) -> None:
+    path = tmp_path / "rollout.jsonl"
+    path.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "timestamp": "2026-03-05T22:31:25.111Z",
+                        "type": "response_item",
+                        "payload": {
+                            "type": "message",
+                            "role": "user",
+                            "content": [{"type": "input_text", "text": "inspect current diffs"}],
+                        },
+                    }
+                ),
+                json.dumps(
+                    {
+                        "timestamp": "2026-03-05T22:31:25.511Z",
+                        "type": "response_item",
+                        "payload": {
+                            "type": "function_call",
+                            "name": "exec_command",
+                            "arguments": '{"cmd":"git diff --stat"}',
+                            "call_id": "call-1",
+                        },
+                    }
+                ),
+                json.dumps(
+                    {
+                        "timestamp": "2026-03-05T22:31:25.911Z",
+                        "type": "response_item",
+                        "payload": {
+                            "type": "function_call_output",
+                            "call_id": "call-1",
+                            "output": "openclawbrain/cli.py | 10 +++++-----",
+                        },
+                    }
+                ),
+                json.dumps(
+                    {
+                        "timestamp": "2026-03-05T22:31:26.111Z",
+                        "type": "response_item",
+                        "payload": {
+                            "type": "message",
+                            "role": "assistant",
+                            "content": [{"type": "output_text", "text": "I found the existing diff."}],
+                        },
+                    }
+                ),
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    interactions = extract_interactions(path)
+    assert len(interactions) == 1
+    assert interactions[0]["query"] == "inspect current diffs"
+    assert interactions[0]["response"] == "I found the existing diff."
+    assert interactions[0]["tool_calls"] == [{"id": "call-1", "name": "exec_command", "arguments": '{"cmd":"git diff --stat"}'}]
+    assert interactions[0]["tool_results"] == [
+        {
+            "tool_call_id": "call-1",
+            "content": "openclawbrain/cli.py | 10 +++++-----",
+            "line_no": 3,
+            "session": "rollout.jsonl",
+            "source": str(path),
+        }
+    ]
 
 
 def test_extract_interactions_attaches_allowlisted_tool_result_for_media_stub(tmp_path: Path) -> None:

--- a/tests/test_train_route_model.py
+++ b/tests/test_train_route_model.py
@@ -105,3 +105,47 @@ def test_evaluate_ce_loss_supports_legacy_df3_features(tmp_path: Path) -> None:
     assert loss >= 0.0
     assert points_total > 0
     assert points_used > 0
+
+
+def test_train_route_model_errors_with_missing_required_trace_fields(tmp_path: Path) -> None:
+    state_path = tmp_path / "state.json"
+    traces_path = tmp_path / "traces.jsonl"
+    out_path = tmp_path / "route_model.npz"
+
+    _write_state(state_path)
+    trace = RouteTrace(
+        query_id="q-missing",
+        ts=1.0,
+        query_text="choose a",
+        seeds=[["seed", 1.0]],
+        fired_nodes=["seed", "target_a"],
+        traversal_config={"max_hops": 15},
+        route_policy={"route_mode": "off"},
+        query_vector=None,
+        decision_points=[
+            RouteDecisionPoint(
+                query_text="choose a",
+                source_id="seed",
+                source_preview="seed",
+                chosen_target_id="target_a",
+                candidates=[RouteCandidate(target_id="target_a", edge_weight=0.4, edge_relevance=0.0)],
+            )
+        ],
+    )
+    traces_path.write_text(route_trace_to_json(trace) + "\n", encoding="utf-8")
+
+    try:
+        train_route_model(
+            state_path=str(state_path),
+            traces_in=str(traces_path),
+            labels_in=None,
+            out_path=str(out_path),
+        )
+    except ValueError as exc:
+        message = str(exc)
+    else:
+        raise AssertionError("expected ValueError for missing training fields")
+
+    assert "required fields" in message
+    assert "missing_query_vector=1" in message
+    assert "points_with_lt2_indexed_candidates=1" in message


### PR DESCRIPTION
This fixes the loop/background-learning path so that when `cmd_loop()` invokes `async-route-pg` with `--traces-out`, it also passes `--include-query-vector`.

Why:
- `train-route-model` requires trainable decision points with non-null `trace.query_vector`
- the loop could otherwise look healthy while producing traces that do not meaningfully refresh the runtime route model

Observed locally:
- repaired loop was running against the right local state/session source and teacher
- route model remained stale
- manual traces showed `query_vector: null`
- loop async-route invocation in `cmd_loop()` omitted `--include-query-vector`

This is the smallest safe fix: one line, no behavior change outside loop-generated route traces.