### PR TITLE
Scaffold canonical v1 contracts and rearchitecture plan

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -1,0 +1,20 @@
+# Canonical Contracts
+
+This directory holds the Phase 1 canonical contract scaffolding from
+`docs/openclawbrain-openclaw-rearchitecture-plan.md`.
+
+Versioned artifacts currently landed:
+
+- `runtime_compile/v1`
+- `interaction_events/v1`
+- `feedback_events/v1`
+- `artifact_manifest/v1`
+
+Each version directory contains:
+
+- a schema document for the contract shape
+- one or more golden JSON fixtures for cross-repo parity tests
+
+OpenClawBrain's local validator/normalizer for these files lives in
+`openclawbrain/contracts/v1.py`. The current runtime and daemon paths are
+intentionally unchanged in this phase.

--- a/contracts/artifact_manifest/v1/golden-manifest.json
+++ b/contracts/artifact_manifest/v1/golden-manifest.json
@@ -1,0 +1,61 @@
+{
+  "contract_version": "artifact_manifest.v1",
+  "pack_id": "brainpack_2026_03_06_001",
+  "agent_id": "main",
+  "build_id": "build_2026_03_06_001",
+  "parent_pack_id": "brainpack_2026_03_05_004",
+  "contract_versions": {
+    "runtime_compile": "runtime_compile.v1",
+    "interaction_events": "interaction_events.v1",
+    "feedback_events": "feedback_events.v1",
+    "artifact_manifest": "artifact_manifest.v1"
+  },
+  "pack_checksum": "sha256:pack123",
+  "compiler_fingerprint": {
+    "compiler": "openclawbrain-ts",
+    "version": "0.1.0",
+    "build_hash": "abc123def456"
+  },
+  "model_fingerprint": {
+    "embedding_model": "BAAI/bge-large-en-v1.5",
+    "embedding_dimension": 1024,
+    "route_model_id": "route_model_2026_03_06"
+  },
+  "runtime_compat": {
+    "openclaw_min": "0.10.0",
+    "openclawbrain_min": "0.1.0"
+  },
+  "route_policy": {
+    "mode_requested": "learned",
+    "route_model_id": "route_model_2026_03_06",
+    "decision_trace_refs_emitted": true
+  },
+  "serve_requirements": {
+    "requires_learned_routing": true,
+    "required_route_assets": [
+      "route-model.onnx",
+      "route-metadata.json"
+    ],
+    "embedding_model": "BAAI/bge-large-en-v1.5",
+    "embedding_dimension": 1024
+  },
+  "workspace_snapshot_id": "workspace_2026_03_06_001",
+  "event_range": {
+    "interaction_event_start_id": "evt_1",
+    "interaction_event_end_id": "evt_7",
+    "feedback_event_start_id": "feedback_evt_1",
+    "feedback_event_end_id": "feedback_evt_3"
+  },
+  "checksums": {
+    "graph.bin": "sha256:graph123",
+    "vectors.bin": "sha256:vectors123",
+    "route-model.onnx": "sha256:route123"
+  },
+  "eval_summary": {
+    "baseline_pack_id": "brainpack_2026_03_05_004",
+    "score_delta": 0.12,
+    "regressions": 0,
+    "status": "promotable"
+  },
+  "created_at": "2026-03-06T11:00:00Z"
+}

--- a/contracts/artifact_manifest/v1/manifest.schema.json
+++ b/contracts/artifact_manifest/v1/manifest.schema.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://openclawbrain.dev/contracts/artifact_manifest/v1/manifest.schema.json",
+  "title": "artifact_manifest.v1 manifest",
+  "type": "object",
+  "required": [
+    "contract_version",
+    "pack_id",
+    "agent_id",
+    "build_id",
+    "contract_versions",
+    "pack_checksum",
+    "compiler_fingerprint",
+    "model_fingerprint",
+    "runtime_compat",
+    "route_policy",
+    "serve_requirements",
+    "workspace_snapshot_id",
+    "event_range",
+    "checksums",
+    "eval_summary",
+    "created_at"
+  ],
+  "properties": {
+    "contract_version": {
+      "const": "artifact_manifest.v1"
+    },
+    "pack_id": {
+      "type": "string"
+    },
+    "agent_id": {
+      "type": "string"
+    },
+    "build_id": {
+      "type": "string"
+    },
+    "parent_pack_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "contract_versions": {
+      "type": "object"
+    },
+    "pack_checksum": {
+      "type": "string"
+    },
+    "compiler_fingerprint": {
+      "type": "object"
+    },
+    "model_fingerprint": {
+      "type": "object"
+    },
+    "runtime_compat": {
+      "type": "object"
+    },
+    "route_policy": {
+      "type": "object"
+    },
+    "serve_requirements": {
+      "type": "object"
+    },
+    "workspace_snapshot_id": {
+      "type": "string"
+    },
+    "event_range": {
+      "type": "object"
+    },
+    "checksums": {
+      "type": "object"
+    },
+    "eval_summary": {
+      "type": "object"
+    },
+    "created_at": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": true
+}

--- a/contracts/feedback_events/v1/event.schema.json
+++ b/contracts/feedback_events/v1/event.schema.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://openclawbrain.dev/contracts/feedback_events/v1/event.schema.json",
+  "title": "feedback_events.v1 event",
+  "type": "object",
+  "required": [
+    "contract_version",
+    "event_id",
+    "event_ts",
+    "agent_id",
+    "session_id",
+    "turn_id",
+    "request_id",
+    "pack_id",
+    "feedback_kind",
+    "source_kind",
+    "message_ref",
+    "affected_turn_id",
+    "affected_context_ids",
+    "dedup_key"
+  ],
+  "properties": {
+    "contract_version": {
+      "const": "feedback_events.v1"
+    },
+    "event_id": {
+      "type": "string"
+    },
+    "event_ts": {
+      "type": "string"
+    },
+    "agent_id": {
+      "type": "string"
+    },
+    "session_id": {
+      "type": "string"
+    },
+    "turn_id": {
+      "type": "string"
+    },
+    "request_id": {
+      "type": "string"
+    },
+    "pack_id": {
+      "type": "string"
+    },
+    "feedback_kind": {
+      "type": "string"
+    },
+    "source_kind": {
+      "type": "string"
+    },
+    "message_ref": {
+      "type": "string"
+    },
+    "affected_turn_id": {
+      "type": "string"
+    },
+    "affected_context_ids": {
+      "type": "array"
+    },
+    "dedup_key": {
+      "type": "string"
+    },
+    "content": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "metadata": {
+      "type": "object"
+    }
+  },
+  "additionalProperties": true
+}

--- a/contracts/feedback_events/v1/golden-event.json
+++ b/contracts/feedback_events/v1/golden-event.json
@@ -1,0 +1,22 @@
+{
+  "contract_version": "feedback_events.v1",
+  "event_id": "feedback_evt_1",
+  "event_ts": "2026-03-06T10:05:00Z",
+  "agent_id": "main",
+  "session_id": "sess_456",
+  "turn_id": "turn_790",
+  "request_id": "req_124",
+  "pack_id": "brainpack_2026_03_06_001",
+  "feedback_kind": "correction",
+  "source_kind": "human",
+  "message_ref": "message:telegram:12345",
+  "affected_turn_id": "turn_789",
+  "affected_context_ids": [
+    "ctx_1"
+  ],
+  "dedup_key": "telegram:12345",
+  "content": "Rollback before restarting workers.",
+  "metadata": {
+    "priority": "high"
+  }
+}

--- a/contracts/interaction_events/v1/event.schema.json
+++ b/contracts/interaction_events/v1/event.schema.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://openclawbrain.dev/contracts/interaction_events/v1/event.schema.json",
+  "title": "interaction_events.v1 event",
+  "type": "object",
+  "required": [
+    "contract_version",
+    "schema_version",
+    "event_id",
+    "event_kind",
+    "event_ts",
+    "agent_id",
+    "session_id",
+    "turn_id",
+    "request_id",
+    "pack_id",
+    "payload"
+  ],
+  "properties": {
+    "contract_version": {
+      "const": "interaction_events.v1"
+    },
+    "schema_version": {
+      "const": 1
+    },
+    "event_id": {
+      "type": "string"
+    },
+    "event_kind": {
+      "type": "string"
+    },
+    "event_ts": {
+      "type": "string"
+    },
+    "agent_id": {
+      "type": "string"
+    },
+    "session_id": {
+      "type": "string"
+    },
+    "turn_id": {
+      "type": "string"
+    },
+    "request_id": {
+      "type": "string"
+    },
+    "pack_id": {
+      "type": "string"
+    },
+    "payload": {
+      "type": "object"
+    }
+  },
+  "additionalProperties": true
+}

--- a/contracts/interaction_events/v1/golden-stream.json
+++ b/contracts/interaction_events/v1/golden-stream.json
@@ -1,0 +1,127 @@
+[
+  {
+    "contract_version": "interaction_events.v1",
+    "schema_version": 1,
+    "event_id": "evt_1",
+    "event_kind": "turn_started",
+    "event_ts": "2026-03-06T10:00:00Z",
+    "agent_id": "main",
+    "session_id": "sess_456",
+    "turn_id": "turn_789",
+    "request_id": "req_123",
+    "pack_id": "brainpack_2026_03_06_001",
+    "payload": {
+      "user_message_ref": "message:user:turn_789"
+    }
+  },
+  {
+    "contract_version": "interaction_events.v1",
+    "schema_version": 1,
+    "event_id": "evt_2",
+    "event_kind": "memory_compiled",
+    "event_ts": "2026-03-06T10:00:01Z",
+    "agent_id": "main",
+    "session_id": "sess_456",
+    "turn_id": "turn_789",
+    "request_id": "req_123",
+    "pack_id": "brainpack_2026_03_06_001",
+    "payload": {
+      "selected_context_ids": [
+        "ctx_1"
+      ],
+      "suppressed_source_refs": [
+        "memory:duplicate:ctx_legacy"
+      ],
+      "routing": {
+        "mode_requested": "learned",
+        "mode_effective": "learned",
+        "used_learned_route_fn": true,
+        "route_model_id": "route_model_2026_03_06",
+        "decision_trace_ref": "route_decision_req_123"
+      },
+      "compile_latency_ms": 18.7,
+      "candidate_count": 24,
+      "selected_count": 1
+    }
+  },
+  {
+    "contract_version": "interaction_events.v1",
+    "schema_version": 1,
+    "event_id": "evt_3",
+    "event_kind": "tool_called",
+    "event_ts": "2026-03-06T10:00:02Z",
+    "agent_id": "main",
+    "session_id": "sess_456",
+    "turn_id": "turn_789",
+    "request_id": "req_123",
+    "pack_id": "brainpack_2026_03_06_001",
+    "payload": {
+      "tool_name": "web_search",
+      "tool_call_id": "toolcall_1"
+    }
+  },
+  {
+    "contract_version": "interaction_events.v1",
+    "schema_version": 1,
+    "event_id": "evt_4",
+    "event_kind": "tool_result",
+    "event_ts": "2026-03-06T10:00:03Z",
+    "agent_id": "main",
+    "session_id": "sess_456",
+    "turn_id": "turn_789",
+    "request_id": "req_123",
+    "pack_id": "brainpack_2026_03_06_001",
+    "payload": {
+      "tool_name": "web_search",
+      "tool_call_id": "toolcall_1",
+      "status": "ok"
+    }
+  },
+  {
+    "contract_version": "interaction_events.v1",
+    "schema_version": 1,
+    "event_id": "evt_5",
+    "event_kind": "assistant_completed",
+    "event_ts": "2026-03-06T10:00:04Z",
+    "agent_id": "main",
+    "session_id": "sess_456",
+    "turn_id": "turn_789",
+    "request_id": "req_123",
+    "pack_id": "brainpack_2026_03_06_001",
+    "payload": {
+      "assistant_message_ref": "message:assistant:turn_789",
+      "finish_reason": "stop"
+    }
+  },
+  {
+    "contract_version": "interaction_events.v1",
+    "schema_version": 1,
+    "event_id": "evt_6",
+    "event_kind": "feedback_recorded",
+    "event_ts": "2026-03-06T10:05:00Z",
+    "agent_id": "main",
+    "session_id": "sess_456",
+    "turn_id": "turn_790",
+    "request_id": "req_124",
+    "pack_id": "brainpack_2026_03_06_001",
+    "payload": {
+      "feedback_event_id": "feedback_evt_1",
+      "feedback_kind": "correction"
+    }
+  },
+  {
+    "contract_version": "interaction_events.v1",
+    "schema_version": 1,
+    "event_id": "evt_7",
+    "event_kind": "session_closed",
+    "event_ts": "2026-03-06T10:05:10Z",
+    "agent_id": "main",
+    "session_id": "sess_456",
+    "turn_id": "turn_790",
+    "request_id": "req_124",
+    "pack_id": "brainpack_2026_03_06_001",
+    "payload": {
+      "close_reason": "assistant_complete"
+    }
+  }
+]

--- a/contracts/runtime_compile/v1/golden-request.json
+++ b/contracts/runtime_compile/v1/golden-request.json
@@ -1,0 +1,39 @@
+{
+  "contract_version": "runtime_compile.v1",
+  "request_id": "req_123",
+  "agent_id": "main",
+  "session_id": "sess_456",
+  "turn_id": "turn_789",
+  "pack_id": "brainpack_2026_03_06_001",
+  "user_message": "what failed last deploy?",
+  "recent_turns": [
+    {
+      "role": "user",
+      "content": "show me the last deploy note",
+      "turn_id": "turn_788"
+    },
+    {
+      "role": "assistant",
+      "content": "Deploy note loaded.",
+      "turn_id": "turn_788a"
+    }
+  ],
+  "tool_context": [
+    {
+      "tool_name": "web_search",
+      "summary": "No deploy ticket found in the tracker.",
+      "output_ref": "tool:web_search:req_122"
+    }
+  ],
+  "budget": {
+    "max_chars": 16000,
+    "max_blocks": 8
+  },
+  "hints": {
+    "recall": true,
+    "correction_sensitive": true
+  },
+  "routing": {
+    "mode_requested": "learned"
+  }
+}

--- a/contracts/runtime_compile/v1/golden-response.json
+++ b/contracts/runtime_compile/v1/golden-response.json
@@ -1,0 +1,36 @@
+{
+  "contract_version": "runtime_compile.v1",
+  "request_id": "req_123",
+  "pack_id": "brainpack_2026_03_06_001",
+  "context_blocks": [
+    {
+      "id": "ctx_1",
+      "kind": "memory",
+      "title": "Deploy failure summary",
+      "content": "The last deploy failed because the dist build was stale and missing plugin SDK files.",
+      "score": 0.93,
+      "sources": [
+        {
+          "kind": "memory",
+          "ref": "memory/2026-03-06#deploy-stale-dist"
+        }
+      ]
+    }
+  ],
+  "suppressed_sources": [
+    "memory:duplicate:ctx_legacy"
+  ],
+  "routing": {
+    "mode_requested": "learned",
+    "mode_effective": "learned",
+    "used_learned_route_fn": true,
+    "route_model_id": "route_model_2026_03_06",
+    "decision_trace_ref": "route_decision_req_123"
+  },
+  "diagnostics": {
+    "candidate_count": 24,
+    "selected_count": 1,
+    "compile_ms": 18.7,
+    "router": "learned_route_fn"
+  }
+}

--- a/contracts/runtime_compile/v1/request.schema.json
+++ b/contracts/runtime_compile/v1/request.schema.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://openclawbrain.dev/contracts/runtime_compile/v1/request.schema.json",
+  "title": "runtime_compile.v1 request",
+  "type": "object",
+  "required": [
+    "contract_version",
+    "request_id",
+    "agent_id",
+    "session_id",
+    "turn_id",
+    "pack_id",
+    "user_message",
+    "recent_turns",
+    "tool_context",
+    "budget",
+    "hints",
+    "routing"
+  ],
+  "properties": {
+    "contract_version": {
+      "const": "runtime_compile.v1"
+    },
+    "request_id": {
+      "type": "string"
+    },
+    "agent_id": {
+      "type": "string"
+    },
+    "session_id": {
+      "type": "string"
+    },
+    "turn_id": {
+      "type": "string"
+    },
+    "pack_id": {
+      "type": "string"
+    },
+    "user_message": {
+      "type": "string"
+    },
+    "recent_turns": {
+      "type": "array"
+    },
+    "tool_context": {
+      "type": "array"
+    },
+    "budget": {
+      "type": "object"
+    },
+    "hints": {
+      "type": "object"
+    },
+    "routing": {
+      "type": "object"
+    }
+  },
+  "additionalProperties": true
+}

--- a/contracts/runtime_compile/v1/response.schema.json
+++ b/contracts/runtime_compile/v1/response.schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://openclawbrain.dev/contracts/runtime_compile/v1/response.schema.json",
+  "title": "runtime_compile.v1 response",
+  "type": "object",
+  "required": [
+    "contract_version",
+    "request_id",
+    "pack_id",
+    "context_blocks",
+    "suppressed_sources",
+    "routing",
+    "diagnostics"
+  ],
+  "properties": {
+    "contract_version": {
+      "const": "runtime_compile.v1"
+    },
+    "request_id": {
+      "type": "string"
+    },
+    "pack_id": {
+      "type": "string"
+    },
+    "context_blocks": {
+      "type": "array"
+    },
+    "suppressed_sources": {
+      "type": "array"
+    },
+    "routing": {
+      "type": "object"
+    },
+    "diagnostics": {
+      "type": "object"
+    }
+  },
+  "additionalProperties": true
+}

--- a/docs/contracts-v1.md
+++ b/docs/contracts-v1.md
@@ -1,0 +1,21 @@
+# Contracts v1
+
+Phase 1 contract scaffolding for the canonical OpenClaw/OpenClawBrain
+rearchitecture lives under [contracts/README.md](../contracts/README.md).
+
+Primary contract roots:
+
+- [contracts/runtime_compile/v1](../contracts/runtime_compile/v1)
+- [contracts/interaction_events/v1](../contracts/interaction_events/v1)
+- [contracts/feedback_events/v1](../contracts/feedback_events/v1)
+- [contracts/artifact_manifest/v1](../contracts/artifact_manifest/v1)
+
+OpenClawBrain-side validation helpers and the legacy feedback bridge live in
+[openclawbrain/contracts/v1.py](../openclawbrain/contracts/v1.py).
+
+Scope boundary for this landing:
+
+- schemas and golden fixtures are normative
+- tests enforce explicit learned-routing fields where the canonical plan
+  requires them
+- no runtime or daemon cutover is implied by these files

--- a/docs/openclawbrain-openclaw-rearchitecture-execution-plan.md
+++ b/docs/openclawbrain-openclaw-rearchitecture-execution-plan.md
@@ -1,0 +1,547 @@
+# OpenClaw + OpenClawBrain Rearchitecture Execution Plan
+
+Status: Canonical execution plan
+
+This document operationalizes [docs/openclawbrain-openclaw-rearchitecture-plan.md](/Users/cormorantai/openclawbrain/docs/openclawbrain-openclaw-rearchitecture-plan.md) into the implementation program we will execute. Where this document conflicts with legacy docs, examples, or runtime assumptions, this document wins.
+
+This is not architecture prose. It is the migration and delivery plan.
+
+## Mission
+
+Build the production OpenClawBrain architecture as a separate, TypeScript-first repo that:
+
+- serves brain context through a narrow `runtime_compile.v1` contract
+- treats learned runtime `route_fn` as the top serving invariant
+- treats structural graph operations, Hebbian co-firing, and decay as first-class learner/pack concerns
+- serves only from immutable promoted packs
+- removes legacy runtime-overlap code aggressively instead of preserving dual architectures
+
+## Fixed Assumptions
+
+These assumptions are locked unless explicitly changed by a new canonical plan:
+
+- OpenClaw owns runtime orchestration, sessions, diagnostics, prompt assembly, fail-open behavior, and active pack pointers.
+- OpenClawBrain lives in a separate repo and is not a second runtime owner.
+- The production implementation is TypeScript-first for contracts, compiler, pack loader, learner orchestration, evaluation, and promotion tooling.
+- Python is allowed only behind offline artifact boundaries when justified by clear ML or research value.
+- Learned `route_fn` is not optional when a pack declares learned routing; no silent heuristic fallback is allowed.
+- Structural graph operations (`split`, `merge`, `prune`, `connect`), Hebbian co-firing reinforcement, and decay are part of the product, not background nice-to-haves.
+- Legacy daemon/socket/hook/session-store parsing paths are migration bridges at most and should be deleted once replacement capability exists.
+
+## Program Success Criteria
+
+The program is complete only when all of the following are true:
+
+1. OpenClaw can compile turn context against a promoted pack using the canonical `runtime_compile.v1` contract.
+2. The production serving path uses the learned `route_fn` whenever the pack requires it, and activation rejects packs that cannot satisfy that requirement.
+3. OpenClawBrain learner builds reproducible, immutable packs from normalized OpenClaw events plus declared workspace snapshots.
+4. Structural graph maintenance, Hebbian reinforcement, and decay are implemented in the TypeScript learner/compiler stack and reflected in pack metadata/evaluation.
+5. Promotion and rollback are pointer flips in OpenClaw, not rebuilds or daemon restarts.
+6. Legacy runtime-overlap code and docs are removed or archived so operators cannot accidentally deploy the old shape.
+
+## Delivery Principles
+
+- Deliver the new serving contract before widening learner scope.
+- Ship the minimum pack format that can enforce learned routing honestly.
+- Port serving-critical logic before porting convenience CLIs.
+- Delete runtime-overlap code as soon as the equivalent OpenClaw-owned path exists.
+- Preserve only offline research value from the Python repo; do not preserve Python because of historical inertia.
+- Every phase ends with an operator-visible gate: either the new path is active, or the old path remains the only supported one.
+
+## Workstreams
+
+| Workstream | Scope | Primary Outputs |
+| --- | --- | --- |
+| WS1. Repo and packaging | Separate TypeScript repo bootstrap, package boundaries, CI, release model | New repo skeleton, package layout, CI gates |
+| WS2. Contracts | Canonical schemas, validators, fixtures, compatibility tests | `runtime_compile`, `interaction_events`, `feedback_events`, `artifact_manifest` packages |
+| WS3. Pack format | Immutable pack layout, checksums, model/runtime requirements, provenance | `manifest.json`, chunk/graph/vector/router payload spec, validators |
+| WS4. Compiler/serve path | TypeScript pack loader, traversal engine, learned `route_fn`, deterministic compile | compile library, worker entrypoint, golden compile tests |
+| WS5. Learner pipeline | Event ingestion, workspace snapshots, Hebbian updates, decay, structural ops, pack assembly | learner orchestrator, pack builder, learner metrics |
+| WS6. Eval and promotion | Candidate-vs-active comparison, activation validation, rollback rules | eval harness, promotion controller contract, activation checks |
+| WS7. OpenClaw integration | OpenClaw-owned compile invocation, prompt injection, pack pointer management, observability | runtime integration PRs in OpenClaw, rollout plan |
+| WS8. Legacy deletion | Remove daemon/socket/hook/runtime-overlap code, archive stale docs/examples/tests | deletion PRs, archived docs, simplified operator story |
+
+## Sequencing
+
+Critical path:
+
+1. Lock contracts and pack schema.
+2. Bootstrap separate TypeScript repo and move canonical contracts there.
+3. Implement TypeScript pack loader and deterministic compile core.
+4. Make learned `route_fn` enforcement real on the production serving path.
+5. Implement learner build pipeline with first-class Hebbian/decay/structural operations.
+6. Land OpenClaw promotion, activation, and fail-open integration.
+7. Delete legacy runtime-overlap surfaces.
+
+Parallelizable after Phase 1:
+
+- evaluation harness work can start as soon as contract fixtures exist
+- OpenClaw integration scaffolding can start as soon as compile request/response fixtures are stable
+- learner event normalization can start before full pack builder completion
+
+Non-parallelizable gates:
+
+- no OpenClaw runtime cutover before learned-routing activation validation exists
+- no deletion of legacy runtime paths before OpenClaw can compile against promoted packs
+- no pack promotion before manifest validation and rollback pointer switching are complete
+
+## Phase Plan
+
+## Phase 0: Program Lock and Repo Split
+
+Objective: establish the new execution boundary and prevent more work from landing into the wrong architecture.
+
+### Scope
+
+- Declare the separate TypeScript repo as the target production repo.
+- Freeze new feature work in legacy Python runtime-overlap surfaces.
+- Define ownership split between OpenClaw runtime work and OpenClawBrain compiler/learner work.
+- Mark this document and the rearchitecture plan as canonical.
+
+### Deliverables
+
+- New TypeScript repo created with workspace/package layout:
+  - `packages/contracts`
+  - `packages/pack-format`
+  - `packages/compiler`
+  - `packages/learner`
+  - `packages/eval`
+  - `packages/cli`
+- ADR or README in the new repo documenting:
+  - repo purpose
+  - production language stance
+  - Python boundary policy
+  - rollout rules
+- Current repo banner docs updated to state Python runtime paths are transitional and not the long-term production architecture.
+
+### Acceptance Criteria
+
+- Separate repo exists and builds in CI.
+- New work on runtime serving is directed only to the TypeScript repo except for short-term bridge fixes.
+- Team agreement recorded on top invariants:
+  - learned `route_fn`
+  - immutable packs
+  - OpenClaw-owned runtime
+  - aggressive legacy deletion
+
+### Deletion/Archive Targets
+
+Archive or explicitly de-canonicalize as legacy guidance:
+
+- [docs/openclaw-integration.md](/Users/cormorantai/openclawbrain/docs/openclaw-integration.md)
+- [docs/openclawbrain-openclaw-hooks.md](/Users/cormorantai/openclawbrain/docs/openclawbrain-openclaw-hooks.md)
+- [docs/new-agent-sop.md](/Users/cormorantai/openclawbrain/docs/new-agent-sop.md)
+- [docs/architecture.md](/Users/cormorantai/openclawbrain/docs/architecture.md)
+- [docs/FULL_REBUILD.md](/Users/cormorantai/openclawbrain/docs/FULL_REBUILD.md)
+
+## Phase 1: Canonical Contracts and Pack Schema
+
+Objective: make the cross-repo boundary executable and testable before compiler or learner implementation expands.
+
+### Scope
+
+- Finalize TypeScript-first schemas and validators for:
+  - `runtime_compile.v1`
+  - `interaction_events.v1`
+  - `feedback_events.v1`
+  - `artifact_manifest.v1`
+- Define the first production pack layout.
+- Write golden fixtures and compatibility tests shared between repos.
+
+### Deliverables
+
+- TypeScript schema/validator package as the source of truth.
+- Generated JSON Schema artifacts for cross-language consumers.
+- Fixture set covering:
+  - learned-required compile requests/responses
+  - heuristic-allowed compile requests/responses
+  - manifest activation rejection cases
+  - event stream examples for correction/teaching/approval/operator override
+- Pack manifest spec that includes:
+  - route policy
+  - serve requirements
+  - graph payload checksums
+  - vector payload checksums
+  - model fingerprints
+  - workspace snapshot provenance
+  - event-range provenance
+
+### Acceptance Criteria
+
+- OpenClaw and OpenClawBrain can both validate the same fixtures with identical outcomes.
+- The contract package rejects responses that claim learned routing without explicit `used_learned_route_fn=true` and explicit learned mode.
+- The manifest validator rejects packs missing required route model/runtime assets.
+- The fixture suite is wired into CI in both repos.
+
+### Deletion/Archive Targets
+
+Delete or deprecate local schema authority outside the new contract package once parity is reached:
+
+- [openclawbrain/contracts/v1.py](/Users/cormorantai/openclawbrain/openclawbrain/contracts/v1.py) as canonical source of truth
+- [docs/contracts-v1.md](/Users/cormorantai/openclawbrain/docs/contracts-v1.md) as a landing doc only; replace with pointers to the new repo once moved
+
+## Phase 2: TypeScript Compiler Core and Honest Serving Path
+
+Objective: stand up a deterministic compile engine that serves from packs and enforces learned-routing truthfully.
+
+### Scope
+
+- Implement pack loading from promoted artifacts.
+- Port serving-critical graph structures and traversal behavior to TypeScript.
+- Implement production `route_fn` execution using pack-provided learned router data.
+- Produce compile responses with deterministic diagnostics.
+
+### Detailed Work
+
+- Port or reimplement core data structures:
+  - nodes
+  - edges
+  - vector index access
+  - traversal config
+  - suppression overlays
+  - provenance lookups
+- Define runtime compile algorithm:
+  - load active pack snapshot
+  - seed candidates from user message and runtime hints
+  - traverse graph with learned `route_fn` controlling habitual candidate expansion/ranking
+  - apply correction/suppression overlays
+  - rank and trim context blocks to budget
+  - return diagnostics and routing metadata
+- Implement deterministic routing behavior:
+  - same request + same pack => same selected candidates and context order
+  - stable tie-break rules
+  - explicit route mode in output
+
+### Deliverables
+
+- `packages/compiler` TypeScript library
+- optional worker entrypoint managed by OpenClaw
+- compile golden tests using frozen pack fixtures
+- benchmark suite for p50/p95 compile latency and pack load latency
+
+### Acceptance Criteria
+
+- Compiler can answer `runtime_compile.v1` requests against a static pack fixture.
+- Learned-required packs fail activation or compile initialization if learned router assets are unavailable.
+- No compile path mutation occurs: no fired-log writes, no learner writes, no stateful per-turn training side effects.
+- Compile outputs are deterministic under repeated runs.
+- Diagnostics clearly expose `mode_requested`, `mode_effective`, `used_learned_route_fn`, and router identity.
+
+### Deletion/Archive Targets
+
+Once OpenClaw can call the new compiler:
+
+- [openclawbrain/daemon.py](/Users/cormorantai/openclawbrain/openclawbrain/daemon.py)
+- [openclawbrain/socket_server.py](/Users/cormorantai/openclawbrain/openclawbrain/socket_server.py)
+- [openclawbrain/socket_client.py](/Users/cormorantai/openclawbrain/openclawbrain/socket_client.py)
+- [openclawbrain/protocol.py](/Users/cormorantai/openclawbrain/openclawbrain/protocol.py)
+- [tests/test_daemon.py](/Users/cormorantai/openclawbrain/tests/test_daemon.py)
+- [tests/test_socket.py](/Users/cormorantai/openclawbrain/tests/test_socket.py)
+- [tests/test_socket_client_cli.py](/Users/cormorantai/openclawbrain/tests/test_socket_client_cli.py)
+- [tests/test_socket_server_args.py](/Users/cormorantai/openclawbrain/tests/test_socket_server_args.py)
+
+## Phase 3: Learner Pipeline With First-Class Graph Dynamics
+
+Objective: rebuild the learning system around normalized events, workspace snapshots, and pack production instead of runtime mutation and raw session parsing.
+
+### Scope
+
+- Ingest normalized OpenClaw interaction and feedback events.
+- Build learning records for corrections, teachings, suppressions, summaries, and route labels.
+- Reimplement graph-learning primitives in the TypeScript learner.
+- Assemble candidate packs from learner outputs plus workspace snapshots.
+
+### Required First-Class Learner Features
+
+These are mandatory for Phase 3 exit. They are not optional follow-up work:
+
+- Hebbian co-firing reinforcement
+  - strengthen edges between co-activated nodes from successful turns
+  - support source attribution and learning-rate controls by signal type
+- Decay
+  - time-aware edge weakening
+  - manifest-recorded decay parameters
+  - deterministic application during builds
+- Structural graph operations
+  - split overloaded nodes
+  - merge redundant neighborhoods
+  - prune weak or invalid edges/nodes
+  - connect new learning nodes into workspace neighborhoods
+- Correction and suppression overlays
+  - explicit negative knowledge and suppression references in the pack
+- Route label production
+  - training/eval-ready decision points tied to pack/router provenance
+
+### Detailed Work
+
+- Define learner input model:
+  - normalized event stream
+  - workspace snapshot manifest
+  - active pack baseline
+  - optional offline-derived artifacts from Python jobs
+- Port or reimplement current useful algorithms from Python:
+  - decay logic from [openclawbrain/decay.py](/Users/cormorantai/openclawbrain/openclawbrain/decay.py)
+  - maintenance orchestration from [openclawbrain/maintain.py](/Users/cormorantai/openclawbrain/openclawbrain/maintain.py)
+  - route labeling/training inputs from [openclawbrain/ops/async_route_pg.py](/Users/cormorantai/openclawbrain/openclawbrain/ops/async_route_pg.py)
+- Replace raw session-store ingestion as the primary interface with event ingestion.
+- Keep raw replay/history import only as one-time or backfill tooling, never as the steady-state learner contract.
+
+### Deliverables
+
+- `packages/learner` orchestrator
+- candidate-pack builder
+- learner state store for checkpoints and input provenance
+- learner metrics/events
+- deterministic rebuild test from frozen input fixtures
+
+### Acceptance Criteria
+
+- Given the same event range, workspace snapshot, and offline artifacts, the learner produces the same pack checksum.
+- Pack manifests record graph-dynamics provenance:
+  - Hebbian parameters
+  - decay parameters
+  - structural-op counts/results
+  - route training provenance
+- Raw OpenClaw/Codex session parsing is no longer required for normal operation.
+- Learner lag does not affect runtime serving.
+
+### Deletion/Archive Targets
+
+Delete or downgrade to explicit migration-only tooling:
+
+- [openclawbrain/replay.py](/Users/cormorantai/openclawbrain/openclawbrain/replay.py) as steady-state pipeline
+- [openclawbrain/full_learning.py](/Users/cormorantai/openclawbrain/openclawbrain/full_learning.py) as steady-state pipeline
+- [openclawbrain/session_sources.py](/Users/cormorantai/openclawbrain/openclawbrain/session_sources.py) as primary ingestion
+- [docs/FULL_REBUILD.md](/Users/cormorantai/openclawbrain/docs/FULL_REBUILD.md)
+- replay/harvest examples in [examples/ops](/Users/cormorantai/openclawbrain/examples/ops) that describe the old operational model
+
+## Phase 4: Learned Router Training, Evaluation, and Activation Gates
+
+Objective: make learned routing an enforced production contract instead of a best-effort mode.
+
+### Scope
+
+- Define router artifact formats that are TypeScript-loadable in production.
+- Build router training and evaluation pipeline.
+- Add activation gates that reject packs whose learned routing cannot be served honestly.
+
+### Deliverables
+
+- route-model artifact format supported by Node/TypeScript runtime
+- training pipeline that emits model fingerprints and evaluation summary
+- evaluation suites:
+  - candidate expansion/ranking accuracy
+  - compile-output regression versus active pack
+  - latency budget compliance
+  - learned-routing enforcement tests
+- activation validator used by OpenClaw before pointer flips
+
+### Acceptance Criteria
+
+- A pack marked `requires_learned_routing=true` cannot activate unless the runtime can load and use the router artifact.
+- Evaluation output compares candidate pack vs active pack on held-out traces and policy checks.
+- Runtime compile on a learned-required pack shows `mode_effective=learned` and `used_learned_route_fn=true` in production integration tests.
+- There is no code path that silently falls back to heuristic routing for learned-required packs.
+
+### Deletion/Archive Targets
+
+Delete the old operator story around “learned if available, heuristic otherwise” from:
+
+- [docs/learned-routing-audit.md](/Users/cormorantai/openclawbrain/docs/learned-routing-audit.md) once superseded by the new OpenClaw/OpenClawBrain operator checks
+- legacy route-mode CLI flows in [openclawbrain/daemon.py](/Users/cormorantai/openclawbrain/openclawbrain/daemon.py)
+- legacy route-model training CLIs that only feed the Python daemon path
+
+## Phase 5: OpenClaw Runtime Integration and Promotion Control
+
+Objective: move the runtime boundary into OpenClaw completely.
+
+### Scope
+
+- Add OpenClaw-owned pack pointer resolution per agent.
+- Add OpenClaw-owned compile invocation, timeout policy, and fail-open behavior.
+- Add OpenClaw-owned prompt assembly and memory diagnostics.
+- Add OpenClaw-owned promotion and rollback control.
+
+### Detailed Work
+
+- OpenClaw runtime changes:
+  - resolve active `pack_id`
+  - issue `runtime_compile.v1` request
+  - apply compile timeout policy
+  - inject selected context blocks into final prompt
+  - emit `memory_compiled` interaction events
+  - surface compile diagnostics in OpenClaw tracing/metrics
+- Promotion controller changes:
+  - validate manifest
+  - validate checksums
+  - validate runtime compatibility and serve requirements
+  - atomically flip active pack pointer
+  - preserve previous pointer for rollback
+
+### Deliverables
+
+- OpenClaw integration PRs
+- active-pack pointer storage design
+- rollout config for fail-open and pack pinning
+- production dashboards for compile success, fail-open, pack distribution, and learned-route usage
+
+### Acceptance Criteria
+
+- OpenClaw can serve requests end-to-end using promoted packs without any OpenClawBrain daemon/socket/hook dependency.
+- OpenClaw can pin a specific `pack_id` for debugging and rollback.
+- OpenClaw runtime traces include compile timing, route mode, pack id, and fail-open reason when applicable.
+- Rollback to the prior pack is an atomic pointer change and completes without pack rebuild.
+
+### Deletion/Archive Targets
+
+Delete integration surfaces that give OpenClawBrain runtime ownership:
+
+- [integrations/openclaw/hooks/openclawbrain-context-injector/HOOK.md](/Users/cormorantai/openclawbrain/integrations/openclaw/hooks/openclawbrain-context-injector/HOOK.md)
+- [integrations/openclaw/hooks/openclawbrain-context-injector/handler.ts](/Users/cormorantai/openclawbrain/integrations/openclaw/hooks/openclawbrain-context-injector/handler.ts)
+- [openclawbrain/openclaw_adapter/query_brain.py](/Users/cormorantai/openclawbrain/openclawbrain/openclaw_adapter/query_brain.py)
+- any OpenClawBrain CLI path whose job is prompt injection instead of pack build/eval/publish
+
+Archive migration-only feedback helpers only if OpenClaw event export supersedes them:
+
+- [openclawbrain/openclaw_adapter/capture_feedback.py](/Users/cormorantai/openclawbrain/openclawbrain/openclaw_adapter/capture_feedback.py)
+- [openclawbrain/openclaw_adapter/learn_by_chat_id.py](/Users/cormorantai/openclawbrain/openclawbrain/openclaw_adapter/learn_by_chat_id.py)
+- [openclawbrain/openclaw_adapter/learn_correction.py](/Users/cormorantai/openclawbrain/openclawbrain/openclaw_adapter/learn_correction.py)
+
+## Phase 6: Legacy Deletion and Operator Story Reset
+
+Objective: end the dual-architecture period and make the new path the only supported production story.
+
+### Scope
+
+- Remove dead runtime-overlap code.
+- Remove docs that teach the old daemon/hook/harvest workflow as the primary operating model.
+- Publish the new operator runbooks around packs, compile, learner, promotion, and rollback.
+
+### Deliverables
+
+- deletion PRs merged
+- docs refresh completed
+- examples refreshed to show pack-based build/promote/rollback flow
+- archived legacy docs moved under `docs/archive/` or removed
+
+### Acceptance Criteria
+
+- The repo no longer advertises `serve`, socket, or hook injection as the recommended production setup.
+- Operators have one canonical setup path and one canonical rollback path.
+- CI no longer exercises deleted runtime-overlap surfaces.
+- Remaining Python code is explicitly categorized as:
+  - offline research
+  - migration/backfill tooling
+  - temporary parity bridge with an owner and removal date
+
+### Deletion/Archive Targets
+
+- [examples/openclaw_quickstart.sh](/Users/cormorantai/openclawbrain/examples/openclaw_quickstart.sh)
+- [examples/openclaw_adapter/README.md](/Users/cormorantai/openclawbrain/examples/openclaw_adapter/README.md)
+- [examples/openclaw_adapter/query_brain.py](/Users/cormorantai/openclawbrain/examples/openclaw_adapter/query_brain.py)
+- launchd/systemd daemon templates that exist only for runtime serving
+- obsolete tests tied only to deleted surfaces
+
+## Cross-Phase Deliverable Map
+
+| Deliverable | Phase | Blocking Dependencies |
+| --- | --- | --- |
+| Separate TypeScript repo scaffold | 0 | none |
+| Canonical contracts package | 1 | repo scaffold |
+| Pack manifest and layout | 1 | contracts package |
+| TypeScript compile core | 2 | contracts, pack layout |
+| Learned-route enforcement | 2-4 | compile core, route artifact format |
+| Learner orchestrator | 3 | contracts, pack layout |
+| Structural-op + Hebbian + decay parity | 3 | learner orchestrator |
+| Router training/eval pipeline | 4 | learner outputs, eval harness |
+| OpenClaw integration | 5 | compile core, activation validator |
+| Promotion/rollback controller | 5 | manifest validator |
+| Legacy deletion | 6 | OpenClaw cutover |
+
+## Testing and Verification Gates
+
+Each phase must land with automated coverage. Minimum required gates:
+
+- Contract fixtures and schema validation
+- Deterministic compile golden tests
+- Pack checksum and manifest validation tests
+- Learned-routing activation rejection tests
+- Learner reproducibility tests from frozen event/workspace inputs
+- Regression tests for suppression/correction overlays
+- Structural-op regression tests:
+  - split
+  - merge
+  - prune
+  - connect
+- Hebbian reinforcement tests
+- Decay parameter and output tests
+- OpenClaw integration tests for:
+  - fail-open on compile timeout
+  - pack pinning
+  - rollback
+  - routing metadata emission
+
+## Migration Rules for Existing Python Code
+
+- Keep only what is needed to derive parity fixtures or offline artifacts.
+- Do not deepen the Python daemon/socket/runtime integration.
+- Do not add new OpenClaw hooks or adapter CLIs for prompt injection.
+- Any Python module retained during migration must be labeled:
+  - `bridge`
+  - `offline`
+  - or `delete_after_phase_X`
+
+Recommended retention during migration:
+
+- keep graph-learning logic as reference material until TypeScript parity exists
+- keep route-label/training code only if it produces language-neutral artifacts consumed by the TypeScript pipeline
+- keep replay/backfill only for one-time history imports
+
+Recommended early deletions:
+
+- runtime daemon lifecycle management
+- socket transport
+- hot in-memory serving claims in operator docs
+- hook-based prompt injection as the recommended architecture
+
+## Immediate Next Actions
+
+These are the next concrete actions, in order:
+
+1. Create the separate TypeScript repo and commit the package skeleton plus CI.
+2. Move canonical contract source-of-truth into the new repo and wire shared golden fixtures.
+3. Define `artifact_manifest.v1` and the first pack directory layout, including graph/router/vector payload boundaries and checksums.
+4. Implement a minimal TypeScript compile core that can load a frozen pack fixture and answer `runtime_compile.v1`.
+5. Add learned-routing activation validation before any runtime integration work proceeds.
+6. Draft the OpenClaw runtime integration PR that resolves `pack_id`, invokes compile, records `memory_compiled`, and fails open on timeout.
+7. Mark `daemon.py`, `socket_server.py`, hook injection docs, and adapter query paths as deprecated in this repo immediately.
+8. Start a parity matrix mapping Python graph-learning behavior to TypeScript implementations:
+   - Hebbian co-firing
+   - decay
+   - split
+   - merge
+   - prune
+   - connect
+   - suppression overlays
+9. Define the event export path from OpenClaw so learner work can proceed without raw session parsing.
+10. Open deletion trackers for every legacy runtime-overlap surface listed in this plan, each with an owner and removal phase.
+
+## Explicit Non-Deliverables
+
+The following are not acceptable substitutes for this plan:
+
+- keeping the Python daemon as the production compile service indefinitely
+- treating hook injection as the long-term OpenClaw integration
+- logging learned-routing diagnostics without actually using the learned `route_fn`
+- preserving raw session-store parsing as the steady-state learner interface
+- postponing deletion until “after everything else is stable”
+
+## Canonical Outcome
+
+The end state is simple:
+
+- OpenClaw owns runtime.
+- OpenClawBrain ships packs, compiler logic, learner outputs, and evaluations from a separate TypeScript-first repo.
+- Learned `route_fn` is a hard serving invariant.
+- Structural graph operations, Hebbian co-firing, and decay are first-class pack-building behavior.
+- Legacy runtime-overlap code is gone.

--- a/docs/openclawbrain-openclaw-rearchitecture-plan.md
+++ b/docs/openclawbrain-openclaw-rearchitecture-plan.md
@@ -1,0 +1,710 @@
+# OpenClaw + OpenClawBrain Rearchitecture Plan
+
+Status: Proposed canonical plan
+
+This is the canonical north-star architecture for integrating OpenClawBrain with regular OpenClaw. It supersedes the target-shape assumptions spread across [docs/architecture.md](/Users/cormorantai/openclawbrain/docs/architecture.md), [docs/openclaw-integration.md](/Users/cormorantai/openclawbrain/docs/openclaw-integration.md), [docs/shadow-routing-upg-architecture.md](/Users/cormorantai/openclawbrain/docs/shadow-routing-upg-architecture.md), and [docs/FULL_REBUILD.md](/Users/cormorantai/openclawbrain/docs/FULL_REBUILD.md) where they conflict with this plan.
+
+This plan does not optimize for backward compatibility. If a current path blurs runtime ownership, duplicates responsibilities already held by OpenClaw, or depends on legacy session-store parsing as a steady-state interface, it should be deleted or rebuilt.
+
+## Why This Rearchitecture
+
+Today the repo still describes and ships multiple overlapping shapes:
+
+- OpenClawBrain as a runtime daemon/socket service.
+- OpenClawBrain as a hook-driven prompt injector.
+- OpenClawBrain as a replay/harvest/teacher loop system.
+- OpenClawBrain as a direct parser of raw OpenClaw and Codex session stores.
+
+That creates the wrong long-term boundary. OpenClaw should own runtime orchestration. OpenClawBrain should own memory compilation and learning. The runtime must not depend on OpenClawBrain acting like a second agent platform.
+
+Recent repo findings already show the cost of weak boundaries: placeholder training exports, brittle raw-session ingestion paths, and multiple partially overlapping learning loops. The fix is not more glue. The fix is a cleaner architecture.
+
+## North Star
+
+OpenClaw remains the sole runtime owner for:
+
+- channels
+- sessions and turn state
+- diagnostics, tracing, and runtime budgets
+- tool execution and completion calls
+- fail-open/fail-closed runtime policy
+- promotion and rollback of active memory artifacts
+
+OpenClawBrain remains a separate repo and becomes:
+
+- the memory/context compiler
+- the learner system
+- the offline and nearline artifact builder
+- the scorer/router pack producer
+- the evaluator of whether a new memory artifact is better than the current one
+
+The runtime relationship is simple:
+
+1. OpenClaw produces normalized runtime inputs.
+2. OpenClaw invokes OpenClawBrain through a narrow compile contract.
+3. OpenClawBrain returns context blocks plus structured metadata.
+4. OpenClaw decides what to inject, how much to inject, how to log it, and what to do on failure.
+
+The learner relationship is also simple:
+
+1. OpenClaw emits normalized interaction and feedback events.
+2. OpenClawBrain consumes those events and workspace snapshots.
+3. OpenClawBrain builds versioned memory artifacts.
+4. OpenClaw validates and promotes an artifact atomically.
+
+## Anti-Goals
+
+- Do not keep OpenClawBrain as an independent runtime owner with its own daemon, socket lifecycle, hook lifecycle, or session truth.
+- Do not keep raw OpenClaw/Codex session parsing as the primary steady-state ingestion interface.
+- Do not preserve CLI compatibility if the command exists only to maintain the old runtime split.
+- Do not put teacher-model calls, feedback scanning, or learning extraction in the user-request critical path.
+- Do not let OpenClawBrain own user-visible diagnostics, request IDs, or runtime latency policy.
+- Do not couple runtime correctness to a separate learner plane being healthy.
+
+## Ownership Boundaries
+
+| Domain | Owner | Notes |
+| --- | --- | --- |
+| Channels, agents, sessions, turn state | OpenClaw | Source of truth. |
+| Prompt assembly and final injected context | OpenClaw | OpenClaw decides budget and ordering. |
+| Runtime request IDs, tracing, diagnostics | OpenClaw | OpenClawBrain can return metadata, not own the trace. |
+| Workspace snapshot discovery | OpenClaw | OpenClaw tells OpenClawBrain what to compile. |
+| Memory compilation from source inputs | OpenClawBrain | Produces versioned artifacts. |
+| Learning from feedback and history | OpenClawBrain | Uses normalized exports from OpenClaw. |
+| Artifact validation and promotion gates | Shared | OpenClawBrain evaluates; OpenClaw promotes. |
+| Artifact activation and rollback | OpenClaw | Runtime owner must own rollback. |
+
+Rules:
+
+- OpenClawBrain may run a learner plane, but it is never a competing runtime owner.
+- Any OpenClawBrain helper process on the runtime path is OpenClaw-started, OpenClaw-supervised, OpenClaw-timed out, and OpenClaw-instrumented.
+- OpenClawBrain state is derived state. OpenClaw sessions and events remain canonical.
+
+## Language and Implementation Stance
+
+The default production target is TypeScript-native architecture everywhere it is practical:
+
+- TypeScript is the canonical implementation language for runtime contracts, pack loading, compile serving, learner orchestration, promotion control, and operational tooling.
+- OpenClawBrain remains a separate repo, but its production-facing surfaces should be published as TypeScript packages, worker entrypoints, and language-neutral pack artifacts that OpenClaw can consume directly.
+- Python is optional and justified only for offline research, experimentation, or ML/data-processing steps that materially benefit from the Python ecosystem.
+- Python is not the default compiler substrate, not the default learner orchestrator, and not part of the default production request path.
+
+Implications:
+
+- Separate repo does not imply separate runtime ownership or a Python daemon boundary.
+- The canonical artifacts and contracts must be loadable, validated, and served from TypeScript without requiring Python in production.
+- If a Python component is introduced, it must terminate at a versioned artifact boundary such as model weights, labels, summaries, or candidate-pack inputs. It must not become the source of truth for runtime behavior.
+
+## Target Components and Planes
+
+### 1. OpenClaw Runtime Plane
+
+Responsibilities:
+
+- receive user and channel events
+- maintain session state and short-term transcript state
+- call tools and models
+- request memory compilation for a turn
+- inject selected memory blocks into the prompt
+- emit runtime metrics and traces
+- emit normalized interaction events for learning
+
+Artifacts owned by OpenClaw:
+
+- session store
+- runtime traces
+- prompt budgets and policy
+- active artifact pointer per agent
+
+### 2. OpenClawBrain Compiler Plane
+
+Responsibilities:
+
+- compile workspace and learned memory into a versioned artifact pack
+- answer turn-scoped compile requests against an active pack
+- expose deterministic pack validation
+- expose deterministic scoring metadata to OpenClaw
+
+Default implementation target:
+
+- a TypeScript compiler core library shared by tests, pack tooling, and the OpenClaw runtime integration
+- an optional TypeScript worker entrypoint for isolation or preload benefits
+- no Python requirement on the production compile path unless there is a narrow, explicit exception with the same contract and observability guarantees
+
+This is not a second runtime. It is a compiler engine. In local development OpenClaw should be able to call it in-process. In production OpenClaw may call a local worker or bounded sidecar, but OpenClaw still owns lifecycle and observability.
+
+### 3. OpenClawBrain Learner Plane
+
+Responsibilities:
+
+- ingest normalized OpenClaw event streams
+- derive corrections, teachings, suppressions, summaries, and route updates
+- build candidate artifact packs
+- run offline evaluation and regression checks
+- publish artifact metadata for OpenClaw promotion
+
+Default implementation target:
+
+- TypeScript for event ingestion, orchestration, evaluation harnesses, pack assembly, and promotion handoff
+- Python only for clearly justified offline ML or research jobs that emit versioned outputs consumed by the TypeScript learner pipeline
+
+The learner plane may be scheduled, queue-backed, or batch-oriented. It must never be required for an interactive request to succeed.
+
+### 4. Artifact Plane
+
+The integration pivots around immutable, versioned artifact packs.
+
+Each pack should contain:
+
+- `manifest.json`
+- compiled content chunks
+- embedding metadata and vector data
+- route/scoring model data
+- route policy metadata and serving requirements
+- suppression and correction overlays
+- provenance map back to workspace and event sources
+- build metrics and evaluation summary
+- checksums for every payload
+
+Pack format rules:
+
+- Pack contents must be language-neutral and TypeScript-loadable in production.
+- No Python-specific runtime serialization formats such as pickle may appear in promoted serving packs.
+- Any learned model artifact included in a pack must be usable from the TypeScript production path, whether through native JS, ONNX, WASM, or another explicitly supported runtime.
+
+OpenClaw only serves from promoted packs. OpenClawBrain only writes new candidate packs.
+
+## Non-Negotiable Serving Invariants
+
+- Runtime compile is read-only and side-effect free. No fired-log writes, no per-turn state mutation, and no hidden learner writes on the request path.
+- A promoted pack is self-contained for serving. Runtime compile may read only the request payload, the promoted pack, and OpenClaw-owned runtime/session state.
+- One request uses one resolved promoted pack snapshot end-to-end. No mid-turn pack switching, partial pack reads, or cross-pack mixing.
+- If a promoted pack declares learned routing as required, the production compile path must actually use the learned `route_fn` to influence candidate expansion or ranking. Learned routing cannot be diagnostic-only.
+- Silent fallback from a learned-required pack to heuristic routing is not allowed. The only acceptable degradations are: reject activation before serving, or OpenClaw-owned fail-open that skips brain context for that turn.
+
+## Canonical Contracts and APIs
+
+All cross-repo boundaries should be versioned and live under a small contracts surface. Suggested location:
+
+- `contracts/runtime_compile/v1`
+- `contracts/interaction_events/v1`
+- `contracts/feedback_events/v1`
+- `contracts/artifact_manifest/v1`
+
+Contract rules:
+
+- The source of truth should be TypeScript-first schemas and validators, with generated JSON Schema or equivalent artifacts for cross-language consumers.
+- Example payloads, golden fixtures, and compatibility tests should be authored against the TypeScript contract package first.
+- Python consumers may bind to these contracts, but they should not define the canonical production schema behavior.
+
+### Contract 1: Runtime Compile Request
+
+Owned by OpenClaw. Sent per turn.
+
+```json
+{
+  "contract_version": "runtime_compile.v1",
+  "request_id": "req_123",
+  "agent_id": "main",
+  "session_id": "sess_456",
+  "turn_id": "turn_789",
+  "pack_id": "brainpack_2026_03_06_001",
+  "user_message": "what failed last deploy?",
+  "recent_turns": [],
+  "tool_context": [],
+  "budget": {
+    "max_chars": 16000,
+    "max_blocks": 8
+  },
+  "hints": {
+    "recall": true,
+    "correction_sensitive": true
+  }
+}
+```
+
+### Contract 2: Runtime Compile Response
+
+Produced by OpenClawBrain. Interpreted and enforced by OpenClaw.
+
+```json
+{
+  "contract_version": "runtime_compile.v1",
+  "request_id": "req_123",
+  "pack_id": "brainpack_2026_03_06_001",
+  "context_blocks": [
+    {
+      "id": "ctx_1",
+      "kind": "memory",
+      "title": "Deploy rollback rule",
+      "content": "If deploy verification fails, rollback before restarting workers.",
+      "score": 0.93,
+      "sources": [
+        {
+          "kind": "workspace",
+          "ref": "docs/deploy.md#rollback"
+        }
+      ]
+    }
+  ],
+  "suppressed_sources": [],
+  "routing": {
+    "mode_requested": "learned",
+    "mode_effective": "learned",
+    "used_learned_route_fn": true,
+    "route_model_id": "local-route-model-v3",
+    "decision_trace_ref": "route_decision_req_123"
+  },
+  "diagnostics": {
+    "candidate_count": 42,
+    "selected_count": 4,
+    "compile_ms": 18,
+    "router": "local-route-model-v3"
+  }
+}
+```
+
+Rules:
+
+- OpenClawBrain returns candidates and metadata, not final prompt ownership.
+- OpenClaw can truncate, reorder, discard, or augment returned blocks.
+- OpenClaw logs runtime diagnostics under its own trace/span.
+- `routing.mode_effective` must be explicit, never implied.
+- `used_learned_route_fn=true` means the learned router changed traversal or ranking on the production serving path, not just that a learned model was loaded.
+- If a pack requires learned routing, activation validation should prevent heuristic fallback long before runtime. A runtime response must not silently degrade to heuristic mode.
+
+### Contract 3: Interaction Event Stream
+
+Owned by OpenClaw. Exported continuously or in batches to the learner plane.
+
+Required event kinds:
+
+- `turn_started`
+- `memory_compiled`
+- `assistant_completed`
+- `tool_called`
+- `tool_result`
+- `feedback_recorded`
+- `session_closed`
+
+Required fields across all events:
+
+- `event_id`
+- `event_ts`
+- `agent_id`
+- `session_id`
+- `turn_id`
+- `request_id`
+- `pack_id`
+- `schema_version`
+
+This replaces raw parsing of OpenClaw internal stores as the primary contract.
+
+Required fields for `memory_compiled` events:
+
+- `selected_context_ids`
+- `suppressed_source_refs`
+- `routing.mode_requested`
+- `routing.mode_effective`
+- `routing.used_learned_route_fn`
+- `routing.decision_trace_ref`
+- `compile_latency_ms`
+
+### Contract 4: Feedback Event
+
+OpenClaw records feedback directly when a user correction, teaching, approval, or operator action occurs. OpenClawBrain learns from that exported record.
+
+Required fields:
+
+- `feedback_kind`: `correction`, `teaching`, `preference`, `approval`, `operator_override`
+- `source_kind`: `human`, `system`, `evaluation`
+- `message_ref`
+- `affected_turn_id`
+- `affected_context_ids`
+- `dedup_key`
+
+### Contract 5: Artifact Manifest
+
+Produced by OpenClawBrain. Promoted by OpenClaw.
+
+Required fields:
+
+- `pack_id`
+- `agent_id`
+- `build_id`
+- `parent_pack_id`
+- `contract_versions`
+- `pack_checksum`
+- `compiler_fingerprint`
+- `model_fingerprint`
+- `runtime_compat`
+- `route_policy`
+- `serve_requirements`
+- `workspace_snapshot_id`
+- `event_range`
+- `checksums`
+- `eval_summary`
+- `created_at`
+
+Where:
+
+- `runtime_compat` declares the minimum OpenClaw/OpenClawBrain compiler versions that may activate the pack.
+- `route_policy` declares the intended runtime route mode and the artifacts required to serve it.
+- `serve_requirements` declares non-negotiable activation checks such as `requires_learned_routing`, embedding dimension/model compatibility, and required local model assets.
+
+OpenClaw must reject manifests that fail checksum, schema, model-compatibility, or serve-requirement validation.
+
+## Runtime Path
+
+Target runtime path:
+
+1. OpenClaw receives a channel event and loads session state.
+2. OpenClaw resolves the active `pack_id` for the agent.
+3. OpenClaw issues a `runtime_compile.v1` request to the OpenClawBrain compiler engine.
+4. OpenClawBrain returns ranked context blocks and diagnostics.
+5. OpenClaw decides final prompt assembly and sends the model request.
+6. OpenClaw records memory-use diagnostics in its own trace.
+7. OpenClaw emits normalized interaction events for later learning.
+
+Runtime invariants:
+
+- no teacher LLM calls
+- no replay jobs
+- no direct parsing of on-disk session logs
+- deterministic response given the same request and pack
+- same resolved pack snapshot for the whole request
+- read-only compile path with no runtime-owned brain writes
+- strict timeout with fail-open behavior owned by OpenClaw
+- learned-required packs must compile with the learned `route_fn` on the production path
+- no silent heuristic fallback for learned-required packs
+- ability to pin a specific `pack_id` during investigation or rollback
+
+## Learner Path
+
+Target learner path:
+
+1. OpenClaw exports normalized interaction and feedback events.
+2. OpenClawBrain ingests events plus a declared workspace snapshot.
+3. OpenClawBrain derives learning records:
+   - corrections
+   - teachings
+   - suppressions
+   - route labels
+   - summaries and compactions
+4. OpenClawBrain compiles a candidate pack.
+5. OpenClawBrain evaluates the candidate against held-out traces and policy checks.
+6. OpenClawBrain publishes the candidate pack and manifest.
+7. OpenClaw validates the manifest and atomically promotes or rejects the pack.
+
+Learner invariants:
+
+- learner lag never blocks runtime
+- pack builds are immutable and reproducible from the same input set
+- pack contents are content-addressed or checksum-validated before promotion
+- promotion is atomic
+- rollback is a pointer change, not a rebuild
+- candidate promotion requires route-specific regression checks when the pack declares learned routing
+
+## Deployment Topology
+
+### Local Development
+
+- OpenClaw runtime on the developer machine
+- OpenClaw-owned active pack pointer on local disk
+- OpenClawBrain TypeScript compiler called in-process or via a short-lived local worker
+- OpenClawBrain learner orchestration runs as a TypeScript CLI or scheduled local task
+- optional Python research/ML jobs run offline and publish artifacts back into the pack pipeline
+
+### Single-Host Production
+
+- OpenClaw runtime service
+- local read-only promoted pack directory
+- OpenClaw-owned TypeScript runtime worker for compile requests
+- separate OpenClawBrain TypeScript learner service or cron job writing candidate packs to staging
+- optional Python offline jobs triggered by the learner plane only when justified by model-training needs
+
+### Multi-Host Production
+
+- OpenClaw runtime fleet serves from replicated promoted packs
+- pack artifacts stored in object storage or artifact registry
+- OpenClawBrain TypeScript learner workers consume normalized event streams
+- OpenClaw promotion controller flips agent pack pointers after validation
+- optional Python batch workers publish derived artifacts back to the learner pipeline, never directly to runtime
+
+Topology rule:
+
+- OpenClawBrain learner infrastructure may scale independently.
+- OpenClawBrain compile helpers may exist.
+- Neither becomes the owner of runtime sessions, channels, or diagnostics.
+
+## Failure Modes and Expected Behavior
+
+| Failure | Expected Behavior |
+| --- | --- |
+| No active pack for agent | OpenClaw serves without brain context and logs `pack_missing`. |
+| Compile timeout | OpenClaw fail-open, records timeout metric, keeps serving. |
+| Pack checksum or schema mismatch | OpenClaw rejects candidate pack and keeps current pack. |
+| Compiler crash | OpenClaw retries within bounded policy or fail-opens. |
+| Learner backlog | Runtime unaffected; freshness degrades only. |
+| Bad promoted pack | OpenClaw rolls back to previous pack pointer immediately. |
+| Model mismatch between pack and runtime | OpenClaw rejects pack activation before serving it. |
+| Learned-required pack missing usable route model/assets | OpenClaw rejects activation before serving it; no heuristic fallback. |
+| Event export outage | Runtime unaffected; learner catches up later from durable export. |
+| Workspace snapshot drift during build | Build marked invalid; no promotion. |
+
+## Observability
+
+OpenClaw runtime metrics:
+
+- compile request count
+- compile success/failure/timeout rate
+- compile latency p50/p95/p99
+- injected chars and blocks per turn
+- suppressions applied per turn
+- fail-open rate
+- requested route mode versus effective route mode
+- learned-route usage rate
+- learned-route enforcement failures
+- active pack distribution by agent
+
+OpenClawBrain learner metrics:
+
+- event ingestion lag
+- pack build duration
+- pack build failure rate
+- candidate vs promoted pack count
+- evaluation delta versus active pack
+- correction and teaching extraction yield
+- artifact size growth
+
+Shared correlation fields:
+
+- `request_id`
+- `session_id`
+- `turn_id`
+- `pack_id`
+- `build_id`
+
+Observability rule:
+
+- OpenClaw owns the runtime trace.
+- OpenClawBrain returns structured diagnostics only.
+- OpenClawBrain does not become a second source of truth for runtime health.
+
+## Language, Model, and Runtime Guidance
+
+Default production stack:
+
+- TypeScript/Node for contracts, validators, compiler core, pack loader, learner orchestration, eval harnesses, and promotion tooling
+- language-neutral artifact packs that OpenClaw can validate and serve without Python
+- optional Python only behind offline artifact-producing boundaries when TypeScript-native tooling is not a reasonable substitute
+
+Runtime guidance:
+
+- Prefer local embeddings and a small deterministic scorer/router.
+- Runtime compile must require zero remote completion-model calls.
+- Preload any runtime model in an OpenClaw-owned TypeScript worker, not an independently managed OpenClawBrain daemon.
+- CPU-first is preferred unless a GPU meaningfully reduces p95 latency without adding operational fragility.
+- Prefer model runtimes that integrate cleanly with TypeScript production services.
+
+Learner guidance:
+
+- Local-first defaults are preferred for embeddings, extraction, summarization, and route-model training.
+- TypeScript should own learner orchestration, data plumbing, and pack assembly even when a Python training job is used offline.
+- Remote teacher models are acceptable only in the learner plane.
+- Every pack manifest must record exact model fingerprints and dimensions.
+- Pack promotion must validate model compatibility before activation.
+
+Practical implication:
+
+- Node-native, WASM, ONNX, llama.cpp bindings, fastembed bindings, or similar tooling are good fits for OpenClawBrain production compiler and learner internals.
+- Python libraries remain valid for offline experimentation or training when they produce stable artifacts consumed by the TypeScript pipeline.
+- A runtime design that requires an always-on separate OCB daemon or Python service to hold model state is not the target architecture.
+
+## Migration Plan
+
+### Phase 0: Freeze the Target Boundary
+
+- Approve this document as the canonical architecture target.
+- Declare OpenClaw the only runtime owner.
+- Declare TypeScript-first production architecture as the default implementation stance.
+- Stop adding new features to the OCB daemon/socket/hook runtime path except for migration support.
+
+Exit criteria:
+
+- architecture approved
+- TypeScript-first production direction approved
+- no new runtime-owned features added to legacy OCB paths
+
+### Phase 1: Define and Land Contracts
+
+- Add versioned contracts for runtime compile, interaction events, feedback events, and artifact manifests as TypeScript-first schemas plus generated portable schemas.
+- Add OpenClaw-side normalized export of interaction and feedback events.
+- Add contract test fixtures in both repos.
+- Add golden fixtures that prove learned-routing fields are present and interpreted identically in both repos.
+- Make the TypeScript contract package the canonical source for validators, examples, and compatibility tests.
+
+Exit criteria:
+
+- both repos validate the same schemas
+- OpenClaw can emit normalized events without OCB parsing raw session stores
+- both repos agree on how `mode_effective` and `used_learned_route_fn` are encoded
+- TypeScript validators are used on the production path for request, response, and manifest validation
+
+### Phase 2: Extract a Real Compiler Core
+
+- Refactor OpenClawBrain runtime logic into a pure TypeScript compiler interface that accepts `runtime_compile.v1`.
+- Make the compiler deterministic and pack-driven.
+- Remove assumptions that the compiler owns session history, sockets, or chat-level fired logs.
+- Move production compile logic behind a TypeScript library boundary that OpenClaw can call in-process first and via a worker second.
+- Emit route decision metadata sufficient to prove whether learned routing actually drove the result.
+
+Exit criteria:
+
+- same pack + same request => same response
+- compiler can run in-process under OpenClaw ownership with no Python dependency
+- compiler tests fail if a learned-required pack can compile without `used_learned_route_fn=true`
+- pack loading, scoring, and response assembly are exercised by TypeScript integration tests
+
+### Phase 3: Build the Pack Pipeline
+
+- Replace mutable runtime `state.json` assumptions with versioned pack builds.
+- Add a TypeScript-first pack loader and build pipeline for manifest parsing, checksum verification, provenance lookup, and atomic staging layout.
+- Keep a translation layer only as long as needed to build first-generation packs from current state.
+- Add activation validation for `runtime_compat`, `route_policy`, and `serve_requirements`.
+- Normalize promoted-pack contents around formats the TypeScript runtime can load directly.
+
+Exit criteria:
+
+- candidate packs can be built and validated from normalized inputs
+- OpenClaw can load a promoted pack without legacy state mutation or Python runtime helpers
+- OpenClaw rejects learned-required packs that cannot be served in learned mode
+- promoted packs contain no Python-only serving artifacts
+
+### Phase 4: Cut Runtime Over to OpenClaw
+
+- Implement native OpenClaw integration for runtime compile requests using the TypeScript compiler core or worker.
+- Remove hook-first runtime injection as the primary path.
+- Make OpenClaw own timeout, budget, and logging around compile requests.
+- Dual-run the native path in shadow mode on real traffic before cutover and compare context/routing outputs against the incumbent path.
+
+Exit criteria:
+
+- production runtime no longer depends on OCB-managed hook install or socket service
+- production runtime no longer depends on Python services for normal compile serving
+- compile failures appear in OpenClaw diagnostics, not only OCB logs
+- pilot agents show `routing.mode_effective=learned` and `used_learned_route_fn=true` on real production traces for learned-required packs
+
+### Phase 5: Move Learning to the New Plane
+
+- Point learner ingestion to normalized OpenClaw event exports.
+- Rebuild correction/teaching/route-learning logic on top of event contracts with TypeScript owning orchestration and pack assembly.
+- Make pack promotion the only way learner outputs affect runtime.
+- Gate promotion on offline eval, route-specific regression tests, and shadow/canary acceptance where available.
+- Keep Python only for explicitly justified offline ML jobs that emit versioned outputs consumed by the TypeScript learner pipeline.
+
+Exit criteria:
+
+- learner can build and promote packs without reading raw OpenClaw session internals
+- runtime consumes only promoted packs
+- route-model changes reach production only through evaluated pack promotion
+- learner scheduling, promotion, and validation do not depend on Python by default
+
+### Phase 6: Delete Legacy Runtime Overlap
+
+- Delete OCB runtime daemon/socket lifecycle.
+- Delete hook-pack-centric runtime ownership.
+- Delete direct raw-session parsing as the primary architecture.
+- Archive or remove docs that describe the old shape as canonical.
+
+Exit criteria:
+
+- one runtime owner
+- one learner pipeline
+- one promoted-pack consumption path
+
+## Deletion and Cleanup Strategy
+
+Delete aggressively once the new path is proven. Likely deletions or hard deprecations:
+
+- [openclawbrain/daemon.py](/Users/cormorantai/openclawbrain/openclawbrain/daemon.py)
+- [openclawbrain/socket_server.py](/Users/cormorantai/openclawbrain/openclawbrain/socket_server.py)
+- [openclawbrain/socket_client.py](/Users/cormorantai/openclawbrain/openclawbrain/socket_client.py)
+- [integrations/openclaw/hooks/openclawbrain-context-injector/HOOK.md](/Users/cormorantai/openclawbrain/integrations/openclaw/hooks/openclawbrain-context-injector/HOOK.md) and the rest of that hook pack
+- runtime-facing adapter CLIs under [openclawbrain/openclaw_adapter](/Users/cormorantai/openclawbrain/openclawbrain/openclaw_adapter)
+- runtime install/status orchestration in [openclawbrain/cli.py](/Users/cormorantai/openclawbrain/openclawbrain/cli.py) for `serve`, `daemon`, `openclaw install`, and hook/loop lifecycle commands
+- legacy runtime-owned artifacts described in [docs/state-directory.md](/Users/cormorantai/openclawbrain/docs/state-directory.md): `daemon.sock`, `daemon.pid`, `fired_log.jsonl`
+
+Demote to migration-only and then delete:
+
+- [openclawbrain/replay.py](/Users/cormorantai/openclawbrain/openclawbrain/replay.py)
+- [openclawbrain/session_sources.py](/Users/cormorantai/openclawbrain/openclawbrain/session_sources.py)
+- raw OpenClaw/Codex session parsers used as steady-state ingestion
+
+Keep and reshape:
+
+- learning logic
+- feedback contract logic
+- route-model training
+- provenance and evaluation
+- workspace compilation logic
+
+Cleanup rule:
+
+- if a component exists mainly because OpenClawBrain currently compensates for missing OpenClaw-native runtime integration, delete it after cutover
+
+## Concrete Execution Plan
+
+### Phase A: Architecture and Contracts
+
+- ratify this plan
+- create TypeScript-first schemas and golden fixtures
+- add repo-level architecture tests that enforce owner boundaries
+
+### Phase B: Pack Compiler MVP
+
+- introduce pack build directory layout
+- add a TypeScript compiler API that reads only pack artifacts plus request payload
+- prove deterministic compile behavior
+
+### Phase C: OpenClaw Native Runtime Integration
+
+- wire OpenClaw runtime to the compiler API
+- ship behind a feature flag
+- shadow both paths on the same turns
+- compare diagnostics, latency, and route-decision actuation before any serving cutover
+
+### Phase D: Learner Rebase
+
+- switch learner ingestion to normalized OpenClaw exports
+- preserve current learning ideas, but rebuild the ingestion boundary around TypeScript orchestration
+- add evaluation gates before promotion
+- isolate any Python training or research step behind artifact handoff boundaries
+
+### Phase E: Cutover
+
+- promote a pilot agent to native runtime compile
+- remove hook/socket dependencies for that agent
+- verify rollback by pack pointer swap
+- verify from production traces that learned-required packs are served with `used_learned_route_fn=true`
+
+### Phase F: Deletion
+
+- delete old daemon/socket/hook paths
+- delete docs that present them as canonical
+- simplify the CLI around TypeScript-native compile, learn, build-pack, eval-pack, and migrate tools
+
+## Success Criteria
+
+The rearchitecture is complete when:
+
+- OpenClaw is the only runtime owner.
+- OpenClawBrain is the compiler and learner, not a second runtime.
+- TypeScript is the default production implementation language across runtime-serving and learner orchestration surfaces.
+- Runtime memory use flows through one versioned compile contract.
+- Learning flows through one normalized event contract.
+- Runtime serves exclusively from promoted packs.
+- Production serving does not require Python by default.
+- Learned `route_fn` from the promoted pack materially drives production compile behavior and is observable in runtime traces.
+- Rollback is atomic and operationally boring.
+- Legacy daemon, socket, hook-first, and raw-session-primary paths are gone.

--- a/openclawbrain/cli.py
+++ b/openclawbrain/cli.py
@@ -75,6 +75,7 @@ from .full_learning import (
 from ._util import _tokenize
 from .maintain import run_maintenance
 from .reward import RewardSource, RewardWeights
+from .feedback_events import from_dict as feedback_event_from_dict
 from .labels import (
     LabelRecord,
     append_labels_jsonl,
@@ -5354,9 +5355,10 @@ def cmd_harvest(args: argparse.Namespace) -> int:
         for idx, event in enumerate(events):
             if not isinstance(event, dict):
                 continue
-            event_type = str(event.get("type", "")).upper()
-            query_id = str(event.get("session_pointer", event.get("session", f"harvest:{idx}")))
-            node_id = event.get("node_id")
+            feedback_event = feedback_event_from_dict(event)
+            event_type = feedback_event.feedback_kind
+            query_id = str(feedback_event.session_pointer or feedback_event.session or f"harvest:{idx}")
+            node_id = feedback_event.node_id
             if isinstance(node_id, str) and node_id:
                 base_score = -1.0 if event_type == "CORRECTION" else 1.0
                 labels.append(
@@ -5365,9 +5367,14 @@ def cmd_harvest(args: argparse.Namespace) -> int:
                         decision_point_idx=0,
                         candidate_scores={node_id: base_score},
                         reward_source=RewardSource.HARVESTER,
-                        weight=1.0,
-                        ts=float(event.get("ts", 0.0) or 0.0),
-                        metadata={"event_type": event_type},
+                        weight=max(0.1, float(feedback_event.confidence)),
+                        ts=float(feedback_event.ts),
+                        metadata={
+                            "event_type": event_type,
+                            "source_kind": feedback_event.source_kind,
+                            "feedback_kind": feedback_event.feedback_kind,
+                            "session_pointer": feedback_event.session_pointer,
+                        },
                     )
                 )
                 continue
@@ -5375,23 +5382,34 @@ def cmd_harvest(args: argparse.Namespace) -> int:
                 {
                     "query_id": query_id,
                     "decision_point_idx": 0,
-                    "fired_ids": event.get("fired_ids"),
-                    "outcome": event.get("outcome", -1.0 if event_type == "CORRECTION" else 1.0),
-                    "ts": float(event.get("ts", 0.0) or 0.0),
-                    "metadata": {"event_type": event_type},
+                    "fired_ids": feedback_event.fired_ids,
+                    "outcome": feedback_event.outcome if feedback_event.outcome is not None else (-1.0 if event_type == "CORRECTION" else 1.0),
+                    "ts": float(feedback_event.ts),
+                    "metadata": {
+                        "event_type": event_type,
+                        "source_kind": feedback_event.source_kind,
+                        "feedback_kind": feedback_event.feedback_kind,
+                        "session_pointer": feedback_event.session_pointer,
+                    },
                 }
             )
             if fallback is not None:
                 labels.append(fallback)
                 continue
-            if event_type in {"TEACHING", "REINFORCEMENT"}:
+            if event_type in {"TEACHING", "REINFORCEMENT", "DIRECTIVE"}:
                 labels.append(
                     from_teacher_output(
                         query_id=query_id,
                         decision_point_idx=0,
                         teacher_scores={},
-                        ts=float(event.get("ts", 0.0) or 0.0),
-                        metadata={"event_type": event_type},
+                        ts=float(feedback_event.ts),
+                        weight=max(0.1, float(feedback_event.confidence)),
+                        metadata={
+                            "event_type": event_type,
+                            "source_kind": feedback_event.source_kind,
+                            "feedback_kind": feedback_event.feedback_kind,
+                            "session_pointer": feedback_event.session_pointer,
+                        },
                     )
                 )
         write_labels_jsonl(str(args.labels_out), labels)

--- a/openclawbrain/contracts/__init__.py
+++ b/openclawbrain/contracts/__init__.py
@@ -1,0 +1,37 @@
+"""Versioned contract helpers for the canonical OpenClaw/OpenClawBrain boundary."""
+
+from .v1 import (
+    CONTRACTS_ROOT,
+    FEEDBACK_EVENT_VERSION,
+    INTERACTION_EVENT_KINDS,
+    INTERACTION_EVENTS_VERSION,
+    ROUTE_MODES,
+    RUNTIME_COMPILE_VERSION,
+    ARTIFACT_MANIFEST_VERSION,
+    ContractValidationError,
+    feedback_event_v1_from_legacy,
+    load_contract_json,
+    validate_artifact_manifest,
+    validate_feedback_event,
+    validate_interaction_event,
+    validate_runtime_compile_request,
+    validate_runtime_compile_response,
+)
+
+__all__ = [
+    "ARTIFACT_MANIFEST_VERSION",
+    "CONTRACTS_ROOT",
+    "FEEDBACK_EVENT_VERSION",
+    "INTERACTION_EVENT_KINDS",
+    "INTERACTION_EVENTS_VERSION",
+    "ROUTE_MODES",
+    "RUNTIME_COMPILE_VERSION",
+    "ContractValidationError",
+    "feedback_event_v1_from_legacy",
+    "load_contract_json",
+    "validate_artifact_manifest",
+    "validate_feedback_event",
+    "validate_interaction_event",
+    "validate_runtime_compile_request",
+    "validate_runtime_compile_response",
+]

--- a/openclawbrain/contracts/v1.py
+++ b/openclawbrain/contracts/v1.py
@@ -1,0 +1,574 @@
+"""Phase 1 contract validators and fixture loaders for the canonical v1 boundary."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from openclawbrain.feedback_events import FeedbackEvent as LegacyFeedbackEvent
+
+RUNTIME_COMPILE_VERSION = "runtime_compile.v1"
+INTERACTION_EVENTS_VERSION = "interaction_events.v1"
+FEEDBACK_EVENT_VERSION = "feedback_events.v1"
+ARTIFACT_MANIFEST_VERSION = "artifact_manifest.v1"
+
+ROUTE_MODES = {"off", "edge", "edge+sim", "learned"}
+INTERACTION_EVENT_KINDS = {
+    "turn_started",
+    "memory_compiled",
+    "assistant_completed",
+    "tool_called",
+    "tool_result",
+    "feedback_recorded",
+    "session_closed",
+}
+FEEDBACK_KINDS = {"correction", "teaching", "preference", "approval", "operator_override"}
+FEEDBACK_SOURCE_KINDS = {"human", "system", "evaluation"}
+
+LEGACY_FEEDBACK_KIND_MAP = {
+    "CORRECTION": "correction",
+    "TEACHING": "teaching",
+    "DIRECTIVE": "operator_override",
+    "REINFORCEMENT": "approval",
+}
+LEGACY_SOURCE_KIND_MAP = {
+    "human": "human",
+    "self": "system",
+    "scanner": "system",
+    "teacher": "evaluation",
+    "harvester": "system",
+}
+
+CONTRACTS_ROOT = Path(__file__).resolve().parents[2] / "contracts"
+
+
+class ContractValidationError(ValueError):
+    """Raised when a payload fails canonical Phase 1 contract validation."""
+
+
+def load_contract_json(*relative_path: str) -> Any:
+    """Load one JSON contract artifact from the repo-root contracts tree."""
+    path = CONTRACTS_ROOT.joinpath(*relative_path)
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _expect_mapping(payload: object, label: str) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        raise ContractValidationError(f"{label} must be an object")
+    return dict(payload)
+
+
+def _require_string(payload: dict[str, Any], key: str, label: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ContractValidationError(f"{label}.{key} must be a non-empty string")
+    return value.strip()
+
+
+def _optional_string(payload: dict[str, Any], key: str, label: str) -> str | None:
+    value = payload.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ContractValidationError(f"{label}.{key} must be a string or null")
+    normalized = value.strip()
+    return normalized or None
+
+
+def _require_bool(payload: dict[str, Any], key: str, label: str) -> bool:
+    value = payload.get(key)
+    if not isinstance(value, bool):
+        raise ContractValidationError(f"{label}.{key} must be a boolean")
+    return value
+
+
+def _require_int(payload: dict[str, Any], key: str, label: str, *, minimum: int | None = None) -> int:
+    value = payload.get(key)
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ContractValidationError(f"{label}.{key} must be an integer")
+    if minimum is not None and value < minimum:
+        raise ContractValidationError(f"{label}.{key} must be >= {minimum}")
+    return value
+
+
+def _optional_int(payload: dict[str, Any], key: str, label: str, *, minimum: int | None = None) -> int | None:
+    value = payload.get(key)
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ContractValidationError(f"{label}.{key} must be an integer or null")
+    if minimum is not None and value < minimum:
+        raise ContractValidationError(f"{label}.{key} must be >= {minimum}")
+    return value
+
+
+def _require_number(payload: dict[str, Any], key: str, label: str, *, minimum: float | None = None) -> float:
+    value = payload.get(key)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ContractValidationError(f"{label}.{key} must be a number")
+    number = float(value)
+    if minimum is not None and number < minimum:
+        raise ContractValidationError(f"{label}.{key} must be >= {minimum}")
+    return number
+
+
+def _require_enum(payload: dict[str, Any], key: str, label: str, allowed: set[str]) -> str:
+    value = _require_string(payload, key, label)
+    if value not in allowed:
+        options = ", ".join(sorted(allowed))
+        raise ContractValidationError(f"{label}.{key} must be one of: {options}")
+    return value
+
+
+def _require_string_list(
+    payload: dict[str, Any],
+    key: str,
+    label: str,
+    *,
+    allow_empty: bool = True,
+) -> list[str]:
+    raw = payload.get(key)
+    if not isinstance(raw, list):
+        raise ContractValidationError(f"{label}.{key} must be an array")
+    items: list[str] = []
+    for index, item in enumerate(raw):
+        if not isinstance(item, str) or not item.strip():
+            raise ContractValidationError(f"{label}.{key}[{index}] must be a non-empty string")
+        items.append(item.strip())
+    if not allow_empty and not items:
+        raise ContractValidationError(f"{label}.{key} must not be empty")
+    return items
+
+
+def _require_mapping_list(payload: dict[str, Any], key: str, label: str) -> list[dict[str, Any]]:
+    raw = payload.get(key)
+    if not isinstance(raw, list):
+        raise ContractValidationError(f"{label}.{key} must be an array")
+    items: list[dict[str, Any]] = []
+    for index, item in enumerate(raw):
+        if not isinstance(item, dict):
+            raise ContractValidationError(f"{label}.{key}[{index}] must be an object")
+        items.append(dict(item))
+    return items
+
+
+def _validate_routing_request(payload: object, label: str) -> dict[str, Any]:
+    routing = _expect_mapping(payload, label)
+    return {
+        "mode_requested": _require_enum(routing, "mode_requested", label, ROUTE_MODES),
+    }
+
+
+def _validate_runtime_routing(payload: object, label: str) -> dict[str, Any]:
+    routing = _expect_mapping(payload, label)
+    normalized = {
+        "mode_requested": _require_enum(routing, "mode_requested", label, ROUTE_MODES),
+        "mode_effective": _require_enum(routing, "mode_effective", label, ROUTE_MODES),
+        "used_learned_route_fn": _require_bool(routing, "used_learned_route_fn", label),
+        "route_model_id": _optional_string(routing, "route_model_id", label),
+        "decision_trace_ref": _optional_string(routing, "decision_trace_ref", label),
+    }
+    if normalized["used_learned_route_fn"] and normalized["mode_effective"] != "learned":
+        raise ContractValidationError(
+            f"{label}.used_learned_route_fn cannot be true when {label}.mode_effective is not learned"
+        )
+    if normalized["mode_effective"] == "learned" and not normalized["decision_trace_ref"]:
+        raise ContractValidationError(f"{label}.decision_trace_ref must be explicit for learned runtime routing")
+    return normalized
+
+
+def _validate_context_source(payload: object, label: str) -> dict[str, Any]:
+    source = _expect_mapping(payload, label)
+    return {
+        "kind": _require_string(source, "kind", label),
+        "ref": _require_string(source, "ref", label),
+    }
+
+
+def _validate_context_block(payload: object, label: str) -> dict[str, Any]:
+    block = _expect_mapping(payload, label)
+    sources = [_validate_context_source(item, f"{label}.sources[{index}]") for index, item in enumerate(block.get("sources", []))]
+    if "sources" not in block or not sources:
+        raise ContractValidationError(f"{label}.sources must contain at least one source")
+    return {
+        "id": _require_string(block, "id", label),
+        "kind": _require_string(block, "kind", label),
+        "title": _require_string(block, "title", label),
+        "content": _require_string(block, "content", label),
+        "score": _require_number(block, "score", label),
+        "sources": sources,
+    }
+
+
+def validate_runtime_compile_request(payload: object) -> dict[str, Any]:
+    request = _expect_mapping(payload, "runtime_compile_request")
+    contract_version = _require_string(request, "contract_version", "runtime_compile_request")
+    if contract_version != RUNTIME_COMPILE_VERSION:
+        raise ContractValidationError("runtime_compile_request.contract_version must be runtime_compile.v1")
+    recent_turns: list[dict[str, Any]] = []
+    for index, turn in enumerate(_require_mapping_list(request, "recent_turns", "runtime_compile_request")):
+        recent_turns.append(
+            {
+                "role": _require_enum(
+                    turn,
+                    "role",
+                    f"runtime_compile_request.recent_turns[{index}]",
+                    {"user", "assistant", "system", "tool"},
+                ),
+                "content": _require_string(turn, "content", f"runtime_compile_request.recent_turns[{index}]"),
+                "turn_id": _optional_string(turn, "turn_id", f"runtime_compile_request.recent_turns[{index}]"),
+            }
+        )
+    tool_context: list[dict[str, Any]] = []
+    for index, item in enumerate(_require_mapping_list(request, "tool_context", "runtime_compile_request")):
+        tool_context.append(
+            {
+                "tool_name": _require_string(item, "tool_name", f"runtime_compile_request.tool_context[{index}]"),
+                "summary": _require_string(item, "summary", f"runtime_compile_request.tool_context[{index}]"),
+                "output_ref": _optional_string(item, "output_ref", f"runtime_compile_request.tool_context[{index}]"),
+            }
+        )
+    budget = _expect_mapping(request.get("budget"), "runtime_compile_request.budget")
+    hints = _expect_mapping(request.get("hints"), "runtime_compile_request.hints")
+    return {
+        "contract_version": contract_version,
+        "request_id": _require_string(request, "request_id", "runtime_compile_request"),
+        "agent_id": _require_string(request, "agent_id", "runtime_compile_request"),
+        "session_id": _require_string(request, "session_id", "runtime_compile_request"),
+        "turn_id": _require_string(request, "turn_id", "runtime_compile_request"),
+        "pack_id": _require_string(request, "pack_id", "runtime_compile_request"),
+        "user_message": _require_string(request, "user_message", "runtime_compile_request"),
+        "recent_turns": recent_turns,
+        "tool_context": tool_context,
+        "budget": {
+            "max_chars": _require_int(budget, "max_chars", "runtime_compile_request.budget", minimum=1),
+            "max_blocks": _require_int(budget, "max_blocks", "runtime_compile_request.budget", minimum=1),
+        },
+        "hints": {
+            "recall": _require_bool(hints, "recall", "runtime_compile_request.hints"),
+            "correction_sensitive": _require_bool(
+                hints,
+                "correction_sensitive",
+                "runtime_compile_request.hints",
+            ),
+        },
+        "routing": _validate_routing_request(request.get("routing"), "runtime_compile_request.routing"),
+    }
+
+
+def validate_runtime_compile_response(payload: object) -> dict[str, Any]:
+    response = _expect_mapping(payload, "runtime_compile_response")
+    contract_version = _require_string(response, "contract_version", "runtime_compile_response")
+    if contract_version != RUNTIME_COMPILE_VERSION:
+        raise ContractValidationError("runtime_compile_response.contract_version must be runtime_compile.v1")
+    blocks = [
+        _validate_context_block(item, f"runtime_compile_response.context_blocks[{index}]")
+        for index, item in enumerate(_require_mapping_list(response, "context_blocks", "runtime_compile_response"))
+    ]
+    diagnostics = _expect_mapping(response.get("diagnostics"), "runtime_compile_response.diagnostics")
+    normalized = {
+        "contract_version": contract_version,
+        "request_id": _require_string(response, "request_id", "runtime_compile_response"),
+        "pack_id": _require_string(response, "pack_id", "runtime_compile_response"),
+        "context_blocks": blocks,
+        "suppressed_sources": _require_string_list(
+            response,
+            "suppressed_sources",
+            "runtime_compile_response",
+            allow_empty=True,
+        ),
+        "routing": _validate_runtime_routing(response.get("routing"), "runtime_compile_response.routing"),
+        "diagnostics": {
+            "candidate_count": _require_int(diagnostics, "candidate_count", "runtime_compile_response.diagnostics", minimum=0),
+            "selected_count": _require_int(diagnostics, "selected_count", "runtime_compile_response.diagnostics", minimum=0),
+            "compile_ms": _require_number(diagnostics, "compile_ms", "runtime_compile_response.diagnostics", minimum=0.0),
+            "router": _optional_string(diagnostics, "router", "runtime_compile_response.diagnostics"),
+        },
+    }
+    return normalized
+
+
+def _validate_interaction_payload(event_kind: str, payload: object, label: str) -> dict[str, Any]:
+    data = _expect_mapping(payload, label)
+    if event_kind == "turn_started":
+        return {
+            "user_message_ref": _require_string(data, "user_message_ref", label),
+        }
+    if event_kind == "memory_compiled":
+        normalized = {
+            "selected_context_ids": _require_string_list(data, "selected_context_ids", label, allow_empty=True),
+            "suppressed_source_refs": _require_string_list(data, "suppressed_source_refs", label, allow_empty=True),
+            "routing": _validate_runtime_routing(data.get("routing"), f"{label}.routing"),
+            "compile_latency_ms": _require_number(data, "compile_latency_ms", label, minimum=0.0),
+            "candidate_count": _optional_int(data, "candidate_count", label, minimum=0),
+            "selected_count": _optional_int(data, "selected_count", label, minimum=0),
+        }
+        return normalized
+    if event_kind == "assistant_completed":
+        return {
+            "assistant_message_ref": _require_string(data, "assistant_message_ref", label),
+            "finish_reason": _require_string(data, "finish_reason", label),
+        }
+    if event_kind == "tool_called":
+        return {
+            "tool_name": _require_string(data, "tool_name", label),
+            "tool_call_id": _require_string(data, "tool_call_id", label),
+        }
+    if event_kind == "tool_result":
+        return {
+            "tool_name": _require_string(data, "tool_name", label),
+            "tool_call_id": _require_string(data, "tool_call_id", label),
+            "status": _require_string(data, "status", label),
+        }
+    if event_kind == "feedback_recorded":
+        return {
+            "feedback_event_id": _require_string(data, "feedback_event_id", label),
+            "feedback_kind": _require_enum(data, "feedback_kind", label, FEEDBACK_KINDS),
+        }
+    if event_kind == "session_closed":
+        return {
+            "close_reason": _require_string(data, "close_reason", label),
+        }
+    raise ContractValidationError(f"{label} has unsupported event_kind {event_kind}")
+
+
+def validate_interaction_event(payload: object) -> dict[str, Any]:
+    event = _expect_mapping(payload, "interaction_event")
+    contract_version = _require_string(event, "contract_version", "interaction_event")
+    if contract_version != INTERACTION_EVENTS_VERSION:
+        raise ContractValidationError("interaction_event.contract_version must be interaction_events.v1")
+    schema_version = _require_int(event, "schema_version", "interaction_event", minimum=1)
+    if schema_version != 1:
+        raise ContractValidationError("interaction_event.schema_version must be 1")
+    event_kind = _require_enum(event, "event_kind", "interaction_event", INTERACTION_EVENT_KINDS)
+    return {
+        "contract_version": contract_version,
+        "schema_version": schema_version,
+        "event_id": _require_string(event, "event_id", "interaction_event"),
+        "event_kind": event_kind,
+        "event_ts": _require_string(event, "event_ts", "interaction_event"),
+        "agent_id": _require_string(event, "agent_id", "interaction_event"),
+        "session_id": _require_string(event, "session_id", "interaction_event"),
+        "turn_id": _require_string(event, "turn_id", "interaction_event"),
+        "request_id": _require_string(event, "request_id", "interaction_event"),
+        "pack_id": _require_string(event, "pack_id", "interaction_event"),
+        "payload": _validate_interaction_payload(event_kind, event.get("payload"), "interaction_event.payload"),
+    }
+
+
+def validate_feedback_event(payload: object) -> dict[str, Any]:
+    event = _expect_mapping(payload, "feedback_event")
+    contract_version = _require_string(event, "contract_version", "feedback_event")
+    if contract_version != FEEDBACK_EVENT_VERSION:
+        raise ContractValidationError("feedback_event.contract_version must be feedback_events.v1")
+    return {
+        "contract_version": contract_version,
+        "event_id": _require_string(event, "event_id", "feedback_event"),
+        "event_ts": _require_string(event, "event_ts", "feedback_event"),
+        "agent_id": _require_string(event, "agent_id", "feedback_event"),
+        "session_id": _require_string(event, "session_id", "feedback_event"),
+        "turn_id": _require_string(event, "turn_id", "feedback_event"),
+        "request_id": _require_string(event, "request_id", "feedback_event"),
+        "pack_id": _require_string(event, "pack_id", "feedback_event"),
+        "feedback_kind": _require_enum(event, "feedback_kind", "feedback_event", FEEDBACK_KINDS),
+        "source_kind": _require_enum(event, "source_kind", "feedback_event", FEEDBACK_SOURCE_KINDS),
+        "message_ref": _require_string(event, "message_ref", "feedback_event"),
+        "affected_turn_id": _require_string(event, "affected_turn_id", "feedback_event"),
+        "affected_context_ids": _require_string_list(event, "affected_context_ids", "feedback_event", allow_empty=True),
+        "dedup_key": _require_string(event, "dedup_key", "feedback_event"),
+        "content": _optional_string(event, "content", "feedback_event"),
+        "metadata": dict(event.get("metadata", {})) if isinstance(event.get("metadata"), dict) else {},
+    }
+
+
+def validate_artifact_manifest(payload: object) -> dict[str, Any]:
+    manifest = _expect_mapping(payload, "artifact_manifest")
+    contract_version = _require_string(manifest, "contract_version", "artifact_manifest")
+    if contract_version != ARTIFACT_MANIFEST_VERSION:
+        raise ContractValidationError("artifact_manifest.contract_version must be artifact_manifest.v1")
+    contract_versions = _expect_mapping(manifest.get("contract_versions"), "artifact_manifest.contract_versions")
+    checksums = _expect_mapping(manifest.get("checksums"), "artifact_manifest.checksums")
+    if not checksums:
+        raise ContractValidationError("artifact_manifest.checksums must not be empty")
+    compiler_fingerprint = _expect_mapping(
+        manifest.get("compiler_fingerprint"),
+        "artifact_manifest.compiler_fingerprint",
+    )
+    model_fingerprint = _expect_mapping(
+        manifest.get("model_fingerprint"),
+        "artifact_manifest.model_fingerprint",
+    )
+    runtime_compat = _expect_mapping(manifest.get("runtime_compat"), "artifact_manifest.runtime_compat")
+    route_policy = _expect_mapping(manifest.get("route_policy"), "artifact_manifest.route_policy")
+    serve_requirements = _expect_mapping(
+        manifest.get("serve_requirements"),
+        "artifact_manifest.serve_requirements",
+    )
+    event_range = _expect_mapping(manifest.get("event_range"), "artifact_manifest.event_range")
+    eval_summary = _expect_mapping(manifest.get("eval_summary"), "artifact_manifest.eval_summary")
+    return {
+        "contract_version": contract_version,
+        "pack_id": _require_string(manifest, "pack_id", "artifact_manifest"),
+        "agent_id": _require_string(manifest, "agent_id", "artifact_manifest"),
+        "build_id": _require_string(manifest, "build_id", "artifact_manifest"),
+        "parent_pack_id": _optional_string(manifest, "parent_pack_id", "artifact_manifest"),
+        "contract_versions": {
+            "runtime_compile": _require_string(contract_versions, "runtime_compile", "artifact_manifest.contract_versions"),
+            "interaction_events": _require_string(
+                contract_versions,
+                "interaction_events",
+                "artifact_manifest.contract_versions",
+            ),
+            "feedback_events": _require_string(
+                contract_versions,
+                "feedback_events",
+                "artifact_manifest.contract_versions",
+            ),
+            "artifact_manifest": _require_string(
+                contract_versions,
+                "artifact_manifest",
+                "artifact_manifest.contract_versions",
+            ),
+        },
+        "pack_checksum": _require_string(manifest, "pack_checksum", "artifact_manifest"),
+        "compiler_fingerprint": {
+            "compiler": _require_string(compiler_fingerprint, "compiler", "artifact_manifest.compiler_fingerprint"),
+            "version": _require_string(compiler_fingerprint, "version", "artifact_manifest.compiler_fingerprint"),
+            "build_hash": _require_string(compiler_fingerprint, "build_hash", "artifact_manifest.compiler_fingerprint"),
+        },
+        "model_fingerprint": {
+            "embedding_model": _require_string(model_fingerprint, "embedding_model", "artifact_manifest.model_fingerprint"),
+            "embedding_dimension": _require_int(
+                model_fingerprint,
+                "embedding_dimension",
+                "artifact_manifest.model_fingerprint",
+                minimum=1,
+            ),
+            "route_model_id": _optional_string(
+                model_fingerprint,
+                "route_model_id",
+                "artifact_manifest.model_fingerprint",
+            ),
+        },
+        "runtime_compat": {
+            "openclaw_min": _require_string(runtime_compat, "openclaw_min", "artifact_manifest.runtime_compat"),
+            "openclawbrain_min": _require_string(
+                runtime_compat,
+                "openclawbrain_min",
+                "artifact_manifest.runtime_compat",
+            ),
+        },
+        "route_policy": {
+            "mode_requested": _require_enum(route_policy, "mode_requested", "artifact_manifest.route_policy", ROUTE_MODES),
+            "route_model_id": _optional_string(route_policy, "route_model_id", "artifact_manifest.route_policy"),
+            "decision_trace_refs_emitted": _require_bool(
+                route_policy,
+                "decision_trace_refs_emitted",
+                "artifact_manifest.route_policy",
+            ),
+        },
+        "serve_requirements": {
+            "requires_learned_routing": _require_bool(
+                serve_requirements,
+                "requires_learned_routing",
+                "artifact_manifest.serve_requirements",
+            ),
+            "required_route_assets": _require_string_list(
+                serve_requirements,
+                "required_route_assets",
+                "artifact_manifest.serve_requirements",
+                allow_empty=True,
+            ),
+            "embedding_model": _require_string(
+                serve_requirements,
+                "embedding_model",
+                "artifact_manifest.serve_requirements",
+            ),
+            "embedding_dimension": _require_int(
+                serve_requirements,
+                "embedding_dimension",
+                "artifact_manifest.serve_requirements",
+                minimum=1,
+            ),
+        },
+        "workspace_snapshot_id": _require_string(manifest, "workspace_snapshot_id", "artifact_manifest"),
+        "event_range": {
+            "interaction_event_start_id": _require_string(
+                event_range,
+                "interaction_event_start_id",
+                "artifact_manifest.event_range",
+            ),
+            "interaction_event_end_id": _require_string(
+                event_range,
+                "interaction_event_end_id",
+                "artifact_manifest.event_range",
+            ),
+            "feedback_event_start_id": _require_string(
+                event_range,
+                "feedback_event_start_id",
+                "artifact_manifest.event_range",
+            ),
+            "feedback_event_end_id": _require_string(
+                event_range,
+                "feedback_event_end_id",
+                "artifact_manifest.event_range",
+            ),
+        },
+        "checksums": {str(key): _require_string(checksums, str(key), "artifact_manifest.checksums") for key in checksums},
+        "eval_summary": {
+            "baseline_pack_id": _require_string(eval_summary, "baseline_pack_id", "artifact_manifest.eval_summary"),
+            "score_delta": _require_number(eval_summary, "score_delta", "artifact_manifest.eval_summary"),
+            "regressions": _require_int(eval_summary, "regressions", "artifact_manifest.eval_summary", minimum=0),
+            "status": _require_string(eval_summary, "status", "artifact_manifest.eval_summary"),
+        },
+        "created_at": _require_string(manifest, "created_at", "artifact_manifest"),
+    }
+
+
+def feedback_event_v1_from_legacy(
+    event: LegacyFeedbackEvent,
+    *,
+    event_id: str,
+    agent_id: str,
+    session_id: str,
+    turn_id: str,
+    request_id: str,
+    pack_id: str,
+    message_ref: str | None = None,
+    affected_turn_id: str | None = None,
+    affected_context_ids: list[str] | None = None,
+) -> dict[str, Any]:
+    """Bridge the existing feedback event model into feedback_events.v1 without cutover."""
+    payload = event.to_dict()
+    feedback_kind = LEGACY_FEEDBACK_KIND_MAP.get(str(payload.get("feedback_kind")), "teaching")
+    source_kind = LEGACY_SOURCE_KIND_MAP.get(str(payload.get("source_kind")), "system")
+    dedup_key = str(
+        payload.get("dedup_key")
+        or payload.get("message_id")
+        or payload.get("event_hash")
+        or event_id
+    )
+    normalized = {
+        "contract_version": FEEDBACK_EVENT_VERSION,
+        "event_id": event_id,
+        "event_ts": str(payload.get("ts")),
+        "agent_id": agent_id,
+        "session_id": session_id,
+        "turn_id": turn_id,
+        "request_id": request_id,
+        "pack_id": pack_id,
+        "feedback_kind": feedback_kind,
+        "source_kind": source_kind,
+        "message_ref": message_ref or str(payload.get("message_id") or event_id),
+        "affected_turn_id": affected_turn_id or turn_id,
+        "affected_context_ids": affected_context_ids if affected_context_ids is not None else list(payload.get("fired_ids", [])),
+        "dedup_key": dedup_key,
+        "content": str(payload.get("content", "")).strip() or None,
+        "metadata": {
+            "legacy_feedback_kind": str(payload.get("feedback_kind", "")),
+            "legacy_source_kind": str(payload.get("source_kind", "")),
+            "legacy_event_hash": str(payload.get("event_hash", "")),
+        },
+    }
+    return validate_feedback_event(normalized)

--- a/openclawbrain/daemon.py
+++ b/openclawbrain/daemon.py
@@ -20,6 +20,7 @@ from .graph import Graph, Node
 from .hasher import HashEmbedder
 from .index import VectorIndex
 from .learn import apply_outcome, apply_outcome_pg
+from .feedback_events import FeedbackEvent
 from .local_embedder import DEFAULT_LOCAL_MODEL, LocalEmbedder, resolve_local_model
 from .maintain import run_maintenance
 from .inject import _apply_inhibitory_edges, inject_correction, inject_node
@@ -897,6 +898,19 @@ def _handle_capture_feedback(
         edges_updated = _real_graph_updates(updates)
         if edges_updated:
             should_write = True
+        canonical_feedback_event = FeedbackEvent(
+            source_kind="human",
+            feedback_kind=kind,
+            content=content,
+            chat_id=chat_id,
+            message_id=str(message_id).strip() if isinstance(message_id, str) and message_id.strip() else None,
+            dedup_key=dedup_key_used,
+            fired_ids=fired_ids,
+            outcome=outcome_used,
+            confidence=1.0,
+            metadata={"source": "capture_feedback"},
+        ).to_dict()
+        _append_jsonl_event(resolved_event_store, canonical_feedback_event)
         _append_learn_event(
             resolved_event_store,
             fired_ids=fired_ids,

--- a/openclawbrain/daemon.py
+++ b/openclawbrain/daemon.py
@@ -213,6 +213,10 @@ def _route_decision_summary(decisions: list[DecisionMetrics]) -> dict[str, objec
     }
 
 
+def _append_jsonl_event(event_store: EventStore, payload: dict[str, object]) -> None:
+    event_store.append(dict(payload))
+
+
 def _append_learn_event(
     event_store: EventStore,
     *,
@@ -594,6 +598,7 @@ def _do_learn(
     node_type: str = "CORRECTION",
     source: str = "daemon",
     log_metadata: dict[str, object] | None = None,
+    canonical_feedback_event: dict[str, object] | None = None,
 ) -> tuple[dict[str, object], bool]:
     """Unified learning: penalize/reinforce fired path + optionally inject node.
 
@@ -601,6 +606,9 @@ def _do_learn(
     """
     should_write = False
     edges_updated = 0
+
+    if canonical_feedback_event is not None:
+        _append_jsonl_event(event_store, canonical_feedback_event)
 
     # 1. Apply outcome to fired path
     if fired_ids and outcome != 0:
@@ -656,6 +664,9 @@ def _do_learn(
     }
     if node_id is not None:
         payload["node_id"] = node_id
+    if canonical_feedback_event is not None:
+        payload["feedback_event_logged"] = True
+        payload["feedback_event_hash"] = canonical_feedback_event.get("event_hash")
 
     return payload, should_write
 
@@ -778,6 +789,17 @@ def _handle_self_learn(
             raise ValueError("state_path is required when event_store is not provided")
         resolved_event_store = JsonlEventStore(_journal_path(state_path))
 
+    feedback_kind = "REINFORCEMENT" if outcome > 0 else node_type
+    canonical_feedback_event = FeedbackEvent(
+        source_kind="self",
+        feedback_kind=feedback_kind,
+        content=raw_content.strip(),
+        fired_ids=fired_ids,
+        outcome=outcome,
+        confidence=1.0,
+        metadata={"source": "self_learn", "node_type": node_type},
+    ).to_dict()
+
     return _do_learn(
         graph, index, embed_fn, resolved_event_store,
         fired_ids=fired_ids,
@@ -786,6 +808,7 @@ def _handle_self_learn(
         node_type=node_type,
         source="self",
         log_metadata={"source": "self"},
+        canonical_feedback_event=canonical_feedback_event,
     )
 
 

--- a/openclawbrain/feedback_events.py
+++ b/openclawbrain/feedback_events.py
@@ -1,0 +1,139 @@
+"""Canonical feedback event contract shared across scanner, realtime capture, self-learn, and harvest."""
+
+from __future__ import annotations
+
+import hashlib
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+SOURCE_KINDS = {"human", "self", "scanner", "teacher", "harvester"}
+FEEDBACK_KINDS = {"CORRECTION", "TEACHING", "DIRECTIVE", "REINFORCEMENT"}
+SEVERITIES = {"low", "medium", "high"}
+
+
+@dataclass(frozen=True)
+class FeedbackEvent:
+    source_kind: str
+    feedback_kind: str
+    content: str
+    confidence: float = 1.0
+    ts: float = field(default_factory=time.time)
+    chat_id: str | None = None
+    message_id: str | None = None
+    dedup_key: str | None = None
+    fired_ids: list[str] = field(default_factory=list)
+    outcome: float | None = None
+    session_pointer: str | None = None
+    session: str | None = None
+    context: str | None = None
+    severity: str | None = None
+    node_id: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "source_kind": self.source_kind,
+            "feedback_kind": self.feedback_kind,
+            "type": self.feedback_kind,
+            "content": self.content,
+            "confidence": float(self.confidence),
+            "ts": float(self.ts),
+            "metadata": dict(self.metadata),
+        }
+        if self.chat_id:
+            payload["chat_id"] = self.chat_id
+        if self.message_id:
+            payload["message_id"] = self.message_id
+        if self.dedup_key:
+            payload["dedup_key"] = self.dedup_key
+        if self.fired_ids:
+            payload["fired_ids"] = list(self.fired_ids)
+        if self.outcome is not None:
+            payload["outcome"] = float(self.outcome)
+        if self.session_pointer:
+            payload["session_pointer"] = self.session_pointer
+        if self.session:
+            payload["session"] = self.session
+        if self.context:
+            payload["context"] = self.context
+        if self.severity:
+            payload["severity"] = self.severity
+        if self.node_id:
+            payload["node_id"] = self.node_id
+        content_hash = hashlib.sha256(self.content.encode("utf-8")).hexdigest()
+        payload["content_hash"] = content_hash
+        payload["event_hash"] = event_hash(payload)
+        return payload
+
+
+def normalize_feedback_kind(value: object, *, default: str = "TEACHING") -> str:
+    raw = str(value or default).strip().upper()
+    return raw if raw in FEEDBACK_KINDS else default
+
+
+def normalize_source_kind(value: object, *, default: str = "scanner") -> str:
+    raw = str(value or default).strip().lower()
+    return raw if raw in SOURCE_KINDS else default
+
+
+def normalize_severity(value: object) -> str | None:
+    if value is None:
+        return None
+    raw = str(value).strip().lower()
+    return raw if raw in SEVERITIES else None
+
+
+def confidence_from_severity(severity: str | None) -> float:
+    return {"low": 0.4, "medium": 0.7, "high": 0.95}.get(severity or "", 1.0)
+
+
+def event_hash(payload: dict[str, Any]) -> str:
+    feedback_kind = normalize_feedback_kind(payload.get("feedback_kind") or payload.get("type"))
+    content_hash = str(payload.get("content_hash") or hashlib.sha256(str(payload.get("content", "")).encode("utf-8")).hexdigest())
+    pointer = str(payload.get("session_pointer") or "")
+    dedup_key = str(payload.get("dedup_key") or payload.get("message_id") or "")
+    if dedup_key:
+        source_kind = normalize_source_kind(payload.get("source_kind"))
+        return "|".join((source_kind, feedback_kind, content_hash, pointer, dedup_key))
+    return "|".join((feedback_kind, content_hash, pointer))
+
+
+def from_dict(payload: dict[str, Any]) -> FeedbackEvent:
+    severity = normalize_severity(payload.get("severity"))
+    confidence = payload.get("confidence")
+    try:
+        confidence_value = float(confidence) if confidence is not None else confidence_from_severity(severity)
+    except (TypeError, ValueError):
+        confidence_value = confidence_from_severity(severity)
+    fired_ids = payload.get("fired_ids") or payload.get("fired") or []
+    if not isinstance(fired_ids, list):
+        fired_ids = []
+    outcome = payload.get("outcome")
+    try:
+        outcome_value = float(outcome) if outcome is not None else None
+    except (TypeError, ValueError):
+        outcome_value = None
+    ts = payload.get("ts")
+    try:
+        ts_value = float(ts) if ts is not None else time.time()
+    except (TypeError, ValueError):
+        ts_value = time.time()
+    return FeedbackEvent(
+        source_kind=normalize_source_kind(payload.get("source_kind") or payload.get("source") or ("self" if payload.get("source") == "self" else "scanner")),
+        feedback_kind=normalize_feedback_kind(payload.get("feedback_kind") or payload.get("type")),
+        content=str(payload.get("content", "")).strip(),
+        confidence=confidence_value,
+        ts=ts_value,
+        chat_id=str(payload.get("chat_id")) if payload.get("chat_id") is not None else None,
+        message_id=str(payload.get("message_id")) if payload.get("message_id") is not None else None,
+        dedup_key=str(payload.get("dedup_key")) if payload.get("dedup_key") is not None else None,
+        fired_ids=[str(v) for v in fired_ids if isinstance(v, str) and v],
+        outcome=outcome_value,
+        session_pointer=str(payload.get("session_pointer")) if payload.get("session_pointer") is not None else None,
+        session=str(payload.get("session")) if payload.get("session") is not None else None,
+        context=str(payload.get("context")) if payload.get("context") is not None else None,
+        severity=severity,
+        node_id=str(payload.get("node_id")) if payload.get("node_id") is not None else None,
+        metadata=dict(payload.get("metadata", {})) if isinstance(payload.get("metadata"), dict) else {},
+    )

--- a/openclawbrain/full_learning.py
+++ b/openclawbrain/full_learning.py
@@ -18,6 +18,7 @@ from typing import Any
 
 from ._util import _extract_json
 from .inject import inject_batch
+from .feedback_events import FeedbackEvent, confidence_from_severity, event_hash
 from .provenance import attach_tool_evidence_provenance
 from .maintain import run_maintenance
 from .session_sources import collect_session_files as _collect_session_source_files
@@ -476,30 +477,24 @@ def _window_to_payload(
             context = item.get("context")
             if not isinstance(context, str):
                 context = ""
-            digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()
-            events.append(
-                {
-                    "type": event_type,
-                    "content": normalized,
-                    "content_hash": digest,
-                    "severity": severity,
-                    "context": context[:600],
-                    "session": session,
-                    "session_pointer": pointer,
-                }
+            event = FeedbackEvent(
+                source_kind="scanner",
+                feedback_kind=event_type,
+                content=normalized,
+                confidence=confidence_from_severity(severity),
+                session=session,
+                session_pointer=pointer,
+                context=context[:600],
+                severity=severity,
+                metadata={"source": "full_learning"},
             )
+            events.append(event.to_dict())
     return events
 
 
 def _event_key(event: dict) -> str:
-    """Stable dedup key: (type, sha256(content), session pointer)."""
-    return "|".join(
-        (
-            str(event.get("type")),
-            str(event.get("content_hash")),
-            str(event.get("session_pointer")),
-        )
-    )
+    """Stable dedup key for canonical feedback events."""
+    return event_hash(event)
 
 
 def event_log_entries(path: Path | str) -> list[dict]:

--- a/tests/test_contracts_v1.py
+++ b/tests/test_contracts_v1.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import pytest
+
+from openclawbrain.contracts.v1 import (
+    ARTIFACT_MANIFEST_VERSION,
+    FEEDBACK_EVENT_VERSION,
+    INTERACTION_EVENT_KINDS,
+    INTERACTION_EVENTS_VERSION,
+    RUNTIME_COMPILE_VERSION,
+    ContractValidationError,
+    feedback_event_v1_from_legacy,
+    load_contract_json,
+    validate_artifact_manifest,
+    validate_feedback_event,
+    validate_interaction_event,
+    validate_runtime_compile_request,
+    validate_runtime_compile_response,
+)
+from openclawbrain.feedback_events import FeedbackEvent
+
+
+def test_contract_schema_files_have_stable_ids() -> None:
+    schema_expectations = [
+        ("runtime_compile", "v1", "request.schema.json", "https://openclawbrain.dev/contracts/runtime_compile/v1/request.schema.json"),
+        ("runtime_compile", "v1", "response.schema.json", "https://openclawbrain.dev/contracts/runtime_compile/v1/response.schema.json"),
+        ("interaction_events", "v1", "event.schema.json", "https://openclawbrain.dev/contracts/interaction_events/v1/event.schema.json"),
+        ("feedback_events", "v1", "event.schema.json", "https://openclawbrain.dev/contracts/feedback_events/v1/event.schema.json"),
+        ("artifact_manifest", "v1", "manifest.schema.json", "https://openclawbrain.dev/contracts/artifact_manifest/v1/manifest.schema.json"),
+    ]
+    for contract_name, version, filename, expected_id in schema_expectations:
+        payload = load_contract_json(contract_name, version, filename)
+        assert payload["$id"] == expected_id
+
+
+def test_runtime_compile_golden_fixtures_validate() -> None:
+    request = load_contract_json("runtime_compile", "v1", "golden-request.json")
+    response = load_contract_json("runtime_compile", "v1", "golden-response.json")
+
+    normalized_request = validate_runtime_compile_request(request)
+    normalized_response = validate_runtime_compile_response(response)
+
+    assert normalized_request["contract_version"] == RUNTIME_COMPILE_VERSION
+    assert normalized_request["routing"]["mode_requested"] == "learned"
+    assert normalized_response["contract_version"] == RUNTIME_COMPILE_VERSION
+    assert normalized_response["routing"]["mode_effective"] == "learned"
+    assert normalized_response["routing"]["used_learned_route_fn"] is True
+    assert normalized_response["routing"]["decision_trace_ref"] == "route_decision_req_123"
+
+
+def test_runtime_compile_response_rejects_incoherent_learned_routing_flags() -> None:
+    response = load_contract_json("runtime_compile", "v1", "golden-response.json")
+    response["routing"]["mode_effective"] = "edge+sim"
+
+    with pytest.raises(ContractValidationError, match="used_learned_route_fn"):
+        validate_runtime_compile_response(response)
+
+
+def test_interaction_event_golden_stream_validates_required_event_kinds() -> None:
+    stream = load_contract_json("interaction_events", "v1", "golden-stream.json")
+
+    seen_event_kinds: set[str] = set()
+    memory_event = None
+    for raw_event in stream:
+        event = validate_interaction_event(raw_event)
+        assert event["contract_version"] == INTERACTION_EVENTS_VERSION
+        seen_event_kinds.add(event["event_kind"])
+        if event["event_kind"] == "memory_compiled":
+            memory_event = event
+
+    assert INTERACTION_EVENT_KINDS.issubset(seen_event_kinds)
+    assert memory_event is not None
+    assert memory_event["payload"]["routing"]["mode_requested"] == "learned"
+    assert memory_event["payload"]["routing"]["mode_effective"] == "learned"
+    assert memory_event["payload"]["routing"]["used_learned_route_fn"] is True
+    assert memory_event["payload"]["routing"]["decision_trace_ref"] == "route_decision_req_123"
+
+
+def test_feedback_event_golden_fixture_validates() -> None:
+    event = load_contract_json("feedback_events", "v1", "golden-event.json")
+
+    normalized = validate_feedback_event(event)
+
+    assert normalized["contract_version"] == FEEDBACK_EVENT_VERSION
+    assert normalized["feedback_kind"] == "correction"
+    assert normalized["source_kind"] == "human"
+    assert normalized["affected_context_ids"] == ["ctx_1"]
+
+
+def test_legacy_feedback_event_can_bridge_to_feedback_events_v1() -> None:
+    legacy_event = FeedbackEvent(
+        source_kind="human",
+        feedback_kind="CORRECTION",
+        content="Rollback before restarting workers.",
+        ts=1709851200.0,
+        message_id="msg_123",
+        dedup_key="feedback-msg-123",
+        fired_ids=["ctx_1"],
+    )
+
+    normalized = feedback_event_v1_from_legacy(
+        legacy_event,
+        event_id="feedback_evt_legacy_1",
+        agent_id="main",
+        session_id="sess_456",
+        turn_id="turn_789",
+        request_id="req_123",
+        pack_id="brainpack_2026_03_06_001",
+        message_ref="message:msg_123",
+        affected_turn_id="turn_789",
+        affected_context_ids=["ctx_1"],
+    )
+
+    assert normalized["feedback_kind"] == "correction"
+    assert normalized["source_kind"] == "human"
+    assert normalized["dedup_key"] == "feedback-msg-123"
+    assert normalized["affected_context_ids"] == ["ctx_1"]
+    assert normalized["metadata"]["legacy_feedback_kind"] == "CORRECTION"
+
+
+def test_artifact_manifest_golden_fixture_validates() -> None:
+    manifest = load_contract_json("artifact_manifest", "v1", "golden-manifest.json")
+
+    normalized = validate_artifact_manifest(manifest)
+
+    assert normalized["contract_version"] == ARTIFACT_MANIFEST_VERSION
+    assert normalized["route_policy"]["mode_requested"] == "learned"
+    assert normalized["serve_requirements"]["requires_learned_routing"] is True
+    assert normalized["contract_versions"]["runtime_compile"] == RUNTIME_COMPILE_VERSION
+    assert normalized["contract_versions"]["interaction_events"] == INTERACTION_EVENTS_VERSION
+    assert normalized["contract_versions"]["feedback_events"] == FEEDBACK_EVENT_VERSION

--- a/tests/test_feedback_events_contract.py
+++ b/tests/test_feedback_events_contract.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from openclawbrain.daemon import _DaemonState, _handle_capture_feedback, _handle_self_learn
+from openclawbrain.feedback_events import FeedbackEvent, from_dict
+from openclawbrain.full_learning import _window_to_payload
+from openclawbrain.graph import Edge, Graph, Node
+from openclawbrain.index import VectorIndex
+from openclawbrain.labels import from_self_learning_event
+from openclawbrain.hasher import HashEmbedder
+
+
+def _simple_graph() -> tuple[Graph, VectorIndex]:
+    g = Graph()
+    g.add_node(Node("a", "alpha content about deployment"))
+    g.add_node(Node("b", "beta content about cleanup"))
+    g.add_edge(Edge("a", "b", weight=0.5))
+    idx = VectorIndex()
+    embed = HashEmbedder().embed
+    idx.upsert("a", embed("alpha content about deployment"))
+    idx.upsert("b", embed("beta content about cleanup"))
+    return g, idx
+
+
+def _daemon_state(graph: Graph, index: VectorIndex) -> _DaemonState:
+    return _DaemonState(graph=graph, index=index, meta={}, fired_log={}, feedback_dedup_keys=set())
+
+
+def test_scanner_event_round_trips_to_canonical_contract() -> None:
+    class Turn:
+        def __init__(self, role: str, content: str, line_no: int, source: str) -> None:
+            self.role = role
+            self.content = content
+            self.line_no = line_no
+            self.source = source
+
+    turns = [
+        Turn("user", "that is wrong", 1, "session.jsonl"),
+        Turn("assistant", "acknowledged", 2, "session.jsonl"),
+    ]
+
+    def fake_llm(_: str, __: str) -> str:
+        return '{"corrections":[{"content":"Use X instead","context":"ctx","severity":"high"}],"teachings":[],"reinforcements":[]}'
+
+    events = _window_to_payload(session="session.jsonl", window=turns, window_idx=1, total_windows=1, llm_fn=fake_llm)
+    assert events
+    event = from_dict(events[0])
+    assert event.source_kind == "scanner"
+    assert event.feedback_kind == "CORRECTION"
+    assert event.session_pointer
+    assert event.metadata
+
+
+def test_capture_feedback_writes_canonical_feedback_event_to_journal(tmp_path: Path) -> None:
+    g, idx = _simple_graph()
+    state_path = tmp_path / "state.json"
+    state_path.write_text('{"graph":{"nodes":[],"edges":[]},"index":{},"meta":{}}', encoding="utf-8")
+    ds = _daemon_state(g, idx)
+    ds.fired_log["chat:test"] = [{"chat_id": "chat:test", "query": "q", "fired_nodes": ["a", "b"], "ts": 1.0, "timestamp": 1.0}]
+
+    payload, should_write = _handle_capture_feedback(
+        daemon_state=ds,
+        graph=g,
+        index=idx,
+        meta={},
+        embed_fn=HashEmbedder().embed,
+        state_path=str(state_path),
+        params={
+            "chat_id": "chat:test",
+            "kind": "CORRECTION",
+            "content": "Use deployment B instead",
+            "lookback": 1,
+            "message_id": "m1",
+        },
+    )
+
+    assert should_write is True
+    assert payload["outcome_used"] == -1.0
+
+    journal = ((tmp_path / "journal.jsonl").read_text(encoding="utf-8").splitlines())
+    records = [json.loads(line) for line in journal]
+    feedback = next(r for r in records if r.get("source_kind") == "human")
+    parsed = from_dict(feedback)
+    assert parsed.feedback_kind == "CORRECTION"
+    assert parsed.chat_id == "chat:test"
+    assert parsed.message_id == "m1"
+    assert parsed.fired_ids == ["a", "b"]
+    assert parsed.outcome == -1.0
+
+
+def test_self_learn_writes_canonical_feedback_event_and_harvest_reads_it(tmp_path: Path) -> None:
+    g, idx = _simple_graph()
+    state_path = tmp_path / "state.json"
+    state_path.write_text('{"graph":{"nodes":[],"edges":[]},"index":{},"meta":{}}', encoding="utf-8")
+    ds = _daemon_state(g, idx)
+
+    payload, should_write = _handle_self_learn(
+        daemon_state=ds,
+        graph=g,
+        index=idx,
+        embed_fn=HashEmbedder().embed,
+        state_path=str(state_path),
+        params={
+            "content": "This route worked reliably",
+            "fired_ids": ["a", "b"],
+            "outcome": 1.0,
+            "node_type": "TEACHING",
+        },
+    )
+
+    assert should_write is True
+    assert payload["feedback_event_logged"] is True
+    journal = ((tmp_path / "journal.jsonl").read_text(encoding="utf-8").splitlines())
+    records = [json.loads(line) for line in journal]
+    feedback = next(r for r in records if r.get("source_kind") == "self")
+    parsed = from_dict(feedback)
+    assert parsed.feedback_kind == "REINFORCEMENT"
+    assert parsed.fired_ids == ["a", "b"]
+    assert parsed.outcome == 1.0
+
+    label = from_self_learning_event(feedback)
+    assert label is not None
+    assert label.candidate_scores == {"a": 1.0, "b": 1.0}
+    assert label.metadata["kind"] == "self_learning"
+
+
+def test_legacy_feedback_event_hash_stays_backward_compatible_without_dedup_identity() -> None:
+    payload = FeedbackEvent(
+        source_kind="scanner",
+        feedback_kind="CORRECTION",
+        content="Do X instead",
+        session_pointer="session.jsonl:1-2",
+    ).to_dict()
+    assert payload["event_hash"].count("|") == 2
+    assert payload["event_hash"].startswith("CORRECTION|")


### PR DESCRIPTION
## Summary
- scaffold Phase 1 canonical v1 contracts for runtime compile, interaction events, feedback events, and artifact manifests
- add Python-side validators plus a legacy feedback bridge so the current repo can validate the same contract fixtures before any cutover
- land canonical rearchitecture docs and execution plan so the separate-repo / OpenClaw-owned runtime boundary is explicit

## Validation
- `source ~/.venvs/openclawbrain/bin/activate && python -m pytest -q tests/test_contracts_v1.py tests/test_feedback_events_contract.py tests/test_daemon.py tests/test_labels.py tests/test_openclaw_adapter_capture_feedback.py tests/test_openclaw_adapter_cli_modules.py tests/test_self_correct.py tests/test_full_learning.py tests/test_cli.py -k 'capture_feedback or self_learn or self_correct or feedback_scan or labels_out or fast_learning or checkpoint or contract'`
